### PR TITLE
Use biosdev nic naming for overcloud nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ oc create -n openstack -f ctlplane-secret.yaml
 
 4) Define your OpenStackControlPlane custom resource. The OpenStackControlPlane custom resource provides a cental place to create and scale VMs used for the OSP Controllers along with any additional vmsets for your deployment. At least 1 Controller VM is required for a basic demo installation and per OSP High Availability guidelines 3 Controller VMs are recommended.
 
+Note: If the rhel-guest-image is used as base to deploy the OpenStackControlPlane virtual machines, make sure to remove the net.ifnames=0 kernel parameter form the image to have the biosdev network interface naming. This can be done like:
+
+```bash
+dnf install -y libguestfs-tools-c
+virt-customize -a bms-image.qcow2 --run-command 'sed -i -e "s/^\(kernelopts=.*\)net.ifnames=0 \(.*\)/\1\2/" /boot/grub2/grubenv'
+```
+
 ```yaml
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackControlPlane
@@ -217,7 +224,7 @@ spec:
       cores: 6
       memory: 12
       diskSize: 40
-      baseImageURL: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
+      baseImageURL: http://host/images/rhel-guest-image-8.3-417.x86_64.qcow2
       storageClass: host-nfs-storageclass
 ```
 
@@ -229,6 +236,13 @@ oc create -f openstackcontrolplane.yaml
 
 5) Define an OpenStackBaremetalSet to scale out OSP Compute hosts. The OpenStackBaremetal resource can be used to define and scale Compute resources and optionally be used to define and scale out baremetal hosts for other types of TripleO roles. The example below defines a single Compute host to be created.
 
+Note: If the rhel-guest-image is used as base to deploy the OpenStackBaremetalSet compute nodes, make sure to remove the net.ifnames=0 kernel parameter form the image to have the biosdev network interface naming. This can be done like:
+
+```bash
+dnf install -y libguestfs-tools-c
+virt-customize -a bms-image.qcow2 --run-command 'sed -i -e "s/^\(kernelopts=.*\)net.ifnames=0 \(.*\)/\1\2/" /boot/grub2/grubenv'
+```
+
 ```yaml
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackBaremetalSet
@@ -239,7 +253,7 @@ spec:
   # How many nodes to provision
   replicas: {{ osp_compute_count }}
   # The image to install on the provisioned nodes. NOTE: needs to be accessible on the OpenShift Metal3 provisioning network.
-  baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
+  baseImageUrl: http://host/images/rhel-image-8.3-417.x86_64.qcow2
   # NOTE: these are automatically created via the OpenStackControlplane CR above
   deploymentSSHSecret: osp-controlplane-ssh-keys
   # The interface on the nodes that will be assigned an IP from the mgmtCidr
@@ -294,6 +308,13 @@ as the `openStackClientImageURL` in the openstackcontrolplane CR.
 Have compute nodes with extra disks to be used as OSDs and create a baremetalset for the ComputeHCI role which has
 the storagemgmt network in addition to the default compute networks and the `IsHCI` parameter set to true.
 
+Note: If the rhel-guest-image is used as base to deploy the OpenStackBaremetalSet compute nodes, make sure to remove the net.ifnames=0 kernel parameter form the image to have the biosdev network interface naming. This can be done like:
+
+```bash
+dnf install -y libguestfs-tools-c
+virt-customize -a bms-image.qcow2 --run-command 'sed -i -e "s/^\(kernelopts=.*\)net.ifnames=0 \(.*\)/\1\2/" /boot/grub2/grubenv'
+```
+
 ```yaml
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackBaremetalSet
@@ -304,7 +325,7 @@ spec:
   # How many nodes to provision
   replicas: 2
   # The image to install on the provisioned nodes
-  baseImageUrl: http://172.22.0.1/images/rhel-guest-image-8.4-825.x86_64.qcow2
+  baseImageUrl: http://host/images/rhel-image-8.3-417.x86_64.qcow2
   provisionServerName: openstack
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys

