### PR TITLE
Use dedicated user for openstackclient pod

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- service_account.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openstackclient

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -201,6 +201,7 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(instance *ospdirectorv1bet
 		},
 	}
 	pod.Spec = corev1.PodSpec{
+		ServiceAccountName:            openstackclient.ServiceAccount,
 		TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 		Volumes:                       openstackclient.GetVolumes(instance),
 		Containers: []corev1.Container{

--- a/pkg/openstackclient/const.go
+++ b/pkg/openstackclient/const.go
@@ -22,4 +22,7 @@ const (
 
 	// FinalizerName -
 	FinalizerName = "openstackclient.osp-director.openstack.org"
+
+	// ServiceAccount -
+	ServiceAccount = "osp-director-operator-openstackclient"
 )


### PR DESCRIPTION
create osp-director-operator-openstackclient user and use it for
creating the openstackclient pod with no permissions to connect to
the OCP API.