### PR TITLE
Small bindata + net-att-def cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ COPY api/ api/
 COPY pkg/ pkg/
 COPY controllers/ controllers/
 COPY templates/ templates/
-COPY bindata/ bindata/
-RUN mkdir -p /usr/share/osp-director-operator/templates && mkdir -p /bindata/ && mkdir -p /cmd/
+RUN mkdir -p /usr/share/osp-director-operator/templates && mkdir -p /cmd/
 
 # Build manager
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o manager main.go
@@ -30,14 +29,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build ${GO_BUILD_EXT
 FROM ${OPERATOR_BASE_IMAGE}
 
 ENV USER_UID=1001 \
-    OPERATOR_BINDATA_DIR=/bindata/ \
     OPERATOR_TEMPLATES=/usr/share/osp-director-operator/templates/ \
     WATCH_NAMESPACE=openstack,openshift-machine-api
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/templates /usr/share/osp-director-operator/templates/.
-COPY --from=builder /workspace/bindata /bindata/.
 USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,6 +124,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachines
@@ -395,18 +407,6 @@ rules:
   - '*'
   verbs:
   - '*'
-- apiGroups:
-  - k8s.cni.cncf.io
-  resources:
-  - network-attachment-definitions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - kubevirt.io
   resources:

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -81,7 +81,8 @@ func (r *OpenStackVMSetReconciler) GetScheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=core,resources=pods;persistentvolumeclaims;events;configmaps;secrets,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,namespace=openstack,resources=datavolumes,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,namespace=openstack,resources=network-attachment-definitions,verbs=create;delete;get;list;patch;update;watch
+// FIXME: Temporarily switching next annotation to cluster-scope, as controller is watching for these in other namespaces
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=kubevirt.io,namespace=openstack,resources=virtualmachines,verbs=create;delete;get;list;patch;update;watch
 // FIXME: Is there a way to scope the following RBAC annotation to just the "openshift-machine-api" namespace?
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=list;watch


### PR DESCRIPTION
Removes bindata from Dockerfile and temporarily moves net-attach-def perms to cluster-scope for the meantime