### PR TITLE
Use pvc for cloud-admin home directory

### DIFF
--- a/pkg/common/pvc.go
+++ b/pkg/common/pvc.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Pvc - pvc details
+type Pvc struct {
+	Name         string
+	Namespace    string
+	Size         string
+	Labels       map[string]string
+	StorageClass string
+	AccessMode   []corev1.PersistentVolumeAccessMode
+}
+
+// CreateOrUpdatePvc -
+func CreateOrUpdatePvc(r ReconcilerCommon, obj metav1.Object, pv *Pvc) (*corev1.PersistentVolumeClaim, controllerutil.OperationResult, error) {
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvc.Name = pv.Name
+	pvc.Namespace = pv.Namespace
+
+	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.GetClient(), pvc, func() error {
+
+		pvc.Labels = pv.Labels
+
+		pvc.Spec.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceStorage: resource.MustParse(pv.Size),
+		}
+
+		pvc.Spec.StorageClassName = &pv.StorageClass
+		pvc.Spec.AccessModes = pv.AccessMode
+
+		err := controllerutil.SetOwnerReference(obj, pvc, r.GetScheme())
+		if err != nil {
+			return fmt.Errorf("error set controller reverence for PVC: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, op, fmt.Errorf("error create/updating pvc: %v", err)
+	}
+
+	return pvc, op, nil
+}

--- a/pkg/openstackclient/const.go
+++ b/pkg/openstackclient/const.go
@@ -25,4 +25,16 @@ const (
 
 	// ServiceAccount -
 	ServiceAccount = "osp-director-operator-openstackclient"
+
+	// CloudAdminUID -
+	CloudAdminUID = 1001
+	// CloudAdminGID -
+	CloudAdminGID = 1001
+	// HostsPersistentStorageSize - size in GB
+	HostsPersistentStorageSize = "1G"
+	// CloudAdminPersistentStorageSize - size in GB
+	CloudAdminPersistentStorageSize = "4G"
+	// PersistentStorageClass -
+	// TODO: move to be CRD parameter PersistentStorageClass
+	PersistentStorageClass = "host-nfs-storageclass"
 )

--- a/pkg/openstackclient/initcontainer.go
+++ b/pkg/openstackclient/initcontainer.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstackclient
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// InitContainer information
+type InitContainer struct {
+	Args           []string
+	Commands       []string
+	ContainerImage string
+	Env            []corev1.EnvVar
+	Privileged     bool
+	VolumeMounts   []corev1.VolumeMount
+}
+
+// GetInitContainers - init containers
+func GetInitContainers(inits []InitContainer) []corev1.Container {
+	trueVar := true
+
+	securityContext := &corev1.SecurityContext{}
+	initContainers := []corev1.Container{}
+
+	for index, init := range inits {
+		if init.Privileged {
+			securityContext.Privileged = &trueVar
+		}
+
+		container := corev1.Container{
+			Name:            fmt.Sprintf("init-%d", index),
+			Image:           init.ContainerImage,
+			SecurityContext: securityContext,
+			VolumeMounts:    init.VolumeMounts,
+			Env:             init.Env,
+		}
+
+		if len(init.Args) != 0 {
+			container.Args = init.Args
+		}
+
+		if len(init.Commands) != 0 {
+			container.Command = init.Commands
+		}
+
+		initContainers = append(initContainers, container)
+	}
+
+	return initContainers
+}

--- a/pkg/openstackclient/volumes.go
+++ b/pkg/openstackclient/volumes.go
@@ -17,54 +17,85 @@ limitations under the License.
 package openstackclient
 
 import (
+	"fmt"
+
 	ospdirectorv1beta1 "github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // GetVolumeMounts -
-func GetVolumeMounts() []corev1.VolumeMount {
+func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
+			Name: fmt.Sprintf("%s-hosts", instance.Name),
+			//MountPath: "/mnt",
+			MountPath: "/etc/hosts",
+			SubPath:   "hosts",
+			ReadOnly:  false,
+		},
+		{
+			Name:      fmt.Sprintf("%s-cloud-admin", instance.Name),
+			MountPath: "/home/cloud-admin",
+			ReadOnly:  false,
+		},
+		{
 			Name:      "id-rsa",
-			MountPath: "/root/.ssh/id_rsa",
+			MountPath: "/home/cloud-admin/.ssh/id_rsa",
 			SubPath:   "id_rsa",
-			ReadOnly:  false,
+			ReadOnly:  true,
 		},
 		{
 			Name:      "ssh-config",
-			MountPath: "/root/.ssh/id_rsa.pub",
+			MountPath: "/home/cloud-admin/.ssh/id_rsa.pub",
 			SubPath:   "id_rsa.pub",
-			ReadOnly:  false,
+			ReadOnly:  true,
 		},
 		{
 			Name:      "ssh-config",
-			MountPath: "/root/.ssh/config",
+			MountPath: "/home/cloud-admin/.ssh/config",
 			SubPath:   "config",
-			ReadOnly:  false,
+			ReadOnly:  true,
 		},
 		{
 			Name:      "tripleo-deploy-config",
-			MountPath: "/root/config",
-			ReadOnly:  false,
+			MountPath: "/home/cloud-admin/config",
+			ReadOnly:  true,
 		},
 		{
 			Name:      "tripleo-deploy-config-custom",
-			MountPath: "/root/config-custom",
-			ReadOnly:  false,
+			MountPath: "/home/cloud-admin/config-custom",
+			ReadOnly:  true,
 		},
 		{
 			Name:      "tripleo-net-config",
-			MountPath: "/root/net-config",
-			ReadOnly:  false,
+			MountPath: "/home/cloud-admin/net-config",
+			ReadOnly:  true,
 		},
 		{
-			Name:      "tripleo-deploy-sh",
-			MountPath: "/root/tripleo-deploy.sh",
+			Name:      "openstackclient-scripts",
+			MountPath: "/home/cloud-admin/tripleo-deploy.sh",
 			SubPath:   "tripleo-deploy.sh",
-			ReadOnly:  false,
+			ReadOnly:  true,
 		},
 	}
 
+}
+
+// GetInitVolumeMounts -
+func GetInitVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "openstackclient-scripts",
+			MountPath: "/usr/local/bin/init.sh",
+			SubPath:   "init.sh",
+			ReadOnly:  true,
+		},
+		{
+			Name:      fmt.Sprintf("%s-hosts", instance.Name),
+			MountPath: "/mnt",
+			ReadOnly:  false,
+		},
+	}
 }
 
 // GetVolumes -
