### PR TITLE
Increase operator CPU and mem allowance

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,9 +31,9 @@ spec:
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 250m
+            memory: 512Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 128Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The default CPU and memory limit were low and causing the operator to be `OOMKilled`