### PR TITLE
Don't return when secret op is not none

### DIFF
--- a/pkg/common/configmap.go
+++ b/pkg/common/configmap.go
@@ -121,7 +121,6 @@ func EnsureConfigMaps(r ReconcilerCommon, obj metav1.Object, cms []Template, env
 		}
 		if op != controllerutil.OperationResultNone {
 			r.GetLogger().Info(fmt.Sprintf("ConfigMap %s successfully reconciled - operation: %s", cm.Name, string(op)))
-			return nil
 		}
 		if envVars != nil {
 			(*envVars)[cm.Name] = EnvValue(hash)

--- a/pkg/common/secret.go
+++ b/pkg/common/secret.go
@@ -231,7 +231,6 @@ func EnsureSecrets(r ReconcilerCommon, obj metav1.Object, sts []Template, envVar
 		}
 		if op != controllerutil.OperationResultNone {
 			r.GetLogger().Info(fmt.Sprintf("Secret %s successfully reconciled - operation: %s", s.Name, string(op)))
-			return nil
 		}
 		if envVars != nil {
 			(*envVars)[s.Name] = EnvValue(hash)


### PR DESCRIPTION
Without this removal, if the first template in the array will prevent the remaining secrets from being created/updated in some scenarios