@@ -142,19 +173,39 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 			},
 		},
 		{
-			Name: "tripleo-deploy-sh",
+			Name: "openstackclient-scripts",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					DefaultMode: &config0755AccessMode,
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "tripleo-deploy-sh",
+						Name: "openstackclient-sh",
 					},
 					Items: []corev1.KeyToPath{
 						{
 							Key:  "tripleo-deploy.sh",
 							Path: "tripleo-deploy.sh",
 						},
+						{
+							Key:  "init.sh",
+							Path: "init.sh",
+						},
 					},
+				},
+			},
+		},
+		{
+			Name: fmt.Sprintf("%s-hosts", instance.Name),
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: fmt.Sprintf("%s-hosts", instance.Name),
+				},
+			},
+		},
+		{
+			Name: fmt.Sprintf("%s-cloud-admin", instance.Name),
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: fmt.Sprintf("%s-cloud-admin", instance.Name),
 				},
 			},
 		},

--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -1,0 +1,21 @@
+#!/bin//bash
+#
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# if the pvc is an empty volume, copy the existing hosts file to it
+if [ ! -f /mnt/hosts ]; then
+  cp /etc/hosts /mnt
+fi

--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -2,15 +2,16 @@
 
 set -eux
 
-sed -i "/# We only get here if no errors/a \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ rc=0" /usr/lib/python3.6/site-packages/tripleoclient/v1/tripleo_deploy.py
-sed -i "s/clouds_home_dir = .*/clouds_home_dir = os.path.expanduser('~')/" /usr/lib/python3.6/site-packages/tripleoclient/utils.py
+# in case of --output-only no rc is set when successful
+sudo sed -i "/# We only get here if no errors/a \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ rc=0" /usr/lib/python3.6/site-packages/tripleoclient/v1/tripleo_deploy.py
 # disable running dhcp on all interfaces, setting disable_configure_safe_defaults in the interface template does not work
-sed -i '/^set -eux/a disable_configure_safe_defaults=true' /usr/share/openstack-tripleo-heat-templates/network/scripts/run-os-net-config.sh
+sudo sed -i '/^set -eux/a disable_configure_safe_defaults=true' /usr/share/openstack-tripleo-heat-templates/network/scripts/run-os-net-config.sh
 
+mkdir -p ~/tripleo-deploy
 rm -rf ~/tripleo-deploy/overcloud-ansible*
 unset OS_CLOUD
 
-openstack tripleo deploy \
+sudo openstack tripleo deploy \
     --templates /usr/share/openstack-tripleo-heat-templates \
     -r /usr/share/openstack-tripleo-heat-templates/roles_data.yaml \
     -n /usr/share/openstack-tripleo-heat-templates/network_data.yaml \
@@ -34,10 +35,11 @@ cd ~/tripleo-deploy
 output_dir=$(ls -dtr overcloud-ansible-* | tail -1)
 ln -sf ${output_dir} overcloud-ansible
 cd ${output_dir}
+# we run with --standalone, therefore have to remove transport=local from ansible.cfg
 sed -i '/transport/d' ansible.cfg
-sed -i "/blockinfile/a \ \ \ \ unsafe_writes: yes" /usr/share/ansible/roles/tripleo-hosts-entries/tasks/main.yml
 
-# change ansible_ssh_user to cloud-admin, todo deployment-user should be also set in the inventroy as ansible_ssh_user
+# For standalone role tripleo_deploy sets root for the ansible_ssh_user in the inventory.
+# Change it to cloud-admin
 sed -i 's/ansible_ssh_user: root/ansible_ssh_user: cloud-admin/g' ~/tripleo-deploy/overcloud-ansible/inventory.yaml
 
 time ansible-playbook -i inventory.yaml --become deploy_steps_playbook.yaml


### PR DESCRIPTION
Move deployment operations to cloud-admin user and use a pvc as
the home directory to have everything in /hob/cloud-admin persistent.

Also use pvc for /etc/hosts to have entries added by the tripleo
deployment persistent.