### PR TITLE
Support deploy ComputeHCI

### DIFF
--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -143,7 +143,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 			Role:                controlplane.Role,
 			HostCount:           controlplane.Count,
 			VIP:                 true,
-			AddToPredictableIPs: false,
+			AddToPredictableIPs: true,
 		}
 		ipset, op, err := common.OvercloudipsetCreateOrUpdate(r, instance, ipsetDetails)
 		if err != nil {

--- a/controllers/openstackipset_controller.go
+++ b/controllers/openstackipset_controller.go
@@ -216,7 +216,6 @@ func (r *OpenStackIPSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	envVars := make(map[string]common.EnvSetter)
 	cmLabels := common.GetLabels(instance.Name, openstackipset.AppLabel)
 
-	//templateParameters, err := overcloudipset.CreateConfigMapParams(r, *overcloudIPList, ctlplaneCidr)
 	templateParameters, err := openstackipset.CreateConfigMapParams(*overcloudIPList, *overcloudNetList)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/openstackclient/volumes.go
+++ b/pkg/openstackclient/volumes.go
@@ -27,8 +27,7 @@ import (
 func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
-			Name: fmt.Sprintf("%s-hosts", instance.Name),
-			//MountPath: "/mnt",
+			Name:      fmt.Sprintf("%s-hosts", instance.Name),
 			MountPath: "/etc/hosts",
 			SubPath:   "hosts",
 			ReadOnly:  false,
@@ -39,21 +38,8 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volu
 			ReadOnly:  false,
 		},
 		{
-			Name:      "id-rsa",
-			MountPath: "/home/cloud-admin/.ssh/id_rsa",
-			SubPath:   "id_rsa",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "ssh-config",
-			MountPath: "/home/cloud-admin/.ssh/id_rsa.pub",
-			SubPath:   "id_rsa.pub",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "ssh-config",
-			MountPath: "/home/cloud-admin/.ssh/config",
-			SubPath:   "config",
+			Name:      "root-ssh",
+			MountPath: "/root/.ssh",
 			ReadOnly:  true,
 		},
 		{
@@ -92,8 +78,36 @@ func GetInitVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.
 		},
 		{
 			Name:      fmt.Sprintf("%s-hosts", instance.Name),
-			MountPath: "/mnt",
+			MountPath: "/mnt/etc",
 			ReadOnly:  false,
+		},
+		{
+			Name:      fmt.Sprintf("%s-cloud-admin", instance.Name),
+			MountPath: "/home/cloud-admin",
+			ReadOnly:  false,
+		},
+		{
+			Name:      "root-ssh",
+			MountPath: "/root/.ssh",
+			ReadOnly:  false,
+		},
+		{
+			Name:      "ssh-config",
+			MountPath: "/mnt/ssh-config/id_rsa",
+			SubPath:   "id_rsa",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "ssh-config",
+			MountPath: "/mnt/ssh-config/id_rsa.pub",
+			SubPath:   "id_rsa.pub",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "ssh-config",
+			MountPath: "/mnt/ssh-config/config",
+			SubPath:   "config",
+			ReadOnly:  true,
 		},
 	}
 }
@@ -106,21 +120,6 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 
 	return []corev1.Volume{
 		{
-			Name: "id-rsa",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: &config0600AccessMode,
-					SecretName:  instance.Spec.DeploymentSSHSecret,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "identity",
-							Path: "id_rsa",
-						},
-					},
-				},
-			},
-		},
-		{
 			Name: "ssh-config",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
@@ -128,15 +127,26 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 					SecretName:  instance.Spec.DeploymentSSHSecret,
 					Items: []corev1.KeyToPath{
 						{
-							Key:  "config",
-							Path: "config",
+							Key:  "identity",
+							Path: "id_rsa",
+							Mode: &config0600AccessMode,
 						},
 						{
 							Key:  "authorized_keys",
 							Path: "id_rsa.pub",
 						},
+						{
+							Key:  "config",
+							Path: "config",
+						},
 					},
 				},
