### PR TITLE
Mark ipsets and provisioner as internal

### DIFF
--- a/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    operators.operatorframework.io/internal-objects: '["overcloudipsets.osp-director.openstack.org","provisionservers.osp-director.openstack.org"]'
   name: osp-director-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This marks the ipset and provisioner APIs as internal
within the CSV. This will have the effect of hiding these
APIs within the OLM web console.