### PR TITLE
For now set OVNMacAddressNetwork and OVNMacAddressPort to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,16 @@ A "Tarball Config Map" can be used to provide (binary) tarballs which are extrac
 
 -[Net-Config files](https://github.com/openstack-k8s-operators/osp-director-dev-tools/tree/master/ansible/files/osp/net_config).
 
--[Net-Config environment](https://github.com/openstack-k8s-operators/osp-director-dev-tools/blob/master/ansible/templates/osp/tripleo_deploy/flat/network-environment.yaml.j2)
+-[Net-Config environment](https://github.com/openstack-k8s-operators/osp-director-dev-tools/blob/master/ansible/templates/osp/tripleo_deploy/vlan/network-environment.yaml.j2)
+
+Note: FIP traffic does not pass to a VLAN tenant network with ML2/OVN and DVR. DVR is enabled by default. If you need VLAN tenant networks with OVN, you can disable DVR. To disable DVR, inlcude the following lines in an environment file:
+
+```yaml
+parameter_defaults:
+  NeutronEnableDVR: false
+```
+
+Support for "distributed vlan traffic in ovn" is being tracked in [manage MAC addresses for "Add support in tripleo for distributed vlan traffic in ovn" ( https://bugs.launchpad.net/tripleo/+bug/1881593 )](https://github.com/openstack-k8s-operators/osp-director-operator/issues/254)
 
 -[Tripleo Deploy custom files](https://github.com/openstack-k8s-operators/osp-director-dev-tools/tree/master/ansible/templates/osp/tripleo_deploy) (NOTE: these are Ansible templates and need to have variables replaced to be used directly!)
 

--- a/templates/openstackipset/config/deployed-server-map.yaml
+++ b/templates/openstackipset/config/deployed-server-map.yaml
@@ -8,6 +8,9 @@ resource_registry:
   OS::TripleO::Network::Ports::InternalApiVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
   OS::TripleO::Network::Ports::StorageVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
   OS::TripleO::Network::Ports::StorageMgmtVipPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  # for now set OVNMacAddressNetwork and OVNMacAddressPort to None, see https://github.com/openstack-k8s-operators/osp-director-operator/issues/254
+  OS::TripleO::OVNMacAddressNetwork: OS::Heat::None
+  OS::TripleO::OVNMacAddressPort: OS::Heat::None
 
 parameter_defaults:
   DeployedServerPortMap:


### PR DESCRIPTION
"Add support in tripleo for distributed vlan traffic in ovn"
( https://bugs.launchpad.net/tripleo/+bug/1881593 ) was backported
to 16.2, which creates an OVNMacAddressNetwork and OVNMacAddressPort
per compute to configure the ovn chassis.
Right now we don't support MAC address management via the operator.
For now set OVNMacAddressNetwork and OVNMacAddressPort to None, which
should not affect the default geneve NeutronNetworkType. If VLAN is
used, FIP traffic does not pass to a VLAN tenant network with ML2/OVN
and DVR. DVR is enabled by default. If you need VLAN tenant networks
with OVN, you can disable DVR. To disable DVR, inlcude the following
lines in an environment file:

```yaml
parameter_defaults:
  NeutronEnableDVR: false
```