### PR TITLE
Rename mgmtInterface to ctlplaneInterface

### DIFF
--- a/api/v1beta1/baremetalset_types.go
+++ b/api/v1beta1/baremetalset_types.go
@@ -32,8 +32,8 @@ type BaremetalSetSpec struct {
 	RhelImageURL string `json:"rhelImageUrl"`
 	// Name of secret holding the stack-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
-	// Interface to use for management network
-	MgmtInterface string `json:"mgmtInterface"`
+	// Interface to use for ctlplane network
+	CtlplaneInterface string `json:"ctlplaneInterface"`
 	// BmhLabelSelector allows for a sub-selection of BaremetalHosts based on arbitrary labels
 	BmhLabelSelector map[string]string `json:"bmhLabelSelector,omitempty"`
 	// Hardware requests for sub-selection of BaremetalHosts with certain hardware specs
@@ -58,7 +58,7 @@ type BaremetalHostStatus struct {
 	Hostname              string `json:"hostname"`
 	UserDataSecretName    string `json:"userDataSecretName"`
 	NetworkDataSecretName string `json:"networkDataSecretName"`
-	MgmtIP                string `json:"mgmtIP"`
+	CtlplaneIP            string `json:"ctlplaneIP"`
 	Online                bool   `json:"online"`
 }
 

--- a/config/crd/bases/osp-director.openstack.org_baremetalsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_baremetalsets.yaml
@@ -42,6 +42,9 @@ spec:
               description: BmhLabelSelector allows for a sub-selection of BaremetalHosts
                 based on arbitrary labels
               type: object
+            ctlplaneInterface:
+              description: Interface to use for ctlplane network
+              type: string
             deploymentSSHSecret:
               description: Name of secret holding the stack-admin ssh keys
               type: string
@@ -131,9 +134,6 @@ spec:
                       type: object
                   type: object
               type: object
-            mgmtInterface:
-              description: Interface to use for management network
-              type: string
             networks:
               description: Networks the name(s) of the OvercloudNetworks used to generate
                 IPs
@@ -158,8 +158,8 @@ spec:
                 with. Used to generate hostnames.
               type: string
           required:
+          - ctlplaneInterface
           - deploymentSSHSecret
-          - mgmtInterface
           - networks
           - rhelImageUrl
           - role
@@ -172,9 +172,9 @@ spec:
                 description: BaremetalHostStatus represents the observed state of
                   a particular allocated BaremetalHost resource
                 properties:
-                  hostname:
+                  ctlplaneIP:
                     type: string
-                  mgmtIP:
+                  hostname:
                     type: string
                   networkDataSecretName:
                     type: string
@@ -183,8 +183,8 @@ spec:
                   userDataSecretName:
                     type: string
                 required:
+                - ctlplaneIP
                 - hostname
-                - mgmtIP
                 - networkDataSecretName
                 - online
                 - userDataSecretName

--- a/config/samples/osp-director_v1beta1_baremetalset.yaml
+++ b/config/samples/osp-director_v1beta1_baremetalset.yaml
@@ -15,8 +15,8 @@ spec:
     - ctlplane
     - tenant
   role: worker
-  # The interface on the nodes that will be assigned an IP from the mgmtCidr
-  mgmtInterface: eth2
+  # The interface on the nodes that will be assigned an IP from the ctlCidr
+  ctlplaneInterface: eth2
   # Arbitrary label selector for BaremetalHosts (optional)
   bmhLabelSelector:
     arbitraryKey: arbitraryValue

--- a/templates/baremetalset/cloudinit/networkdata
+++ b/templates/baremetalset/cloudinit/networkdata
@@ -1,11 +1,11 @@
 links:
-- name: {{ .MgmtInterface }}
-  id: {{ .MgmtInterface }}
+- name: {{ .CtlplaneInterface }}
+  id: {{ .CtlplaneInterface }}
   type: vif
 networks:
-- netmask: {{ .MgmtNetmask }}
-  link: {{ .MgmtInterface }}
-  id: {{ .MgmtInterface }}
-  ip_address: {{ .MgmtIp }}
+- netmask: {{ .CtlplaneNetmask }}
+  link: {{ .CtlplaneInterface }}
+  id: {{ .CtlplaneInterface }}
+  ip_address: {{ .CtlplaneIp }}
   type: ipv4
-  gateway: {{ .MgmtGateway }}
+  gateway: {{ .CtlplaneGateway }}


### PR DESCRIPTION
The mgmtInterface was used as ctlplane interface. Lets rename the
interface to what it is actually used for. Adding mgmt interface
to the baremetalset is tracked in
https://github.com/openstack-k8s-operators/osp-director-operator/issues/113