### PR TITLE
Use tripleoclient from tripleo

### DIFF
--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -345,7 +345,9 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(instance *ospdirectorv1bet
 		{
 			ContainerImage: instance.Spec.ImageURL,
 			Commands: []string{
-				"/bin/bash", "-c", "/usr/local/bin/init.sh",
+				"/bin/bash",
+				"-c",
+				"/usr/local/bin/init.sh",
 			},
 			Env:          common.MergeEnvs([]corev1.EnvVar{}, envVars),
 			Privileged:   false,

--- a/pkg/openstackclient/const.go
+++ b/pkg/openstackclient/const.go
@@ -27,9 +27,9 @@ const (
 	ServiceAccount = "osp-director-operator-openstackclient"
 
 	// CloudAdminUID -
-	CloudAdminUID = 1001
+	CloudAdminUID = 42401
 	// CloudAdminGID -
-	CloudAdminGID = 1001
+	CloudAdminGID = 42401
 	// HostsPersistentStorageSize - size in GB
 	HostsPersistentStorageSize = "1G"
 	// CloudAdminPersistentStorageSize - size in GB


### PR DESCRIPTION
[1] adds the changes to tripleoclient so that we can use the tripleo
container image instead of our curr current created. This allign
cloud-admin uid with tripleoclient image form [1].

[1] https://review.opendev.org/c/openstack/tripleo-common/+/776174