### PR TITLE
Correct err check result in provisionserver

### DIFF
--- a/controllers/provisionserver_controller.go
+++ b/controllers/provisionserver_controller.go
@@ -127,7 +127,7 @@ func (r *ProvisionServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	err = common.EnsureConfigMaps(r, instance, cm, &envVars)
 
 	if err != nil {
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	// provisionserver


### PR DESCRIPTION
This corrects an err check result so that it returns the err
if there are issues configuring configmaps.