### PR TITLE
Add imageImportStorageClass

### DIFF
--- a/api/v1beta1/controllervm_types.go
+++ b/api/v1beta1/controllervm_types.go
@@ -34,6 +34,8 @@ type ControllerVMSpec struct {
 	BaseImageURL string `json:"baseImageURL"`
 	// StorageClass to be used for the controller disks
 	StorageClass string `json:"storageClass"`
+	// ImageImportStorageClass used to import base image into the cluster
+	ImageImportStorageClass string `json:"imageImportStorageClass"`
 	// name of secret holding the stack-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
 	// OSPNetwork

--- a/api/v1beta1/controlplane_types.go
+++ b/api/v1beta1/controlplane_types.go
@@ -41,6 +41,8 @@ type ControllerSpec struct {
 	BaseImageURL string `json:"baseImageURL"`
 	// StorageClass to be used for the controller disks
 	StorageClass string `json:"storageClass"`
+	// ImageImportStorageClass used to import base image into the cluster
+	ImageImportStorageClass string `json:"imageImportStorageClass"`
 	// OSPNetwork
 	OSPNetwork Network `json:"ospNetwork"`
 	// Networks the name(s) of the OvercloudNetworks used to generate IPs

--- a/bindata/cdi/01-cdi-base-image.yaml
+++ b/bindata/cdi/01-cdi-base-image.yaml
@@ -11,6 +11,9 @@ spec:
       requests:
         storage: {{ .DiskSize }}Gi
     volumeMode: Filesystem
+{{if .ImageImportStorageClass }}
+    storageClassName: {{ .ImageImportStorageClass }}
+{{end}}
   source:
     http:
       url: {{ .BaseImageURL }}

--- a/config/crd/bases/osp-director.openstack.org_controllervms.yaml
+++ b/config/crd/bases/osp-director.openstack.org_controllervms.yaml
@@ -54,6 +54,10 @@ spec:
               description: root Disc size in GB
               format: int32
               type: integer
+            imageImportStorageClass:
+              description: ImageImportStorageClass used to import base image into
+                the cluster
+              type: string
             memory:
               description: amount of Memory in GB used by the controller VMs
               format: int32
@@ -93,6 +97,7 @@ spec:
           - cores
           - deploymentSSHSecret
           - diskSize
+          - imageImportStorageClass
           - memory
           - networks
           - ospNetwork

--- a/config/crd/bases/osp-director.openstack.org_controlplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_controlplanes.yaml
@@ -55,6 +55,10 @@ spec:
                   description: root Disc size in GB
                   format: int32
                   type: integer
+                imageImportStorageClass:
+                  description: ImageImportStorageClass used to import base image into
+                    the cluster
+                  type: string
                 memory:
                   description: amount of Memory in GB used by the controller VMs
                   format: int32
@@ -93,6 +97,7 @@ spec:
               - controllerCount
               - cores
               - diskSize
+              - imageImportStorageClass
               - memory
               - networks
               - ospNetwork

--- a/config/samples/osp-director_v1beta1_controllervm.yaml
+++ b/config/samples/osp-director_v1beta1_controllervm.yaml
@@ -10,6 +10,7 @@ spec:
   memory: 5
   diskSize: 10
   storageClass: host-nfs-storageclass
+  #imageImportStorageClass: local #optional
   deploymentSSHSecret: osp-controlplane-ssh-keys
   ospNetwork:
     bridgeName: br-osp

--- a/config/samples/osp-director_v1beta1_controlplane.yaml
+++ b/config/samples/osp-director_v1beta1_controlplane.yaml
@@ -13,7 +13,7 @@ spec:
     diskSize: 50
     baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
     storageClass: host-nfs-storageclass
-
+    #imageImportStorageClass: local #optional
     networks:
       - ctlplane
     role: controller

--- a/controllers/controllervm_controller.go
+++ b/controllers/controllervm_controller.go
@@ -339,6 +339,7 @@ func (r *ControllerVMReconciler) getRenderData(instance *ospdirectorv1beta1.Cont
 	data.Data["Cores"] = instance.Spec.Cores
 	data.Data["Memory"] = instance.Spec.Memory
 	data.Data["StorageClass"] = instance.Spec.StorageClass
+	data.Data["ImageImportStorageClass"] = instance.Spec.ImageImportStorageClass
 	data.Data["Network"] = instance.Spec.OSPNetwork.Name
 	data.Data["BridgeName"] = instance.Spec.OSPNetwork.BridgeName
 	data.Data["DesiredState"] = instance.Spec.OSPNetwork.DesiredState.String()

--- a/controllers/controlplane_controller.go
+++ b/controllers/controlplane_controller.go
@@ -141,6 +141,7 @@ func (r *ControlPlaneReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		ospControllerVM.Spec.Memory = instance.Spec.Controller.Memory
 		ospControllerVM.Spec.DiskSize = instance.Spec.Controller.DiskSize
 		ospControllerVM.Spec.StorageClass = instance.Spec.Controller.StorageClass
+		ospControllerVM.Spec.ImageImportStorageClass = instance.Spec.Controller.DeepCopy().ImageImportStorageClass
 		ospControllerVM.Spec.DeploymentSSHSecret = deploymentSecretName
 		ospControllerVM.Spec.OSPNetwork = instance.Spec.Controller.OSPNetwork
 		ospControllerVM.Spec.Networks = instance.Spec.Controller.Networks


### PR DESCRIPTION
This can be used to customize the storageClass used for
DataVolume imports. Under certain situation (dev environments)
this is beneficial for performance reasons.