--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -54,6 +54,10 @@ type OpenStackVirtualMachineRoleSpec struct {
 	// BaseImageVolumeName Optional. If supplied will be used as the base volume for the VM instead of BaseImageURL.
 	BaseImageVolumeName string `json:"baseImageVolumeName,omitempty"`
 
+	// +kubebuilder:default=enp2s0
+	// Interface to use for ctlplane network
+	CtlplaneInterface string `json:"ctlplaneInterface"`
+
 	// +kubebuilder:default={ctlplane,external,internalapi,tenant,storage,storagemgmt}
 	// Networks the name(s) of the OpenStackNetworks used to generate IPs
 	Networks []string `json:"networks"`

--- a/api/v1beta1/openstackvmset_types.go
+++ b/api/v1beta1/openstackvmset_types.go
@@ -41,6 +41,10 @@ type OpenStackVMSetSpec struct {
 	// name of secret holding the stack-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
 
+	// +kubebuilder:default=enp2s0
+	// Interface to use for ctlplane network
+	CtlplaneInterface string `json:"ctlplaneInterface"`
+
 	// +kubebuilder:default={ctlplane,external,internalapi,tenant,storage,storagemgmt}
 	// Networks the name(s) of the OpenStackNetworks used to generate IPs
 	Networks []string `json:"networks"`

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -74,6 +74,10 @@ spec:
                       description: number of Cores assigned to the VM
                       format: int32
                       type: integer
+                    ctlplaneInterface:
+                      default: enp2s0
+                      description: Interface to use for ctlplane network
+                      type: string
                     diskSize:
                       description: root Disc size in GB
                       format: int32
@@ -114,6 +118,7 @@ spec:
                       type: string
                   required:
                   - cores
+                  - ctlplaneInterface
                   - diskSize
                   - memory
                   - networks

--- a/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
@@ -52,6 +52,10 @@ spec:
                 description: number of Cores assigned to the VMs
                 format: int32
                 type: integer
+              ctlplaneInterface:
+                default: enp2s0
+                description: Interface to use for ctlplane network
+                type: string
               deploymentSSHSecret:
                 description: name of secret holding the stack-admin ssh keys
                 type: string
@@ -97,6 +101,7 @@ spec:
                 type: integer
             required:
             - cores
+            - ctlplaneInterface
             - deploymentSSHSecret
             - diskSize
             - isTripleoRole

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -19,6 +19,7 @@ spec:
       baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
       storageClass: host-nfs-storageclass
       baseImageVolumeName: openstack-base-img #optional
+      ctlplaneInterface: enp2s0 #defaults to enp2s0
       networks:
       - ctlplane
       - external

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
@@ -19,6 +19,7 @@ spec:
       baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
       storageClass: host-nfs-storageclass
       baseImageVolumeName: openstack-base-img #optional
+      ctlplaneInterface: enp2s0 #defaults to enp2s0
       networks:
       - ctlplane
       - external
@@ -36,6 +37,7 @@ spec:
       baseImageURL: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
       storageClass: host-nfs-storageclass
       #baseImageVolumeName: #optional
+      ctlplaneInterface: enp2s0 #defaults to enp2s0
       networks:
       - ctlplane
       - external

--- a/config/samples/osp-director_v1beta1_openstackvmset.yaml
+++ b/config/samples/osp-director_v1beta1_openstackvmset.yaml
@@ -13,6 +13,7 @@ spec:
   #imageImportStorageClass: local #optional
   deploymentSSHSecret: osp-controlplane-ssh-keys
   isTripleoRole: true
+  ctlplaneInterface: enp2s0 #defaults to enp2s0
   networks:
     - ctlplane
   roleName: Controller

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -201,6 +201,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 			}
 			vmSet.Spec.BaseImageVolumeName = vmRole.DeepCopy().BaseImageVolumeName
 			vmSet.Spec.DeploymentSSHSecret = deploymentSecretName
+			vmSet.Spec.CtlplaneInterface = vmRole.CtlplaneInterface
 			vmSet.Spec.Networks = vmRole.Networks
 			vmSet.Spec.RoleName = vmRole.RoleName
 			vmSet.Spec.IsTripleoRole = vmRole.IsTripleoRole

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -460,6 +460,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 func (r *OpenStackVMSetReconciler) generateVirtualMachineNetworkData(instance *ospdirectorv1beta1.OpenStackVMSet, ipset *ospdirectorv1beta1.OpenStackIPSet, envVars *map[string]common.EnvSetter, templateParameters map[string]interface{}, host ospdirectorv1beta1.Host) error {
 	templateParameters["ControllerIP"] = host.IPAddress
+	templateParameters["CtlplaneInterface"] = instance.Spec.CtlplaneInterface
 
 	gateway := ipset.Status.Networks["ctlplane"].Gateway
 	if gateway != "" {

--- a/templates/vmset/cloudinit/networkdata
+++ b/templates/vmset/cloudinit/networkdata
@@ -1,6 +1,6 @@
 version: 2
 ethernets:
-  eth1:
+  {{ .CtlplaneInterface }}:
     addresses: [ {{ .ControllerIP }} ]
 {{- if .Gateway }}
     {{ .Gateway }}


### PR DESCRIPTION
Document usage of biosdev names for osvmset and osbmset and
introduce parameter to set ctlplane interface for vmset, which
defaults to enp2s0 and usually won't need to be changed.