### PR TITLE
Kuttl tests for new networking arch

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,6 +124,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachines

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -145,12 +145,12 @@ func (r *OpenStackClientReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 
 	for _, net := range instance.Spec.Networks {
 		if _, ok := nncMap[net]; !ok {
-			r.Log.Error(err, fmt.Sprintf("NetworkConfigurationPolicy for network %s does not exist!", net))
-			return ctrl.Result{}, err
+			r.Log.Info(fmt.Sprintf("NetworkConfigurationPolicy for network %s does not yet exist.  Reconciling again in 10 seconds", net))
+			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
 		if _, ok := nadMap[net]; !ok {
-			r.Log.Error(err, fmt.Sprintf("NetworkAttachmentDefinition for network %s does not exist!", net))
-			return ctrl.Result{}, err
+			r.Log.Error(err, fmt.Sprintf("NetworkAttachmentDefinition for network %s does not yet exist.  Reconciling again in 10 seconds", net))
+			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
 	}
 

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -81,7 +81,8 @@ func (r *OpenStackVMSetReconciler) GetScheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=core,resources=pods;persistentvolumeclaims;events;configmaps;secrets,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,namespace=openstack,resources=datavolumes,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,namespace=openstack,resources=network-attachment-definitions,verbs=get;list
+// FIXME: Cluster-scope required below for now, as the operator watches openshift-machine-api namespace as well
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list
 // +kubebuilder:rbac:groups=kubevirt.io,namespace=openstack,resources=virtualmachines,verbs=create;delete;get;list;patch;update;watch
 // FIXME: Is there a way to scope the following RBAC annotation to just the "openshift-machine-api" namespace?
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=list;watch
@@ -225,12 +226,12 @@ func (r *OpenStackVMSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 
 	for _, net := range instance.Spec.Networks {
 		if _, ok := nncMap[net]; !ok {
-			r.Log.Error(err, fmt.Sprintf("NetworkConfigurationPolicy for network %s does not exist!", net))
-			return ctrl.Result{}, err
+			r.Log.Info(fmt.Sprintf("NetworkConfigurationPolicy for network %s does not yet exist.  Reconciling again in 10 seconds", net))
+			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
 		if _, ok := nadMap[net]; !ok {
-			r.Log.Error(err, fmt.Sprintf("NetworkAttachmentDefinition for network %s does not exist!", net))
-			return ctrl.Result{}, err
+			r.Log.Error(err, fmt.Sprintf("NetworkAttachmentDefinition for network %s does not yet exist.  Reconciling again in 10 seconds", net))
+			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
 	}
 

--- a/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
@@ -1,7 +1,7 @@
 #
 # Check for:
 #
-# - OpenStackNet
+# - 1 OpenStackNet
 #
 
 apiVersion: osp-director.openstack.org/v1beta1
@@ -12,5 +12,22 @@ metadata:
 spec:
   allocationEnd: 192.168.25.250
   allocationStart: 192.168.25.100
+  attachConfiguration:
+    bridgeName: br-osp
+    nodeNetworkConfigurationPolicy:
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: enp6s0
+          description: Linux bridge with enp6s0 as a port
+          name: br-osp
+          state: up
+          type: linux-bridge
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
   cidr: 192.168.25.0/24
   gateway: 192.168.25.1

--- a/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
@@ -1,11 +1,11 @@
 #
 # Check for:
 #
-# - OpenStackControlPlane
-# - OpenStackVMSet
-# - OpenStackClient
-# - OpenStackNet (IP reservations for OpenStackControlPlane and OpenStackClient)
-# - OpenStackIPSets (IP reservations for OpenStackControlPlane and OpenStackClient)
+# - 1 OpenStackControlPlane
+# - 1 OpenStackVMSet
+# - 1 OpenStackClient
+# - 1 OpenStackNet (IP reservations for OpenStackControlPlane and OpenStackClient)
+# - 3 OpenStackIPSets (IP reservations for OpenStackControlPlane and OpenStackClient)
 #
 
 apiVersion: osp-director.openstack.org/v1beta1
@@ -15,37 +15,19 @@ metadata:
   namespace: openstack
 spec:
   openStackClientImageURL: quay.io/openstack-k8s-operators/tripleo-deploy:latest
-  ospNetwork:
-    bridgeName: br-osp
-    name: osp
-    nodeNetworkConfigurationPolicy:
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""
-      desiredState:
-        interfaces:
-        - bridge:
-            options:
-              stp:
-                enabled: false
-            port:
-            - name: enp6s0
-          description: Linux bridge with enp6s0 as a port
-          name: br-osp # must be same as bridgeName
-          state: up
-          type: linux-bridge
   virtualMachineRoles:
     controller:
-      roleName: Controller
-      roleCount: 0
+      baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
+      baseImageVolumeName: openstack-base-img
       cores: 2
+      diskSize: 50
       isTripleoRole: true
       memory: 20
-      diskSize: 50
-      baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
-      storageClass: host-nfs-storageclass
-      baseImageVolumeName: openstack-base-img #optional
       networks:
       - ctlplane
+      roleCount: 0
+      roleName: Controller
+      storageClass: host-nfs-storageclass
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -58,27 +40,10 @@ spec:
   cores: 2
   deploymentSSHSecret: osp-controlplane-ssh-keys
   diskSize: 50
+  isTripleoRole: true
   memory: 20
   networks:
   - ctlplane
-  ospNetwork:
-    bridgeName: br-osp
-    name: osp
-    nodeNetworkConfigurationPolicy:
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""
-      desiredState:
-        interfaces:
-        - bridge:
-            options:
-              stp:
-                enabled: false
-            port:
-            - name: enp6s0
-          description: Linux bridge with enp6s0 as a port
-          name: br-osp # must be same as bridgeName
-          state: up
-          type: linux-bridge
   roleName: Controller
   storageClass: host-nfs-storageclass
   vmCount: 0
@@ -108,6 +73,28 @@ kind: OpenStackNet
 metadata:
   name: ctlplane
   namespace: openstack
+spec:
+  allocationEnd: 192.168.25.250
+  allocationStart: 192.168.25.100
+  attachConfiguration:
+    bridgeName: br-osp
+    nodeNetworkConfigurationPolicy:
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: enp6s0
+          description: Linux bridge with enp6s0 as a port
+          name: br-osp
+          state: up
+          type: linux-bridge
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+  cidr: 192.168.25.0/24
+  gateway: 192.168.25.1
 status:
   reservations:
   - addToPredictableIPs: false
@@ -146,8 +133,44 @@ status:
     ctlplane:
       allocationEnd: 192.168.25.250
       allocationStart: 192.168.25.100
+      attachConfiguration:
+        bridgeName: br-osp
+        nodeNetworkConfigurationPolicy:
+          desiredState:
+            interfaces:
+            - bridge:
+                options:
+                  stp:
+                    enabled: false
+                port:
+                - name: enp6s0
+              description: Linux bridge with enp6s0 as a port
+              name: br-osp
+              state: up
+              type: linux-bridge
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
       cidr: 192.168.25.0/24
       gateway: 192.168.25.1
+      vlan: 0
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackIPSet
+metadata:
+  labels:
+    addToPredictableIPsLabel: "true"
+  name: controller
+  namespace: openstack
+spec:
+  addToPredictableIPs: true
+  hostCount: 0
+  networks:
+  - ctlplane
+  roleName: Controller
+  vip: false
+status:
+  hosts: {}
+  networks: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -172,19 +195,37 @@ status:
     ctlplane:
       allocationEnd: 192.168.25.250
       allocationStart: 192.168.25.100
+      attachConfiguration:
+        bridgeName: br-osp
+        nodeNetworkConfigurationPolicy:
+          desiredState:
+            interfaces:
+            - bridge:
+                options:
+                  stp:
+                    enabled: false
+                port:
+                - name: enp6s0
+              description: Linux bridge with enp6s0 as a port
+              name: br-osp
+              state: up
+              type: linux-bridge
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
       cidr: 192.168.25.0/24
       gateway: 192.168.25.1
+      vlan: 0
 ---
 apiVersion: nmstate.io/v1alpha1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   labels:
-    app: osp-vmset
-    cr: controller
-    osp-director.openstack.org/name: controller
+    app: osp-openstacknet
+    cr: ctlplane
+    osp-director.openstack.org/name: ctlplane
     osp-director.openstack.org/namespace: openstack
     owner: osp-director
-  name: br-osp
+  name: ctlplane
 spec:
   desiredState:
     interfaces:
@@ -200,3 +241,12 @@ spec:
       type: linux-bridge
   nodeSelector:
     node-role.kubernetes.io/worker: ""
+status:
+  conditions:
+  - reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+  - reason: SuccessfullyConfigured
+    status: "False"
+    type: Degraded
+

--- a/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
@@ -1,11 +1,11 @@
 #
 # Check for:
 #
-# - OpenStackControlPlane
-# - OpenStackVMSet
-# - VirtualMachines
-# - OpenStackNet (IP reservations)
-# - OpenStackIPSet (IP reservations)
+# - 1 OpenStackControlPlane
+# - 1 OpenStackVMSet
+# - 3 VirtualMachines
+# - 1 OpenStackNet (IP reservations)
+# - 1 OpenStackIPSet (IP reservations)
 #
 
 apiVersion: osp-director.openstack.org/v1beta1
@@ -140,3 +140,27 @@ status:
     controller-2:
       ipaddresses:
         ctlplane: 192.168.25.104/24
+  networks:
+    ctlplane:
+      allocationEnd: 192.168.25.250
+      allocationStart: 192.168.25.100
+      attachConfiguration:
+        bridgeName: br-osp
+        nodeNetworkConfigurationPolicy:
+          desiredState:
+            interfaces:
+            - bridge:
+                options:
+                  stp:
+                    enabled: false
+                port:
+                - name: enp6s0
+              description: Linux bridge with enp6s0 as a port
+              name: br-osp
+              state: up
+              type: linux-bridge
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+      cidr: 192.168.25.0/24
+      gateway: 192.168.25.1
+      vlan: 0

--- a/tests/kuttl/tests/openstackcontrolplane_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/04-assert.yaml
@@ -1,11 +1,11 @@
 #
 # Check for:
 #
-# - OpenStackControlPlane
-# - OpenStackVMSet
-# - VirtualMachine
-# - OpenStackNet (IP reservations)
-# - OpenStackIPSet (IP reservations)
+# - 1 OpenStackControlPlane
+# - 1 OpenStackVMSet
+# - 1 VirtualMachine
+# - 1 OpenStackNet (IP reservations)
+# - 1 OpenStackIPSet (IP reservations)
 #
 
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
@@ -1,11 +1,11 @@
 #
 # Check for:
 #
-# - OpenStackControlPlane
-# - OpenStackVMSet
-# - VirtualMachines
-# - OpenStackNet (IP reservations)
-# - OpenStackIPSet (IP reservations)
+# - 1 OpenStackControlPlane
+# - 1 OpenStackVMSet
+# - 3 VirtualMachines
+# - 1 OpenStackNet (IP reservations)
+# - 1 OpenStackIPSet (IP reservations)
 #
 
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
@@ -1,7 +1,7 @@
 #
 # Check for:
 #
-# - OpenStackNet (should be preserved with all historical reservations)
+# - 1 OpenStackNet (should be preserved with all historical reservations)
 #
 
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/tests/openstackcontrolplane_scale/06-errors.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/06-errors.yaml
@@ -1,11 +1,11 @@
 #
 # Check for:
 #
-# - OpenStackControlPlane (should be removed)
-# - OpenStackVMSet (should be removed)
-# - VirtualMachines (3 should be removed)
-# - OpenStackClient (should be removed)
-# - OpenStackIPSets (should be removed for OpenStackVMSet and OpenStackClient)
+# - 1 OpenStackControlPlane (should be removed)
+# - 1 OpenStackVMSet (should be removed)
+# - 3 VirtualMachines (3 should be removed)
+# - 1 OpenStackClient (should be removed)
+# - 3 OpenStackIPSets (2 should be removed for OpenStackVMSet and 1 for OpenStackClient)
 #
 
 apiVersion: osp-director.openstack.org/v1beta1
@@ -42,6 +42,12 @@ apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackClient
 metadata:
   name: openstackclient
+  namespace: openstack
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackIPSet
+metadata:
+  name: overcloud
   namespace: openstack
 ---
 apiVersion: osp-director.openstack.org/v1beta1


### PR DESCRIPTION
Includes a change to `net-attach-def` perms and networking checks in `OpenStackVmset` and `OpenStackClient` controllers