### PR TITLE
Add intf selection option to prov server

### DIFF
--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -24,6 +24,8 @@ import (
 type OpenStackProvisionServerSpec struct {
 	// The port on which the Apache server should listen
 	Port int `json:"port"`
+	// An optional interface to use instead of the cluster's default provisioning interface (if any)
+	Interface string `json:"interface,omitempty"`
 	// URL to *gzipped* RHEL qcow2 image (TODO: support uncompressed -- current implementation is Metal3 pattern)
 	BaseImageURL string `json:"baseImageUrl"`
 }

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -45,6 +45,10 @@ spec:
                 description: 'URL to *gzipped* RHEL qcow2 image (TODO: support uncompressed
                   -- current implementation is Metal3 pattern)'
                 type: string
+              interface:
+                description: An optional interface to use instead of the cluster's
+                  default provisioning interface (if any)
+                type: string
               port:
                 description: The port on which the Apache server should listen
                 type: integer


### PR DESCRIPTION
Tucking this away in the `OpenStackProvisionServer` for now, but basically this allows a user to deploy a provision server on worker nodes and also select a specific interface to examine to acquire an associated IP address.  Normally we look for the Metal3 `Provisioning` CRD's specified interface, but the fact of the matter is that the actual `OpenStackProvisionServer` pod's Apache process listens on all IPs on the host (`Listen [::]:<port>`).  This might allow for more flexibility down the road if we needed to acquire a prov server's IP from a different interface (and we have at least seen one request for this use case from the field).  NOTE: `OpenStackBaremetalSet` will continue to deploy prov servers that use the Metal3 provisioning interface.  This does not change the default behavior.