+			},
+		},
+		{
+			Name: "root-ssh",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
 			},
 		},
 		{

--- a/pkg/overcloudipset/configmap.go
+++ b/pkg/overcloudipset/configmap.go
@@ -65,7 +65,7 @@ func CreateConfigMapParams(overcloudIPList ospdirectorv1beta1.OpenStackIPSetList
 		for _, reservation := range net.Status.Reservations {
 
 			// if ctlplane network add to DeployedServerPortMap
-			if net.Name == "ctlplane" {
+			if net.Name == "ctlplane" && reservation.AddToPredictableIPs {
 
 				// in case of control plane vip the DeployedServerPortMap is
 				// named control_virtual_ip instead of ctlplane_virtual_ip

--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -16,6 +16,21 @@
 set -ex
 
 # if the pvc is an empty volume, copy the existing hosts file to it
-if [ ! -f /mnt/hosts ]; then
-  cp /etc/hosts /mnt
+if [ ! -f /mnt/etc/hosts ]; then
+  cp /etc/hosts /mnt/etc/
 fi
+
+mkdir -p /home/cloud-admin/tripleo-deploy/validations
+rm -rf /home/cloud-admin/tripleo-deploy/overcloud-ansible*
+
+# add cloud-admin ssh keys to EmptyDir Vol mount to /root/.ssh in openstackclient
+sudo mkdir -p /root/.ssh
+sudo cp /mnt/ssh-config/* /root/.ssh/
+sudo chmod 600 /root/.ssh/id_rsa
+sudo chown -R root: /root/.ssh
+
+# add cloud-admin ssh keys to /home/cloud-admin/.ssh in openstackclient
+mkdir -p /home/cloud-admin/.ssh
+cp /mnt/ssh-config/* /home/cloud-admin/.ssh/
+chmod 600 /home/cloud-admin/.ssh/id_rsa
+chown -R cloud-admin: /home/cloud-admin/.ssh

--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -2,16 +2,20 @@
 
 set -eux
 
-# disable running dhcp on all interfaces, setting disable_configure_safe_defaults in the interface template does not work
-sudo sed -i '/^set -eux/a disable_configure_safe_defaults=true' /usr/share/openstack-tripleo-heat-templates/network/scripts/run-os-net-config.sh
+render() {
+  # disable running dhcp on all interfaces, setting disable_configure_safe_defaults in the interface template does not work
+  sudo sed -i '/^set -eux/a disable_configure_safe_defaults=true' /usr/share/openstack-tripleo-heat-templates/network/scripts/run-os-net-config.sh
 
-mkdir -p ~/tripleo-deploy
-rm -rf ~/tripleo-deploy/overcloud-ansible*
-unset OS_CLOUD
+  rm -rf /home/cloud-admin/tripleo-deploy/overcloud-ansible*
+  if [ ! -L /var/log/validations ]; then
+    sudo ln -s /home/cloud-admin/tripleo-deploy/validations /var/log/validations
+  fi
 
-sudo openstack tripleo deploy \
+  unset OS_CLOUD
+
+  sudo openstack tripleo deploy \
     --templates /usr/share/openstack-tripleo-heat-templates \
-    -r /usr/share/openstack-tripleo-heat-templates/roles_data.yaml \
+    -r ROLESFILE \
     -n /usr/share/openstack-tripleo-heat-templates/network_data.yaml \
     -e /usr/share/openstack-tripleo-heat-templates/overcloud-resource-registry-puppet.yaml \
     -e /usr/share/openstack-tripleo-heat-templates/environments/network-isolation.yaml \
@@ -30,17 +34,47 @@ sudo openstack tripleo deploy \
     --deployment-user $(id -u -n) \
     --output-only
 
-cd ~/tripleo-deploy
-output_dir=$(ls -dtr overcloud-ansible-* | tail -1)
-ln -sf ${output_dir} overcloud-ansible
-cd ${output_dir}
-# we run with --standalone, therefore have to remove transport=local from ansible.cfg
-sed -i '/transport/d' ansible.cfg
+  cd ~/tripleo-deploy
+  output_dir=$(ls -dtr overcloud-ansible-* | tail -1)
+  ln -sf ${output_dir} overcloud-ansible
+  cd ${output_dir}
+  # we run with --standalone, therefore have to remove transport=local from ansible.cfg
+  sed -i '/transport/d' ansible.cfg
 
-# For standalone role tripleo_deploy sets root for the ansible_ssh_user in the inventory.
-# Change it to cloud-admin
-sed -i 's/ansible_ssh_user: root/ansible_ssh_user: cloud-admin/g' ~/tripleo-deploy/overcloud-ansible/inventory.yaml
+  # For standalone role tripleo_deploy sets root for the ansible_ssh_user in the inventory.
+  # Change it to cloud-admin
+  sed -i 's/ansible_ssh_user: root/ansible_ssh_user: cloud-admin/g' ~/tripleo-deploy/overcloud-ansible/inventory.yaml
 
-time ansible-playbook -i inventory.yaml --become deploy_steps_playbook.yaml
+}
 
-cp /etc/openstack/clouds.yaml ~/tripleo-deploy/
+play() {
+
+  cd ~/tripleo-deploy/overcloud-ansible
+  # TODO: for now disable opendev-validation-ceph
+  # The check fails because the lvm2 package is not installed in openstackclient container image image
+  # and ansible_facts include packages from undercloud.
+  time ansible-playbook -i inventory.yaml \
+    --private-key /home/cloud-admin/.ssh/id_rsa \
+    --skip-tags opendev-validation-ceph \
+    --become deploy_steps_playbook.yaml
+
+  cp /etc/openstack/clouds.yaml ~/tripleo-deploy/
+
+}
+
+usage() { echo "Usage: $0 [-r] [-p]" 1>&2; exit 1; }
+
+while getopts ":rp" arg; do
+    case "${arg}" in
+        r)
+            render
+            ;;
+        p)
+            play
+            ;;
+        *)
+            usage
+            exit 0
+            ;;
+    esac
+done

--- a/templates/openstackipset/config/deployed-server-map.yaml
+++ b/templates/openstackipset/config/deployed-server-map.yaml
@@ -22,6 +22,9 @@ parameter_defaults:
         - ip_address: {{ $network.IPaddr }}
       subnets:
         - cidr: {{ $network.Cidr }}
+      network:
+        tags:
+          - {{ $network.Cidr }}
 {{- end }}
 {{- end }}
 {{- range $viptyp, $ip := .NetworkVip }}


### PR DESCRIPTION
Adds support for Compute nodes also be Ceph OSP nodes.

Also splits the tripleo-deploy.sh to have -r and -p option for
the two phases:
-r use ephemeral heat to render the ansible playbooks
-p run ansible playbooks

With this we can control which part of the deployment process
to run.

Note: right now skip-tags opendev-validation-ceph gets added to
the deployment command if IsHCI is set on a baremetalset. Ceph
validations check verify if lvm2 package is installed. The check
verifies if the package is in any host of the ansible facts, which
includes the "undercloud". Since the lvm2 package is not installed
in the openstackclient container image this fails.