### PR TITLE
CM cr name from role

### DIFF
--- a/controllers/controlplane_controller.go
+++ b/controllers/controlplane_controller.go
@@ -128,9 +128,8 @@ func (r *ControlPlaneReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	// Create or update the controllerVM CR object
 	ospControllerVM := &ospdirectorv1beta1.ControllerVM{
 		ObjectMeta: metav1.ObjectMeta{
-			// FIXME: currently we use the name of the resource as the basename
-			Name: "controller",
-			//Name:      fmt.Sprintf("%s-controllervm", instance.Name),
+			// use the role name as the VM CR name
+			Name:      strings.ToLower(instance.Spec.Controller.Role),
 			Namespace: instance.Namespace,
 		},
 	}


### PR DESCRIPTION
So far the hard coded controller string was used for the ControllerVM
CR. Use the lower case role name instead.