### PR TITLE
Add ProvisionServerName to BaremetalSet CR

### DIFF
--- a/api/v1beta1/baremetalset_types.go
+++ b/api/v1beta1/baremetalset_types.go
@@ -29,7 +29,10 @@ type BaremetalSetSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	Replicas int `json:"replicas,omitempty"`
 	// Remote URL pointing to desired RHEL qcow2 image
-	RhelImageURL string `json:"rhelImageUrl"`
+	RhelImageURL string `json:"rhelImageUrl,omitempty"`
+	// Name of the pre-created ProvisionServer to use. If su
+	// ProvisionServerName Optional. If supplied will be used as the base Image for the baremetalset instead of RhelImageURL.
+	ProvisionServerName string `json:"provisionServerName,omitempty"`
 	// Name of secret holding the stack-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
 	// Interface to use for ctlplane network

--- a/api/v1beta1/baremetalset_types.go
+++ b/api/v1beta1/baremetalset_types.go
@@ -30,7 +30,6 @@ type BaremetalSetSpec struct {
 	Replicas int `json:"replicas,omitempty"`
 	// Remote URL pointing to desired RHEL qcow2 image
 	RhelImageURL string `json:"rhelImageUrl,omitempty"`
-	// Name of the pre-created ProvisionServer to use. If su
 	// ProvisionServerName Optional. If supplied will be used as the base Image for the baremetalset instead of RhelImageURL.
 	ProvisionServerName string `json:"provisionServerName,omitempty"`
 	// Name of secret holding the stack-admin ssh keys

--- a/config/crd/bases/osp-director.openstack.org_baremetalsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_baremetalsets.yaml
@@ -146,6 +146,11 @@ spec:
                 set the root pwd by adding NodeRootPassword: <base64 enc pwd> to the
                 secret data'
               type: string
+            provisionServerName:
+              description: Name of the pre-created ProvisionServer to use. If su ProvisionServerName
+                Optional. If supplied will be used as the base Image for the baremetalset
+                instead of RhelImageURL.
+              type: string
             replicas:
               description: Replicas The number of baremetalhosts to attempt to aquire
               minimum: 0
@@ -161,7 +166,6 @@ spec:
           - ctlplaneInterface
           - deploymentSSHSecret
           - networks
-          - rhelImageUrl
           - role
           type: object
         status:

--- a/controllers/baremetalset_controller.go
+++ b/controllers/baremetalset_controller.go
@@ -184,7 +184,7 @@ func (r *BaremetalSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	} else {
 		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.ProvisionServerName, Namespace: instance.Namespace}, provisionServer)
 		if err != nil && errors.IsNotFound(err) {
-			r.Log.Info(fmt.Sprintf("ProvisionServer %s not found reconcil in 10s", instance.Spec.ProvisionServerName))
+			r.Log.Info(fmt.Sprintf("ProvisionServer %s not found reconcile again in 10 seconds", instance.Spec.ProvisionServerName))
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		} else if err != nil {
 			return ctrl.Result{}, err

--- a/controllers/baremetalset_controller.go
+++ b/controllers/baremetalset_controller.go
@@ -179,8 +179,9 @@ func (r *BaremetalSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 		if op != controllerutil.OperationResultNone {
 			r.Log.Info(fmt.Sprintf("BaremetalSet %s ProvisionServer successfully reconciled - operation: %s", instance.Name, string(op)))
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
+
 	} else {
 		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.ProvisionServerName, Namespace: instance.Namespace}, provisionServer)
 		if err != nil && errors.IsNotFound(err) {

--- a/controllers/vmset_controller.go
+++ b/controllers/vmset_controller.go
@@ -214,7 +214,7 @@ func (r *VMSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: baseImageName, Namespace: instance.Namespace}, pvc)
 	if err != nil && errors.IsNotFound(err) {
-		r.Log.Info(fmt.Sprintf("PersistentVolumeClaim %s not found reconcil in 10s", baseImageName))
+		r.Log.Info(fmt.Sprintf("PersistentVolumeClaim %s not found reconcile again in 10 seconds", baseImageName))
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	} else if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
This adds a new ProvisionServerName to BaremetalSet that
can be used as an alternate to RhelImageUrl.

Also updates BaremetalSet so that either RhelImageUrl or
ProvisionServerName needs to be set.

Pre-creating a ProvisionServer is desirable if you plan on sharing
the same image with multiple BaremetalSets. Also, pre-creating a
provisionserver should speed up future demos.