### PR TITLE
Remove rhos-release and document rhsm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,13 +342,51 @@ The osplaybookgenerator created above will automatically generate playbooks any 
 
 9) Login to the 'openstackclient' pod and deploy the OSP software via the rendered ansible playbooks. At this point all baremetal and virtualmachine resources have been provisioned within the OCP cluster.
 
+The `tripleo-deploy.sh` script supports three actions:
+* `-d` - show the `git diff` of the playbooks to the previous accepted
+* `-a` - accept the new available rendered playbooks and tag them as `latest`
+* `-p` - run the ansible driven OpenStack deployment
+
+a) check for new version of renered playbooks and accept them
+
+```bash
+oc rsh openstackclient
+bash
+cd /home/cloud-admin
+
+# (optional) show the `git diff` of the playbooks to the previous accepted
+./tripleo-deploy.sh -d
+
+# accept the new available rendered playbooks (if available) and tag them as `latest`
+./tripleo-deploy.sh -a
+```
+
+b) register the overcloud systems to required channels
+
+The command in step a) to accept the current available rendered playbooks contain the latest inventory file of the overcloud and can be used to register the overcloud nodes to the required repositories for deployment. Use the procedure as described in [5.9. Running Ansible-based registration manually](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html-single/advanced_overcloud_customization/index#running-ansible-based-registration-manually-portal) do do so.
+
+TODO: update link to 16.2 release when available
+
+```bash
+oc rsh openstackclient
+bash
+cd /home/cloud-admin
+
+<create the ansible playbook for the overcloud nodes - e.g. rhsm.yaml>
+
+# register the overcloud nodes to required repositories
+ansible-playpook -i /home/cloud-admin/playbooks/tripleo-ansible/inventory.yaml ./rhsm.yaml
+```
+
+c) run ansible driven OpenStack deployment
+
 ```bash
 oc rsh openstackclient
 bash
 cd /home/cloud-admin
 
 # run ansible driven OpenStack deployment
-./tripleo-deploy.sh
+./tripleo-deploy.sh -p
 ```
 
 Deploy Ceph via tripleo using ComputeHCI

--- a/templates/baremetalset/cloudinit/userdata
+++ b/templates/baremetalset/cloudinit/userdata
@@ -12,6 +12,3 @@ chpasswd:
     root:{{ .NodeRootPassword }}
   expire: False
 {{- end }}
-runcmd:
-  - dnf install -y http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
-  - rhos-release 16.2

--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -39,6 +39,15 @@ diff() {
 play() {
   init
   pushd /home/cloud-admin/playbooks > /dev/null
+
+  if [ ! -d /home/cloud-admin/playbooks/tripleo-ansible ]; then
+    echo "Playbooks directory don't exist! Run the following command to accept and tag the new playbooks first:"
+    echo "  $0 -a"
+    echo ""
+    echo "Then re-run '$0 -p' to run the new playbooks."
+    exit
+  fi
+
   if ! git diff --exit-code --no-patch refs/tags/latest remotes/$LATEST_BRANCH; then
     echo "New playbooks detected. Run the following command to view a diff of the changes:"
     echo "  $0 -d"
@@ -49,14 +58,8 @@ play() {
     echo "Then re-run '$0 -p' to run the new playbooks."
     exit
   fi
-  if git branch | grep " tripleo_deploy_working$" > /dev/null; then
-    git checkout tripleo_deploy_working >/dev/null
-    git reset --hard refs/tags/latest
-  else
-    git checkout -b tripleo_deploy_working latest
-  fi
 
-  cd tripleo-ansible*
+  cd tripleo-ansible
 
   # TODO: for now disable opendev-validation-ceph
   # The check fails because the lvm2 package is not installed in openstackclient container image image
@@ -78,6 +81,15 @@ accept() {
   git push -f --delete origin refs/tags/latest
   git tag latest refs/remotes/$LATEST_BRANCH
   git push origin --tags
+
+  # checkout accepted code
+  if git branch | grep " tripleo_deploy_working$" > /dev/null; then
+    git checkout tripleo_deploy_working >/dev/null
+    git reset --hard refs/tags/latest
+  else
+    git checkout -b tripleo_deploy_working latest
+  fi
+
   popd > /dev/null
 }
 

--- a/templates/vmset/cloudinit/userdata
+++ b/templates/vmset/cloudinit/userdata
@@ -10,12 +10,3 @@ chpasswd:
     root:{{ .NodeRootPassword }}
   expire: False
 {{- end }}
-write_files:
-  - path: /tmp/write_file
-    content: |
-      BLAA
-      BOOOO
-runcmd:
-  - dnf install -y http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
-  - rhos-release 16.2
-  - dnf install -y qemu-guest-agent && systemctl enable --now qemu-guest-agent


### PR DESCRIPTION
This removes the installation of rhos-release package vi cloud-init
and documents the procedure how to register the overcloud nodes
via ansible to RHSM/Satellite.

Also moves the checkout of the accepted rendered playbooks to the
tripleo-deploy.sh -a action that the updated inventory.yaml file
is available to be used to register the overcloud nodes before
running the playbooks with -p.

Depends-On: https://github.com/openstack-k8s-operators/osp-director-dev-tools/pull/146