### PR TITLE
Remove hard coded OpenStackClient storageClass

### DIFF
--- a/api/v1beta1/openstackclient_types.go
+++ b/api/v1beta1/openstackclient_types.go
@@ -35,6 +35,9 @@ type OpenStackClientSpec struct {
 	// +kubebuilder:default={ctlplane,external}
 	// Networks the name(s) of the OpenStackNetworks used to generate IPs
 	Networks []string `json:"networks"`
+
+	// StorageClass to be used for the openstackclient persistent storage
+	StorageClass string `json:"storageClass,omitempty"`
 }
 
 // OpenStackClientStatus defines the observed state of OpenStackClient

--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -26,6 +26,8 @@ type OpenStackControlPlaneSpec struct {
 	VirtualMachineRoles map[string]OpenStackVirtualMachineRoleSpec `json:"virtualMachineRoles"`
 	// OpenstackClient image
 	OpenStackClientImageURL string `json:"openStackClientImageURL"`
+	// OpenStackClientStorageClass storage class
+	OpenStackClientStorageClass string `json:"openStackClientStorageClass,omitempty"`
 	// PasswordSecret used to e.g specify root pwd
 	PasswordSecret string `json:"passwordSecret,omitempty"`
 

--- a/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
@@ -75,6 +75,10 @@ spec:
                 items:
                   type: string
                 type: array
+              storageClass:
+                description: StorageClass to be used for the openstackclient persistent
+                  storage
+                type: string
             required:
             - cloudName
             - deploymentSSHSecret

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -52,6 +52,9 @@ spec:
                 items:
                   type: string
                 type: array
+              openStackClientStorageClass:
+                description: OpenStackClientStorageClass storage class
+                type: string
               passwordSecret:
                 description: PasswordSecret used to e.g specify root pwd
                 type: string

--- a/config/samples/osp-director_v1beta1_openstackclient.yaml
+++ b/config/samples/osp-director_v1beta1_openstackclient.yaml
@@ -8,3 +8,4 @@ spec:
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
     - ctlplane
+  storageClass: host-nfs-storageclass

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -8,6 +8,7 @@ spec:
   openStackClientNetworks:
     - ctlplane
     - external
+  openStackClientStorageClass: host-nfs-storageclass
   virtualMachineRoles:
     controller:
       roleName: Controller

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
@@ -8,6 +8,7 @@ spec:
   openStackClientNetworks:
     - ctlplane
     - external
+  openStackClientStorageClass: host-nfs-storageclass
   virtualMachineRoles:
     controller:
       roleName: Controller

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -237,7 +237,7 @@ func (r *OpenStackClientReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 		Namespace:    instance.Namespace,
 		Size:         openstackclient.HostsPersistentStorageSize,
 		Labels:       common.GetLabels(instance.Name, openstackclient.AppLabel),
-		StorageClass: openstackclient.PersistentStorageClass,
+		StorageClass: instance.Spec.StorageClass,
 		AccessMode: []corev1.PersistentVolumeAccessMode{
 			corev1.ReadWriteOnce,
 		},
@@ -256,7 +256,7 @@ func (r *OpenStackClientReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 		Namespace:    instance.Namespace,
 		Size:         openstackclient.CloudAdminPersistentStorageSize,
 		Labels:       common.GetLabels(instance.Name, openstackclient.AppLabel),
-		StorageClass: openstackclient.PersistentStorageClass,
+		StorageClass: instance.Spec.StorageClass,
 		AccessMode: []corev1.PersistentVolumeAccessMode{
 			corev1.ReadWriteOnce,
 		},

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -248,6 +248,8 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 		openstackclient.Spec.ImageURL = instance.Spec.OpenStackClientImageURL
 		openstackclient.Spec.DeploymentSSHSecret = deploymentSecretName
 		openstackclient.Spec.CloudName = instance.Name
+		openstackclient.Spec.StorageClass = instance.Spec.OpenStackClientStorageClass
+
 		if len(instance.Spec.OpenStackClientNetworks) > 0 {
 			openstackclient.Spec.Networks = instance.Spec.OpenStackClientNetworks
 		}

--- a/pkg/openstackclient/const.go
+++ b/pkg/openstackclient/const.go
@@ -34,9 +34,6 @@ const (
 	HostsPersistentStorageSize = "1G"
 	// CloudAdminPersistentStorageSize - size in GB
 	CloudAdminPersistentStorageSize = "4G"
-	// PersistentStorageClass -
-	// TODO: move to be CRD parameter PersistentStorageClass
-	PersistentStorageClass = "host-nfs-storageclass"
 	// Count - openstackclient count is atm fixed to 1
 	Count = 1
 	// Role - openstackclient has not tripleo role, set it as const

--- a/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
@@ -18,6 +18,7 @@ spec:
   openStackClientNetworks:
     - ctlplane
     - external
+  openStackClientStorageClass: host-nfs-storageclass
   virtualMachineRoles:
     controller:
       baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
@@ -76,6 +77,7 @@ spec:
   networks:
   - ctlplane
   - external
+  storageClass: host-nfs-storageclass
 status:
   netStatus:
     openstackclient-0:


### PR DESCRIPTION
Adds OpenStackClientStorageClass parameter to the controlplane
CRD to be able to controll the storage class the pvc for the
openstackclient gets created.