### PR TITLE
Make openstackclient CRD more generic

### DIFF
--- a/api/v1beta1/openstackclient_types.go
+++ b/api/v1beta1/openstackclient_types.go
@@ -24,10 +24,16 @@ import (
 type OpenStackClientSpec struct {
 	// Name of the image
 	ImageURL string `json:"imageURL"`
+
+	// +kubebuilder:validation:Optional
 	// name of secret holding the stack-admin ssh keys
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
+
+	// +kubebuilder:validation:Optional
 	// GitSecret used to pull playbooks into the openstackclient pod
 	GitSecret string `json:"gitSecret"`
+
+	// +kubebuilder:validation:Optional
 	// cloudname passed in via OS_CLOUDNAME
 	CloudName string `json:"cloudName"`
 
@@ -37,6 +43,14 @@ type OpenStackClientSpec struct {
 
 	// StorageClass to be used for the openstackclient persistent storage
 	StorageClass string `json:"storageClass,omitempty"`
+
+	// +kubebuilder:default=42401
+	// RunUID user ID to run the pod with
+	RunUID int `json:"runUID"`
+
+	// +kubebuilder:default=42401
+	// RunGID user ID to run the pod with
+	RunGID int `json:"runGID"`
 }
 
 // OpenStackClientStatus defines the observed state of OpenStackClient

--- a/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
@@ -62,16 +62,23 @@ spec:
                 items:
                   type: string
                 type: array
+              runGID:
+                default: 42401
+                description: RunGID user ID to run the pod with
+                type: integer
+              runUID:
+                default: 42401
+                description: RunUID user ID to run the pod with
+                type: integer
               storageClass:
                 description: StorageClass to be used for the openstackclient persistent
                   storage
                 type: string
             required:
-            - cloudName
-            - deploymentSSHSecret
-            - gitSecret
             - imageURL
             - networks
+            - runGID
+            - runUID
             type: object
           status:
             description: OpenStackClientStatus defines the observed state of OpenStackClient

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -295,24 +295,26 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	// - change CR.Status.VMs to be struct with name + Pod IP of the controllers
 
 	// Create openstack client pod
-	openstackclient := &ospdirectorv1beta1.OpenStackClient{
+	osc := &ospdirectorv1beta1.OpenStackClient{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openstackclient",
 			Namespace: instance.Namespace,
 		},
 	}
-	op, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, openstackclient, func() error {
-		openstackclient.Spec.ImageURL = instance.Spec.OpenStackClientImageURL
-		openstackclient.Spec.DeploymentSSHSecret = deploymentSecretName
-		openstackclient.Spec.CloudName = instance.Name
-		openstackclient.Spec.StorageClass = instance.Spec.OpenStackClientStorageClass
-		openstackclient.Spec.GitSecret = instance.Spec.GitSecret
+	op, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, osc, func() error {
+		osc.Spec.ImageURL = instance.Spec.OpenStackClientImageURL
+		osc.Spec.DeploymentSSHSecret = deploymentSecretName
+		osc.Spec.CloudName = instance.Name
+		osc.Spec.StorageClass = instance.Spec.OpenStackClientStorageClass
+		osc.Spec.GitSecret = instance.Spec.GitSecret
+		osc.Spec.RunUID = openstackclient.CloudAdminUID
+		osc.Spec.RunGID = openstackclient.CloudAdminGID
 
 		if len(instance.Spec.OpenStackClientNetworks) > 0 {
-			openstackclient.Spec.Networks = instance.Spec.OpenStackClientNetworks
+			osc.Spec.Networks = instance.Spec.OpenStackClientNetworks
 		}
 
-		err := controllerutil.SetControllerReference(instance, openstackclient, r.Scheme)
+		err := controllerutil.SetControllerReference(instance, osc, r.Scheme)
 		if err != nil {
 			return err
 		}

--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -23,23 +23,26 @@ fi
 mkdir -p /home/cloud-admin/tripleo-deploy/validations
 rm -rf /home/cloud-admin/tripleo-deploy/overcloud-ansible*
 
-# add cloud-admin ssh keys to EmptyDir Vol mount to /root/.ssh in openstackclient
-sudo mkdir -p /root/.ssh
-sudo cp /mnt/ssh-config/* /root/.ssh/
-sudo chmod 600 /root/.ssh/id_rsa
-sudo chown -R root: /root/.ssh
+if [ -d /mnt/ssh-config ]; then
+  # add cloud-admin ssh keys to EmptyDir Vol mount to /root/.ssh in openstackclient
+  sudo mkdir -p /root/.ssh
+  sudo cp /mnt/ssh-config/* /root/.ssh/
+  sudo chmod 600 /root/.ssh/id_rsa
+  sudo chown -R root: /root/.ssh
 
-# add cloud-admin ssh keys to /home/cloud-admin/.ssh in openstackclient
-mkdir -p /home/cloud-admin/.ssh
-cp /mnt/ssh-config/* /home/cloud-admin/.ssh/
-chmod 600 /home/cloud-admin/.ssh/id_rsa
-chmod 600 /home/cloud-admin/.ssh/git_id_rsa
-chown -R cloud-admin: /home/cloud-admin/.ssh
+  # add cloud-admin ssh keys to /home/cloud-admin/.ssh in openstackclient
+  mkdir -p /home/cloud-admin/.ssh
+  cp /mnt/ssh-config/* /home/cloud-admin/.ssh/
+  chmod 600 /home/cloud-admin/.ssh/id_rsa
+  chmod 600 /home/cloud-admin/.ssh/git_id_rsa
+  chown -R cloud-admin: /home/cloud-admin/.ssh
+fi
 
-GIT_HOST=$(echo $GIT_URL | sed -e 's|^git@\(.*\):.*|\1|g')
-GIT_USER=$(echo $GIT_URL | sed -e 's|^git@.*:\(.*\)/.*|\1|g')
+if [ -v GIT_URL ]; then
+  GIT_HOST=$(echo $GIT_URL | sed -e 's|^git@\(.*\):.*|\1|g')
+  GIT_USER=$(echo $GIT_URL | sed -e 's|^git@.*:\(.*\)/.*|\1|g')
 
-cat <<EOF >> /home/cloud-admin/.ssh/config
+  cat <<EOF >> /home/cloud-admin/.ssh/config
 
 
 Host $GIT_HOST
@@ -48,5 +51,6 @@ Host $GIT_HOST
     StrictHostKeyChecking no
 EOF
 
-git config --global user.email "dev@null.io"
-git config --global user.name "OSP Director Operator"
+  git config --global user.email "dev@null.io"
+  git config --global user.name "OSP Director Operator"
+fi


### PR DESCRIPTION
To use the openstackclient CRD for other purposes, like running
tempest using a tempest container image, the osclient CRD needs
to be more generic.

This makes DeploymentSSHSecret, GitSecret, and CloudName optional
parmeters and introduce RunUID and RunGID parameters which default
to the cloud-admin (42401) to be able to run pods using other/
custom users.

Also modifies the tripleo-deploy.sh to
* create ~/.config/openstack and copies the clouds.yaml there
instead of the current ~/tripleo-deploy directory. /home/cloud-admin
is a persistent storage so we can place it in the users home
directory. This resolves an issue where the openstackclient
pod gets recreated and the default /etc/openstack/clouds.yaml
is lost and would need to be copied from ~/tripleo-deploy/clouds.yaml

* adds ANSIBLE* environment variables for deployment like currently
set in an undercloud deployment script