### PR TITLE
Allow baseImageVolumeName to be truly optional

### DIFF
--- a/api/v1beta1/openstackvmset_types.go
+++ b/api/v1beta1/openstackvmset_types.go
@@ -73,6 +73,7 @@ type Host struct {
 	DomainNameUniq    string                                            `json:"domainNameUniq"`
 	IPAddress         string                                            `json:"ipAddress"`
 	NetworkDataSecret string                                            `json:"networkDataSecret"`
+	BaseImageName     string                                            `json:"baseImageName"`
 	Labels            map[string]string                                 `json:"labels"`
 	NNCP              map[string]nmstate.NodeNetworkConfigurationPolicy `json:"nncp"`
 	NAD               map[string]networkv1.NetworkAttachmentDefinition  `json:"nad"`


### PR DESCRIPTION
Moves the initialization/generation of the `baseImageName` to earlier in the VMSet logic, and sets either the default or the CR spec's value as its value.  That value is then passed to the functions that need it.