### PR TITLE
Verify node status before run playbook job

### DIFF
--- a/config/crd/bases/osp-director.openstack.org_openstackplaybookgenerators.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackplaybookgenerators.yaml
@@ -89,7 +89,8 @@ spec:
                 default: false
                 description: Interactive enables the user to rsh into the playbook
                   generator pod for interactive debugging with the ephemeral heat
-                  instance
+                  instance. If enabled manual execution of the script to generate
+                  playbooks will be required.
                 type: boolean
               tarballConfigMap:
                 description: Optional. config map containing custom Heat template


### PR DESCRIPTION
This introduce a condtion to wait for all osbms and osvmset to
be in provisioned state before running the playbook rendering
job. With this we can be sure all resources are up before we
generate the playbooks or the user can run them.