### PR TITLE
Fixes for playbookgenerator script

### DIFF
--- a/templates/openstackplaybookgenerator/bin/create-playbooks.sh
+++ b/templates/openstackplaybookgenerator/bin/create-playbooks.sh
@@ -16,6 +16,7 @@ Host $GIT_HOST
     IdentityFile /home/cloud-admin/.ssh/git_id_rsa
     StrictHostKeyChecking no
 EOF
+chmod 644 /home/cloud-admin/.ssh/config
 
 unset OS_CLOUD
 export OS_AUTH_TYPE=none

--- a/templates/openstackplaybookgenerator/bin/create-playbooks.sh
+++ b/templates/openstackplaybookgenerator/bin/create-playbooks.sh
@@ -69,7 +69,7 @@ if [ -z "$PREPARE_ENV_ARGS" ]; then
   openstack tripleo container image prepare default --output-env-file container-image-prepare.yaml
   PREPARE_ENV_ARGS="-e container-image-prepare.yaml"
 fi
-openstack tripleo container image prepare $PREPARE_ENV_ARGS -r roles_data.yaml --output-env-file=tripleo-overcloud-images.yaml
+openstack tripleo container image prepare $PREPARE_ENV_ARGS -e hostnamemap.yaml -r roles_data.yaml --output-env-file=tripleo-overcloud-images.yaml
 
 mkdir -p ~/tripleo-deploy
 rm -rf ~/tripleo-deploy/overcloud-ansible*


### PR DESCRIPTION
When custom roles are used, where there is no CountDefault in the
role, the container image prepare command will not add the container
images to the resulting tripleo-overcloud-images.yaml . Always add
our hostnamemap.yaml file, whsets the number of nodes deployed
to the role.