### PR TITLE
Image downloader Dockerfile to meet CPaaS requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,10 @@ ARG REMOTE_SOURCE_DIR=/remote-source
 ARG REMOTE_SOURCE_SUBDIR=
 ARG DEST_ROOT=/dest-root
 
-ARG GO_BUILD_EXTRA_ARGS
+ARG GO_BUILD_EXTRA_ARGS=
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
 WORKDIR ${REMOTE_SOURCE_DIR}/${REMOTE_SOURCE_SUBDIR}
-
-RUN go version
-RUN go env
-RUN if [ -f $CACHITO_ENV_FILE ] ; then echo $CACHITO_ENV_FILE; cat $CACHITO_ENV_FILE ; fi
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi && go env
 
 RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
@@ -28,10 +23,8 @@ RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 # and so that source changes don't invalidate our downloaded layer
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 
-#RUN mkdir -p /usr/share/osp-director-operator/templates && mkdir -p /cmd/
-
 # Build manager
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -v -a -o ${DEST_ROOT}/manager main.go
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
 RUN cp -r templates ${DEST_ROOT}/templates
 
@@ -63,5 +56,7 @@ COPY --from=builder ${DEST_ROOT}/manager .
 COPY --from=builder ${DEST_ROOT}/templates ${OPERATOR_TEMPLATES}
 
 USER ${USER_ID}
+
+ENV PATH="/:${PATH}"
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.provision-ip-discovery-agent
+++ b/Dockerfile.provision-ip-discovery-agent
@@ -1,15 +1,47 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
-WORKDIR /go/src/github.com/openstack-k8s-operators/osp-director-operator
-COPY . .
-RUN go mod vendor
-RUN BIN_PATH=build/_output/cmd ./containers/provision_ip_discovery_agent/build-provision-ip-discovery-agent.sh
+ARG GOLANG_BUILDER=golang:1.14
+ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/base
 
-FROM registry.svc.ci.openshift.org/ocp/4.7:base
-RUN yum -y update && yum clean all
+# Build the manager binary
+FROM ${GOLANG_BUILDER} AS builder
+
+#Arguments required by OSBS build system
+ARG CACHITO_ENV_FILE=/remote-source/cachito.env
+
+ARG REMOTE_SOURCE=.
+ARG REMOTE_SOURCE_DIR=/remote-source
+ARG REMOTE_SOURCE_SUBDIR=
+ARG DEST_ROOT=/dest-root
+ARG WHAT=provision-ip-discovery-agent
+
+ARG GO_BUILD_EXTRA_ARGS=
+
+COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
+WORKDIR ${REMOTE_SOURCE_DIR}/${REMOTE_SOURCE_SUBDIR}
+
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=1 go build ${GO_BUILD_EXTRA_ARGS} -o ${DEST_ROOT}/${WHAT} ./containers/provision_ip_discovery_agent
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM ${OPERATOR_BASE_IMAGE}
+
+# Those arguments must match ones from builder
+ARG DEST_ROOT=/dest-root
+ARG WHAT=provision-ip-discovery-agent
+
 LABEL io.k8s.display-name="OSP-Director-Operator provision-ip-discovery-agent" \
       io.k8s.description="This is an agent that discovers the IP of a designated provisioning interface on a given host" \
       io.openshift.tags="openstack,director" \
       maintainer="Andrew Bays <abays@redhat.com>"
-COPY --from=builder /go/src/github.com/openstack-k8s-operators/osp-director-operator/build/_output/cmd/provision-ip-discovery-agent /usr/bin/
 
-CMD ["/usr/bin/provision-ip-discovery-agent"]
+LABEL com.redhat.component="osp-director-provisioner-container" \
+      name="osp-director-provisioner-container" \
+      version="1.0"
+
+WORKDIR /
+
+# Install binary to WORKDIR
+COPY --from=builder ${DEST_ROOT}/${WHAT} .
+
+ENV PATH="/:${PATH}"
+
+ENTRYPOINT ["/provision-ip-discovery-agent"]

--- a/containers/image_downloader/Dockerfile
+++ b/containers/image_downloader/Dockerfile
@@ -1,8 +1,25 @@
-FROM centos:centos7 as build
+ARG IMAGE_DOWNLOADER_BASE=centos:centos7
 
-RUN yum install -y qemu-img
+FROM ${IMAGE_DOWNLOADER_BASE} as build
+
+ARG PKG_CMD=yum
+ARG REMOTE_SOURCE=
+# Buildah expects the entrypoint.sh to be relative to pwd, podman expects
+# the file to be relative to the Dockerfile location
+ARG ENTRYPOINT_PATH=entrypoint.sh
+
+RUN ${PKG_CMD} install -y qemu-img
+
+LABEL   com.redhat.component="osp-director-downloader-container" \
+        name="osp-director-downloader" \
+        version="1.0" \
+        summary="OSP Director Image Downloader" \
+        io.k8s.name="osp director image downloader" \
+        io.k8s.description="This image includes the osp-director-downloader" \
+        io.openshift.tags="cn-openstack openstack"
 
 WORKDIR /
 
-ADD ./entrypoint.sh /
+COPY ${REMOTE_SOURCE}/${ENTRYPOINT_PATH} /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Updated Dockerfile for the image_downloader container that
allows to translate from upstream to downstream using
dockerfile_to_osbs.sh from openstack-k8s-operators-ci.