### PR TITLE
Add watch perm for jobs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/openstackplaybookgenerator_controller.go
+++ b/controllers/openstackplaybookgenerator_controller.go
@@ -75,7 +75,7 @@ func (r *OpenStackPlaybookGeneratorReconciler) GetScheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=osp-director.openstack.org,resources=openstackplaybookgenerators/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osp-director.openstack.org,resources=openstackplaybookgenerators/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;create;update;delete;
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;create;update;delete;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
We are missing a `watch` permission on `Jobs` for the OSPG controller.  This change will fix this message repeating in the operator logs:

```
E0601 18:31:53.267645       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.3/tools/cache/reflector.go:156: Failed to watch *v1.Job: unknown (get jobs.batch)
E0601 18:31:53.970255       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.3/tools/cache/reflector.go:156: Failed to watch *v1.Job: unknown (get jobs.batch)
```