### PR TITLE
Make VMSet baseImageURL optional

### DIFF
--- a/api/v1beta1/vmset_types.go
+++ b/api/v1beta1/vmset_types.go
@@ -31,7 +31,7 @@ type VMSetSpec struct {
 	// root Disc size in GB
 	DiskSize uint32 `json:"diskSize"`
 	// Name of the VM base image used to setup the VMs
-	BaseImageURL string `json:"baseImageURL"`
+	BaseImageURL string `json:"baseImageURL,omitempty"`
 	// StorageClass to be used for the disks
 	StorageClass string `json:"storageClass"`
 	// BaseImageVolumeName Optional. If supplied will be used as the base volume for the VM instead of BaseImageURL.

--- a/api/v1beta1/vmset_webhook.go
+++ b/api/v1beta1/vmset_webhook.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -50,19 +52,39 @@ var _ webhook.Validator = &VMSet{}
 func (r *VMSet) ValidateCreate() error {
 	vmsetlog.Info("validate create", "name", r.Name)
 
-	return checkRoleNameExists(r.TypeMeta, r.ObjectMeta, r.Spec.Role)
+	return r.validateCr()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMSet) ValidateUpdate(old runtime.Object) error {
 	vmsetlog.Info("validate update", "name", r.Name)
 
-	return checkRoleNameExists(r.TypeMeta, r.ObjectMeta, r.Spec.Role)
+	return r.validateCr()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMSet) ValidateDelete() error {
 	vmsetlog.Info("validate delete", "name", r.Name)
+
+	return nil
+}
+
+func (r *VMSet) validateCr() error {
+	if err := r.checkBaseImageReqs(); err != nil {
+		return err
+	}
+
+	if err := checkRoleNameExists(r.TypeMeta, r.ObjectMeta, r.Spec.Role); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *VMSet) checkBaseImageReqs() error {
+	if r.Spec.BaseImageURL == "" && r.Spec.BaseImageVolumeName == "" {
+		return fmt.Errorf("Either \"baseImageURL\" or \"baseImageVolumeName\" must be provided")
+	}
 
 	return nil
 }

--- a/config/crd/bases/osp-director.openstack.org_vmsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_vmsets.yaml
@@ -97,7 +97,6 @@ spec:
               description: Number of VMs to configure, 1 or 3
               type: integer
           required:
-          - baseImageURL
           - cores
           - deploymentSSHSecret
           - diskSize


### PR DESCRIPTION
Makes VMSet `baseImageURL` and `baseImageVolumeName` optional, but requires one of them to be set