### PR TITLE
Fix golangci github action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -49,3 +49,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Run golangci lint
         uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.38.0
+          args: --timeout 3m


### PR DESCRIPTION
Pin golangci-lint to the latest stable version and increase
default timeout which was 1m.