### PR TITLE
Change nncp to be network independent

### DIFF
--- a/api/v1beta1/openstacknet_types.go
+++ b/api/v1beta1/openstacknet_types.go
@@ -31,7 +31,6 @@ type IPReservation struct {
 
 // NetworkConfiguration - OSP network to create NodeNetworkConfigurationPolicy and NetworkAttachmentDefinition
 type NetworkConfiguration struct {
-	BridgeName string `json:"bridgeName,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}
 	NodeNetworkConfigurationPolicy nmstateapi.NodeNetworkConfigurationPolicySpec `json:"nodeNetworkConfigurationPolicy,omitempty"`

--- a/api/v1beta1/openstackvmset_types.go
+++ b/api/v1beta1/openstackvmset_types.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	nmstate "github.com/nmstate/kubernetes-nmstate/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -98,16 +97,15 @@ const (
 
 // Host -
 type Host struct {
-	Hostname          string                                            `json:"hostname"`
-	HostRef           string                                            `json:"hostRef"`
-	DomainName        string                                            `json:"domainName"`
-	DomainNameUniq    string                                            `json:"domainNameUniq"`
-	IPAddress         string                                            `json:"ipAddress"`
-	NetworkDataSecret string                                            `json:"networkDataSecret"`
-	BaseImageName     string                                            `json:"baseImageName"`
-	Labels            map[string]string                                 `json:"labels"`
-	NNCP              map[string]nmstate.NodeNetworkConfigurationPolicy `json:"nncp"`
-	NAD               map[string]networkv1.NetworkAttachmentDefinition  `json:"nad"`
+	Hostname          string                                           `json:"hostname"`
+	HostRef           string                                           `json:"hostRef"`
+	DomainName        string                                           `json:"domainName"`
+	DomainNameUniq    string                                           `json:"domainNameUniq"`
+	IPAddress         string                                           `json:"ipAddress"`
+	NetworkDataSecret string                                           `json:"networkDataSecret"`
+	BaseImageName     string                                           `json:"baseImageName"`
+	Labels            map[string]string                                `json:"labels"`
+	NAD               map[string]networkv1.NetworkAttachmentDefinition `json:"nad"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,6 @@ package v1beta1
 
 import (
 	"github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	"github.com/nmstate/kubernetes-nmstate/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -199,13 +198,6 @@ func (in *Host) DeepCopyInto(out *Host) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
-		}
-	}
-	if in.NNCP != nil {
-		in, out := &in.NNCP, &out.NNCP
-		*out = make(map[string]v1alpha1.NodeNetworkConfigurationPolicy, len(*in))
-		for key, val := range *in {
-			(*out)[key] = *val.DeepCopy()
 		}
 	}
 	if in.NAD != nil {

--- a/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
@@ -69,8 +69,6 @@ spec:
                 description: AttachConfiguration used for NodeNetworkConfigurationPolicy
                   and NetworkAttachmentDefinition
                 properties:
-                  bridgeName:
-                    type: string
                   nodeNetworkConfigurationPolicy:
                     description: NodeNetworkConfigurationPolicySpec defines the desired
                       state of NodeNetworkConfigurationPolicy

--- a/config/samples/osp-director_v1beta1_openstacknet.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet.yaml
@@ -8,7 +8,6 @@ spec:
   cidr: 192.168.25.0/24
   gateway: 192.168.25.1 # optional
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/config/samples/osp-director_v1beta1_openstacknet_ctlplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_ctlplane.yaml
@@ -8,7 +8,6 @@ spec:
   cidr: 192.168.25.0/24
   gateway: 192.168.25.1 # optional
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/config/samples/osp-director_v1beta1_openstacknet_external.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_external.yaml
@@ -9,7 +9,6 @@ spec:
   allocationStart: 10.0.0.4
   allocationEnd: 10.0.0.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/config/samples/osp-director_v1beta1_openstacknet_internalapi.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_internalapi.yaml
@@ -8,7 +8,6 @@ spec:
   allocationStart: 172.16.2.4
   allocationEnd: 172.16.2.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/config/samples/osp-director_v1beta1_openstacknet_storage.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_storage.yaml
@@ -8,7 +8,6 @@ spec:
   allocationStart: 172.16.1.4
   allocationEnd: 172.16.1.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/config/samples/osp-director_v1beta1_openstacknet_storagemgmt.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_storagemgmt.yaml
@@ -8,7 +8,6 @@ spec:
   allocationStart: 172.16.3.4
   allocationEnd: 172.16.3.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/config/samples/osp-director_v1beta1_openstacknet_tenant.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_tenant.yaml
@@ -8,7 +8,6 @@ spec:
   allocationStart: 172.16.0.4
   allocationEnd: 172.16.0.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -35,7 +35,6 @@ import (
 	ospdirectorv1beta1 "github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1"
 	common "github.com/openstack-k8s-operators/osp-director-operator/pkg/common"
 	openstackclient "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstackclient"
-	openstacknet "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstacknet"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -187,23 +186,13 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 	}
-	// verify that NodeNetworkConfigurationPolicy and NetworkAttachmentDefinition for each configured network exists
-	nncMap, err := common.GetAllNetworkConfigurationPolicies(r, map[string]string{
-		common.OwnerControllerNameLabelSelector: openstacknet.AppLabel,
-	})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// verify that NetworkAttachmentDefinition for each configured network exist
 	nadMap, err := common.GetAllNetworkAttachmentDefinitions(r, instance)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	for _, net := range instance.Spec.Networks {
-		if _, ok := nncMap[net]; !ok {
-			r.Log.Info(fmt.Sprintf("NetworkConfigurationPolicy for network %s does not yet exist.  Reconciling again in 10 seconds", net))
-			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
-		}
 		if _, ok := nadMap[net]; !ok {
 			r.Log.Error(err, fmt.Sprintf("NetworkAttachmentDefinition for network %s does not yet exist.  Reconciling again in 10 seconds", net))
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil

--- a/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
@@ -14,7 +14,6 @@ spec:
   allocationEnd: 192.168.25.250
   allocationStart: 192.168.25.100
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -44,7 +43,6 @@ spec:
   allocationStart: 10.0.0.4
   allocationEnd: 10.0.0.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
@@ -71,7 +69,6 @@ spec:
   allocationStart: 172.16.2.4
   allocationEnd: 172.16.2.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
@@ -98,7 +95,6 @@ spec:
   allocationStart: 172.16.1.4
   allocationEnd: 172.16.1.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
@@ -125,7 +121,6 @@ spec:
   allocationStart: 172.16.3.4
   allocationEnd: 172.16.3.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
@@ -152,7 +147,6 @@ spec:
   allocationStart: 172.16.0.4
   allocationEnd: 172.16.0.250
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
@@ -102,7 +102,6 @@ spec:
   allocationEnd: 192.168.25.250
   allocationStart: 192.168.25.100
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -153,7 +152,6 @@ spec:
   allocationEnd: 10.0.0.250
   allocationStart: 10.0.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -205,7 +203,6 @@ spec:
   allocationEnd: 172.16.2.250
   allocationStart: 172.16.2.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -249,7 +246,6 @@ spec:
   allocationEnd: 172.16.0.250
   allocationStart: 172.16.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -293,7 +289,6 @@ spec:
   allocationEnd: 172.16.1.250
   allocationStart: 172.16.1.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -337,7 +332,6 @@ spec:
   allocationEnd: 172.16.3.250
   allocationStart: 172.16.3.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:

--- a/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
@@ -182,7 +182,6 @@ spec:
   allocationEnd: 10.0.0.250
   allocationStart: 10.0.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -249,7 +248,6 @@ spec:
   allocationEnd: 172.16.2.250
   allocationStart: 172.16.2.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -308,7 +306,6 @@ spec:
   allocationEnd: 172.16.1.250
   allocationStart: 172.16.1.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -367,7 +364,6 @@ spec:
   allocationEnd: 172.16.3.250
   allocationStart: 172.16.3.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -426,7 +422,6 @@ spec:
   allocationEnd: 172.16.0.250
   allocationStart: 172.16.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:

--- a/tests/kuttl/tests/openstackcontrolplane_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/04-assert.yaml
@@ -137,7 +137,6 @@ spec:
   allocationEnd: 10.0.0.250
   allocationStart: 10.0.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -204,7 +203,6 @@ spec:
   allocationEnd: 172.16.2.250
   allocationStart: 172.16.2.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -263,7 +261,6 @@ spec:
   allocationEnd: 172.16.1.250
   allocationStart: 172.16.1.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -322,7 +319,6 @@ spec:
   allocationEnd: 172.16.3.250
   allocationStart: 172.16.3.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -381,7 +377,6 @@ spec:
   allocationEnd: 172.16.0.250
   allocationStart: 172.16.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:

--- a/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
@@ -182,7 +182,6 @@ spec:
   allocationEnd: 10.0.0.250
   allocationStart: 10.0.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -249,7 +248,6 @@ spec:
   allocationEnd: 172.16.2.250
   allocationStart: 172.16.2.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -309,7 +307,6 @@ spec:
   allocationEnd: 172.16.1.250
   allocationStart: 172.16.1.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -369,7 +366,6 @@ spec:
   allocationEnd: 172.16.3.250
   allocationStart: 172.16.3.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -429,7 +425,6 @@ spec:
   allocationEnd: 172.16.0.250
   allocationStart: 172.16.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:

--- a/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
@@ -28,7 +28,6 @@ spec:
   allocationEnd: 10.0.0.250
   allocationStart: 10.0.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -66,7 +65,6 @@ spec:
   allocationEnd: 172.16.2.250
   allocationStart: 172.16.2.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -104,7 +102,6 @@ spec:
   allocationEnd: 172.16.1.250
   allocationStart: 172.16.1.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -142,7 +139,6 @@ spec:
   allocationEnd: 172.16.3.250
   allocationStart: 172.16.3.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:
@@ -180,7 +176,6 @@ spec:
   allocationEnd: 172.16.0.250
   allocationStart: 172.16.0.4
   attachConfiguration:
-    bridgeName: br-osp
     nodeNetworkConfigurationPolicy:
       desiredState:
         interfaces:


### PR DESCRIPTION
At the moment we create for each network a nncp and a
network-attachment-definition corrensponding to the network name.
This results in duplicate nncp for the same bridge if more then
one network use the same bridge which can result in config race.

This patch changes the nncp creation to create the nncp for the
bridge instead of the network. With this we only create a single
nncp for required bridges.

Notes:
- this change only creates/updates the nncp for the desired
  config in the osnet cr. It does not verify if the config is
  different from what the current nncp might be. In case two
  networks use the same bridge name, but different interfaces,
  resulting from a typo/missconfig. The nncp gets updated and
  might result in an update loop.
- since the osnet controller waits for the nncp to be created
  before it creates the network-attachment-definition, the check
  for the nncp in the osvmset/osclient controller were not
  required and are now removed.
- at the moment there is no finalizer no finalizer on the nncp.
  It is not an issue right now as we do not cleanup the nncp on
  osnet cr delete. When we add nncp cleanup we need to make sure
  to add finalizers on the nncp for each network that the nncp
  only gets deleted when all networks are gone.