### PR TITLE
support customized root pwd

### DIFF
--- a/api/v1beta1/baremetalset_types.go
+++ b/api/v1beta1/baremetalset_types.go
@@ -42,6 +42,10 @@ type BaremetalSetSpec struct {
 	Networks []string `json:"networks"`
 	// Role the name of the Overcloud role this IPset is associated with. Used to generate hostnames.
 	Role string `json:"role"`
+	// PasswordSecret the name of the secret used to optionally set the root pwd by adding
+	// NodeRootPassword: <base64 enc pwd>
+	// to the secret data
+	PasswordSecret string `json:"passwordSecret,omitempty"`
 }
 
 // BaremetalSetStatus defines the observed state of BaremetalSet

--- a/api/v1beta1/controllervm_types.go
+++ b/api/v1beta1/controllervm_types.go
@@ -42,6 +42,10 @@ type ControllerVMSpec struct {
 	Networks []string `json:"networks"`
 	// Role the name of the Overcloud role this IPset is associated with. Used to generate hostnames.
 	Role string `json:"role"`
+	// PasswordSecret the name of the secret used to optionally set the root pwd by adding
+	// NodeRootPassword: <base64 enc pwd>
+	// to the secret data
+	PasswordSecret string `json:"passwordSecret,omitempty"`
 }
 
 // ControllerHostStatus represents the hostname and IP info for a specific controller

--- a/api/v1beta1/controlplane_types.go
+++ b/api/v1beta1/controlplane_types.go
@@ -25,6 +25,8 @@ type ControlPlaneSpec struct {
 	Controller ControllerSpec `json:"controller"`
 	// OpenstackClient image
 	OpenStackClientImageURL string `json:"openStackClientImageURL"`
+	// PasswordSecret used to e.g specify root pwd
+	PasswordSecret string `json:"passwordSecret,omitempty"`
 }
 
 // ControllerSpec - defines the desired state of Controllers VMs

--- a/config/crd/bases/osp-director.openstack.org_baremetalsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_baremetalsets.yaml
@@ -140,6 +140,11 @@ spec:
               items:
                 type: string
               type: array
+            passwordSecret:
+              description: 'PasswordSecret the name of the secret used to optionally
+                set the root pwd by adding NodeRootPassword: <base64 enc pwd> to the
+                secret data'
+              type: string
             replicas:
               description: Replicas The number of baremetalhosts to attempt to aquire
               minimum: 0

--- a/config/crd/bases/osp-director.openstack.org_controllervms.yaml
+++ b/config/crd/bases/osp-director.openstack.org_controllervms.yaml
@@ -80,6 +80,11 @@ spec:
               - bridgeName
               - name
               type: object
+            passwordSecret:
+              description: 'PasswordSecret the name of the secret used to optionally
+                set the root pwd by adding NodeRootPassword: <base64 enc pwd> to the
+                secret data'
+              type: string
             role:
               description: Role the name of the Overcloud role this IPset is associated
                 with. Used to generate hostnames.

--- a/config/crd/bases/osp-director.openstack.org_controlplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_controlplanes.yaml
@@ -102,6 +102,9 @@ spec:
             openStackClientImageURL:
               description: OpenstackClient image
               type: string
+            passwordSecret:
+              description: PasswordSecret used to e.g specify root pwd
+              type: string
           required:
           - controller
           - openStackClientImageURL

--- a/templates/baremetalset/cloudinit/userdata
+++ b/templates/baremetalset/cloudinit/userdata
@@ -3,12 +3,15 @@
 fqdn: {{ .Hostname }}
 users:
   - name: cloud-admin
-    # for now set a password '12345678'
-    passwd: $6$s2t53Brmt2f0Ws5G$mdOCrvOrlKSrjpzLjxtgC5cb6.d5eHMLwmshbVYhs9.u0xdmy5m/Z8SJgc52wZ4V2N8gGS1bnjJ8hBF1w4tW/1
-    lock_passwd: false
     ssh-authorized-keys: {{ .AuthorizedKeys }}
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash
+{{- if .NodeRootPassword }}
+chpasswd:
+  list: |
+    root:{{ .NodeRootPassword }}
+  expire: False
+{{- end }}
 runcmd:
   - dnf install -y http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
   - rhos-release 16.2

--- a/templates/controllervm/cloudinit/userdata
+++ b/templates/controllervm/cloudinit/userdata
@@ -1,12 +1,15 @@
 #cloud-config
 users:
   - name: cloud-admin
-    # for now set a password '12345678'
-    passwd: $6$s2t53Brmt2f0Ws5G$mdOCrvOrlKSrjpzLjxtgC5cb6.d5eHMLwmshbVYhs9.u0xdmy5m/Z8SJgc52wZ4V2N8gGS1bnjJ8hBF1w4tW/1
-    lock_passwd: false
     ssh-authorized-keys: {{ .AuthorizedKeys }}
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash
+{{- if .NodeRootPassword }}
+chpasswd:
+  list: |
+    root:{{ .NodeRootPassword }}
+  expire: False
+{{- end }}
 write_files:
   - path: /tmp/write_file
     content: |


### PR DESCRIPTION
if PasswordSercret parameter is provided in the CR the controllers
set the root password via cloud init for the root user. It is expected
that the PasswordSercet data has a NodeRootPassword key with a plane
text password.