### PR TITLE
Add baseImageVolumeName

### DIFF
--- a/api/v1beta1/controlplane_types.go
+++ b/api/v1beta1/controlplane_types.go
@@ -43,8 +43,8 @@ type ControllerSpec struct {
 	BaseImageURL string `json:"baseImageURL"`
 	// StorageClass to be used for the controller disks
 	StorageClass string `json:"storageClass"`
-	// ImageImportStorageClass used to import base image into the cluster
-	ImageImportStorageClass string `json:"imageImportStorageClass,omitempty"`
+	// BaseImageVolumeName Optional. If supplied will be used as the base volume for the VM instead of BaseImageURL.
+	BaseImageVolumeName string `json:"baseImageVolumeName,omitempty"`
 	// OSPNetwork
 	OSPNetwork Network `json:"ospNetwork"`
 	// Networks the name(s) of the OvercloudNetworks used to generate IPs

--- a/api/v1beta1/vmset_types.go
+++ b/api/v1beta1/vmset_types.go
@@ -34,8 +34,8 @@ type VMSetSpec struct {
 	BaseImageURL string `json:"baseImageURL"`
 	// StorageClass to be used for the disks
 	StorageClass string `json:"storageClass"`
-	// ImageImportStorageClass used to import base image into the cluster
-	ImageImportStorageClass string `json:"imageImportStorageClass,omitempty"`
+	// BaseImageVolumeName Optional. If supplied will be used as the base volume for the VM instead of BaseImageURL.
+	BaseImageVolumeName string `json:"baseImageVolumeName,omitempty"`
 	// name of secret holding the stack-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
 	// OSPNetwork

--- a/bindata/cdi/01-cdi-base-image.yaml
+++ b/bindata/cdi/01-cdi-base-image.yaml
@@ -1,7 +1,7 @@
 apiVersion: cdi.kubevirt.io/v1alpha1
 kind: DataVolume
 metadata:
-  name: {{ .BaseImageName }}
+  name: {{ .BaseImageVolumeName }}
   namespace: {{ .Namespace }}
 spec:
   pvc:
@@ -11,9 +11,7 @@ spec:
       requests:
         storage: {{ .DiskSize }}Gi
     volumeMode: Filesystem
-{{if .ImageImportStorageClass }}
-    storageClassName: {{ .ImageImportStorageClass }}
-{{end}}
+    storageClassName: {{ .StorageClass }}
   source:
     http:
       url: {{ .BaseImageURL }}

--- a/bindata/virtualmachine/01-virtual-machine.yaml
+++ b/bindata/virtualmachine/01-virtual-machine.yaml
@@ -23,7 +23,7 @@ spec:
         storageClassName: {{ .StorageClass }}
       source:
         pvc:
-          name: {{ .BaseImageName }}
+          name: {{ .BaseImageVolumeName }}
           namespace: {{ .Namespace }}
   running: true
   template:

--- a/config/crd/bases/osp-director.openstack.org_controlplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_controlplanes.yaml
@@ -43,6 +43,9 @@ spec:
                   description: Name of the VM base image used to setup the controller
                     VMs
                   type: string
+                baseImageVolumeName:
+                  description: BaseImageVolumeName Optional. If supplied will supplant
+                  type: string
                 controllerCount:
                   description: Number of controllers to configure, 1 or 3
                   type: integer
@@ -54,10 +57,6 @@ spec:
                   description: root Disc size in GB
                   format: int32
                   type: integer
-                imageImportStorageClass:
-                  description: ImageImportStorageClass used to import base image into
-                    the cluster
-                  type: string
                 memory:
                   description: amount of Memory in GB used by the controller VMs
                   format: int32

--- a/config/crd/bases/osp-director.openstack.org_vmsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_vmsets.yaml
@@ -39,6 +39,10 @@ spec:
             baseImageURL:
               description: Name of the VM base image used to setup the VMs
               type: string
+            baseImageVolumeName:
+              description: BaseImageVolumeName Optional. If supplied will be used
+                as the base volume for the VM instead of BaseImageURL.
+              type: string
             cores:
               description: number of Cores assigned to the VMs
               format: int32
@@ -50,10 +54,6 @@ spec:
               description: root Disc size in GB
               format: int32
               type: integer
-            imageImportStorageClass:
-              description: ImageImportStorageClass used to import base image into
-                the cluster
-              type: string
             memory:
               description: amount of Memory in GB used by the VMs
               format: int32

--- a/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
@@ -17,11 +17,6 @@ spec:
       kind: BaremetalSet
       name: baremetalsets.osp-director.openstack.org
       version: v1beta1
-    - description: VMSet is the Schema for the vmsets API
-      displayName: Controller VM
-      kind: VMSet
-      name: vmsets.osp-director.openstack.org
-      version: v1beta1
     - description: ControlPlane is the Schema for the controlplanes API
       displayName: Control Plane
       kind: ControlPlane
@@ -46,6 +41,11 @@ spec:
       displayName: Provision Server
       kind: ProvisionServer
       name: provisionservers.osp-director.openstack.org
+      version: v1beta1
+    - description: VMSet is the Schema for the vmsets API
+      displayName: VMSet
+      kind: VMSet
+      name: vmsets.osp-director.openstack.org
       version: v1beta1
   description: Install and manage an OpenStack cloud with OSP Director on OpenShift
   displayName: OSP Director Operator

--- a/config/samples/osp-director_v1beta1_controlplane.yaml
+++ b/config/samples/osp-director_v1beta1_controlplane.yaml
@@ -13,7 +13,7 @@ spec:
     diskSize: 50
     baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
     storageClass: host-nfs-storageclass
-    #imageImportStorageClass: local #optional
+    #baseImageVolumeName: #optional
     networks:
       - ctlplane
     role: controller

--- a/controllers/controlplane_controller.go
+++ b/controllers/controlplane_controller.go
@@ -155,7 +155,7 @@ func (r *ControlPlaneReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		ospVMSet.Spec.Memory = instance.Spec.Controller.Memory
 		ospVMSet.Spec.DiskSize = instance.Spec.Controller.DiskSize
 		ospVMSet.Spec.StorageClass = instance.Spec.Controller.StorageClass
-		ospVMSet.Spec.ImageImportStorageClass = instance.Spec.Controller.DeepCopy().ImageImportStorageClass
+		ospVMSet.Spec.BaseImageVolumeName = instance.Spec.Controller.DeepCopy().BaseImageVolumeName
 		ospVMSet.Spec.DeploymentSSHSecret = deploymentSecretName
 		ospVMSet.Spec.OSPNetwork = instance.Spec.Controller.OSPNetwork
 		ospVMSet.Spec.Networks = instance.Spec.Controller.Networks

--- a/controllers/vmset_controller.go
+++ b/controllers/vmset_controller.go
@@ -246,9 +246,11 @@ func (r *VMSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// Create base image, controller disks get cloned from this
-	err = r.cdiCreateBaseDisk(instance)
-	if err != nil {
-		return ctrl.Result{}, err
+	if instance.Spec.BaseImageVolumeName == "" {
+		err = r.cdiCreateBaseDisk(instance)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Create network config
@@ -265,6 +267,9 @@ func (r *VMSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	//   annotations -> cdi.kubevirt.io/storage.pod.phase: Succeeded
 	pvc := &corev1.PersistentVolumeClaim{}
 	baseImageName := fmt.Sprintf("osp-vmset-baseimage-%s", instance.UID[0:4])
+	if instance.Spec.BaseImageVolumeName != "" {
+		baseImageName = instance.Spec.BaseImageVolumeName
+	}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: baseImageName, Namespace: instance.Namespace}, pvc)
 	if err != nil && errors.IsNotFound(err) {
 		r.Log.Info(fmt.Sprintf("PersistentVolumeClaim %s not found reconcil in 10s", baseImageName))
@@ -356,14 +361,17 @@ func (r *VMSetReconciler) getRenderData(instance *ospdirectorv1beta1.VMSet) (*bi
 	data := bindatautil.MakeRenderData()
 	// Base image used to clone the controller VM images from
 	// adding first 5 char from instance.UID as identifier
-	data.Data["BaseImageName"] = fmt.Sprintf("osp-vmset-baseimage-%s", instance.UID[0:4])
+	if instance.Spec.BaseImageVolumeName == "" {
+		data.Data["BaseImageVolumeName"] = fmt.Sprintf("osp-vmset-baseimage-%s", instance.UID[0:4])
+	} else {
+		data.Data["BaseImageVolumeName"] = instance.Spec.BaseImageVolumeName
+	}
 	data.Data["BaseImageURL"] = instance.Spec.BaseImageURL
 	data.Data["DiskSize"] = instance.Spec.DiskSize
 	data.Data["Namespace"] = instance.Namespace
 	data.Data["Cores"] = instance.Spec.Cores
 	data.Data["Memory"] = instance.Spec.Memory
 	data.Data["StorageClass"] = instance.Spec.StorageClass
-	data.Data["ImageImportStorageClass"] = instance.Spec.ImageImportStorageClass
 	data.Data["Network"] = instance.Spec.OSPNetwork.Name
 	data.Data["BridgeName"] = instance.Spec.OSPNetwork.BridgeName
 	data.Data["DesiredState"] = instance.Spec.OSPNetwork.DesiredState.String()


### PR DESCRIPTION
This patch adds baseImageVolumeName and removes imageImportStorageClass.
By allowing an external baseImageVolume to be specified we allow
end users to pre-create their own DataVolume in any manner they choose
thus optimizing base image imports for their environments.

Specifying a baseImageVolume will effectively disable the baseImageURL
param although baseImageURL is still left as required for now
until we get validation hooks enabled to enforce either/or
validation across these two parameters.