### PR TITLE
DNM: Tesing dependencies with openshift ci robot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG GOLANG_BUILDER=golang:1.13
 ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary
+# Testing Depends-on
 FROM ${GOLANG_BUILDER} AS builder
 
 ARG GO_BUILD_EXTRA_ARGS


### PR DESCRIPTION
Yet another test for the deps between pull requests,
this time on a project that has branch protection rules
set by the openshift CI infrastructure.

Depends On: https://github.com/openstack-k8s-operators/osp-director-dev-tools/pull/73