### PR TITLE
Use dedicated service account and RunUser for playbookgenerator

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -90,3 +90,41 @@ subjects:
 - kind: ServiceAccount
   name: openstackprovisionserver
   namespace: openstack
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openstackplaybookgenerator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openstackplaybookgenerator-role
+  namespace: openstack
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openstackplaybookgenerator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openstackplaybookgenerator-role
+subjects:
+  # Applying the role to both SA (with and without prefix) to be able
+  # to run the operator local
+- kind: ServiceAccount
+  name: osp-director-operator-openstackplaybookgenerator
+  namespace: openstack
+- kind: ServiceAccount
+  name: openstackplaybookgenerator
+  namespace: openstack

--- a/pkg/openstackephemeralheat/const.go
+++ b/pkg/openstackephemeralheat/const.go
@@ -1,1 +1,12 @@
 package openstackephemeralheat
+
+const (
+	// ServiceAccount -
+	ServiceAccount = "osp-director-operator-openstackplaybookgenerator"
+	// HeatUID -
+	HeatUID = 42418
+	// MySQLUID -
+	MySQLUID = 42434
+	// RabbitMQUID -
+	RabbitMQUID = 42439
+)

--- a/pkg/openstackephemeralheat/heat.go
+++ b/pkg/openstackephemeralheat/heat.go
@@ -15,6 +15,7 @@ func HeatGetLabels(name string) map[string]string {
 
 // HeatAPIPod -
 func HeatAPIPod(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *corev1.Pod {
+	var runAsUser = int64(HeatUID)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -23,6 +24,10 @@ func HeatAPIPod(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *corev1.Pod
 			Labels:    HeatGetLabels(instance.Name),
 		},
 		Spec: corev1.PodSpec{
+			ServiceAccountName: ServiceAccount,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &runAsUser,
+			},
 			Containers: []corev1.Container{
 				{
 					Name:  "heat",
@@ -103,6 +108,7 @@ func HeatAPIService(instance *ospdirectorv1beta1.OpenStackEphemeralHeat, scheme 
 
 // HeatEngineReplicaSet -
 func HeatEngineReplicaSet(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *appsv1.ReplicaSet {
+	var runAsUser = int64(HeatUID)
 
 	selectorLabels := map[string]string{
 		"app":              "osp-director-operator-heat-engine",
@@ -127,6 +133,10 @@ func HeatEngineReplicaSet(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *
 					Labels:    selectorLabels,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: ServiceAccount,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: &runAsUser,
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  "heat-engine",

--- a/pkg/openstackephemeralheat/mariadb.go
+++ b/pkg/openstackephemeralheat/mariadb.go
@@ -14,6 +14,7 @@ func MariadbGetLabels(name string) map[string]string {
 
 // MariadbPod -
 func MariadbPod(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *corev1.Pod {
+	var runAsUser = int64(MySQLUID)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -22,7 +23,10 @@ func MariadbPod(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *corev1.Pod
 			Labels:    MariadbGetLabels(instance.Name),
 		},
 		Spec: corev1.PodSpec{
-			//ServiceAccountName: "mariadb",
+			ServiceAccountName: ServiceAccount,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &runAsUser,
+			},
 			Containers: []corev1.Container{
 				{
 					Name:  "mariadb",

--- a/pkg/openstackephemeralheat/rabbitmq.go
+++ b/pkg/openstackephemeralheat/rabbitmq.go
@@ -14,6 +14,7 @@ func RabbitmqGetLabels(name string) map[string]string {
 
 // RabbitmqPod -
 func RabbitmqPod(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *corev1.Pod {
+	var runAsUser = int64(RabbitMQUID)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -22,6 +23,10 @@ func RabbitmqPod(instance *ospdirectorv1beta1.OpenStackEphemeralHeat) *corev1.Po
 			Labels:    RabbitmqGetLabels(instance.Name),
 		},
 		Spec: corev1.PodSpec{
+			ServiceAccountName: ServiceAccount,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &runAsUser,
+			},
 			Containers: []corev1.Container{
 				{
 					Name:  "rabbitmq",


### PR DESCRIPTION
When running the operator local, openstackplaybookgenerator fails
to create heat-engine replica pods due to security context settings:

```
$ oc get pods
NAME                               READY   STATUS    RESTARTS   AGE
default                            1/1     Running   0          28s
default-895tm                      0/1     Error     2          27s
default-8zrqd                      0/1     Error     2          27s
default-k8jhw                      0/1     Error     2          27s

$ oc logs default-895t
+ sudo -E kolla_set_configs
sudo: PERM_SUDOERS: setresuid(-1, 1, -1): Operation not permitted
sudo: no valid sudoers sources found, quitting
sudo: setresuid() [0, 0, 0] -> [1000660000, -1, -1]: Operation not permitted
sudo: unable to initialize policy plugin

$ oc get rs default
...
Replicaset:
spec:
  containers:
  - env:
    - name: KOLLA_CONFIG_STRATEGY
      value: COPY_ALWAYS
    - name: ConfigHash
      value: n656h5ch599hd7h55dh697h664h678h557h56ch7bhf4h547h5d8hfbh58chddh645h699h668hcfh6hd8h97h677h86h66h54fh5c6h557h5f7h66dq
    image: quay.io/tripleotraincentos8/centos-binary-heat-engine:current-tripleo
    imagePullPolicy: IfNotPresent
    name: heat-engine
    resources: {}
    securityContext:
      capabilities:
        drop:
        - KILL
        - MKNOD
        - SETGID
        - SETUID
      runAsUser: 1000660000
```

With this change we introduce a dedicated service account for the
openstackplaybookgenerator with anyuid permissions and make sure
the pods get started using the tripleo UIDs.