### PR TITLE
OSNet finalizer for NNCP removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/pkg/openstacknet/funcs.go
+++ b/pkg/openstacknet/funcs.go
@@ -3,20 +3,19 @@ package openstacknet
 import (
 	"context"
 
+	"github.com/ghodss/yaml"
 	ospdirectorv1beta1 "github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/osp-director-operator/pkg/common"
+	"github.com/tidwall/gjson"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetOpenStackNetsBindingMap - Returns map of OpenStackNet name to binding type
 func GetOpenStackNetsBindingMap(r common.ReconcilerCommon, namespace string) (map[string]string, error) {
 	// Acquire a list and map of all OpenStackNetworks available in this namespace
-	osNetList := &ospdirectorv1beta1.OpenStackNetList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(namespace),
-	}
+	osNetList, err := GetOpenStackNetsWithLabel(r, namespace, map[string]string{})
 
-	if err := r.GetClient().List(context.Background(), osNetList, listOpts...); err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -32,4 +31,55 @@ func GetOpenStackNetsBindingMap(r common.ReconcilerCommon, namespace string) (ma
 	}
 
 	return osNets, nil
+}
+
+// GetOpenStackNetsAttachConfigBridgeNames - Return a map of OpenStackNet names in the passed namespace to the bridge-name in their attachConfig
+func GetOpenStackNetsAttachConfigBridgeNames(r common.ReconcilerCommon, namespace string) (map[string]string, error) {
+	osNets, err := GetOpenStackNetsWithLabel(r, namespace, map[string]string{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	osNetBridgeNames := map[string]string{}
+
+	for _, osNet := range osNets.Items {
+		desiredStateBytes := osNet.Spec.AttachConfiguration.NodeNetworkConfigurationPolicy.DesiredState.Raw
+
+		if len(desiredStateBytes) > 0 {
+			jsonBytes, err := yaml.YAMLToJSON(desiredStateBytes)
+
+			if err != nil {
+				return nil, err
+			}
+
+			jsonStr := string(jsonBytes)
+
+			if gjson.Get(jsonStr, "interfaces.#.name").Exists() {
+				osNetBridgeNames[osNet.Name] = gjson.Get(jsonStr, "interfaces.#.name").Array()[0].String()
+			}
+		}
+	}
+
+	return osNetBridgeNames, nil
+}
+
+// GetOpenStackNetsWithLabel - Return a list of all OpenStackNets in the namespace that have (optional) labels
+func GetOpenStackNetsWithLabel(r common.ReconcilerCommon, namespace string, labelSelector map[string]string) (*ospdirectorv1beta1.OpenStackNetList, error) {
+	osNetList := &ospdirectorv1beta1.OpenStackNetList{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+
+	if len(labelSelector) > 0 {
+		labels := client.MatchingLabels(labelSelector)
+		listOpts = append(listOpts, labels)
+	}
+
+	if err := r.GetClient().List(context.Background(), osNetList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	return osNetList, nil
 }

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/00-prep.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/00-prep.yaml
@@ -1,0 +1,18 @@
+#
+# Q: WHAT IS TESTED HERE?
+#
+# A: 
+#
+# - Create 2 OpenStackNets and verify the associated NNCP is created
+# - Delete 1 OpenStackNet and verify the associated NNCP still exists
+# - Delete the other OpenStackNet and verify the associated NNCP is deleted as well
+#
+
+#
+# Attempt to "clear the field" if necessary
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: ../../common/scripts/prep.sh

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/01-assert.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/01-assert.yaml
@@ -1,0 +1,110 @@
+#
+# Check for:
+#
+# - 2 OpenStackNets
+# - 1 NNCP
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNet
+metadata:
+  finalizers:
+  - openstacknet.osp-director.openstack.org
+  name: ctlplane
+  namespace: openstack
+spec:
+  allocationEnd: 192.168.25.250
+  allocationStart: 192.168.25.100
+  attachConfiguration:
+    nodeNetworkConfigurationPolicy:
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: enp7s0
+          description: Linux bridge with enp7s0 as a port
+          name: br-osp
+          state: up
+          type: linux-bridge
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+  cidr: 192.168.25.0/24
+  gateway: 192.168.25.1
+status:
+  conditions:
+  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNet
+metadata:
+  finalizers:
+  - openstacknet.osp-director.openstack.org
+  name: tenant
+  namespace: openstack
+spec:
+  cidr: 172.16.0.0/24
+  vlan: 50
+  allocationStart: 172.16.0.4
+  allocationEnd: 172.16.0.250
+  attachConfiguration:
+    nodeNetworkConfigurationPolicy:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: enp7s0
+          description: Linux bridge with enp7s0 as a port
+          name: br-osp
+          state: up
+          type: linux-bridge
+status:
+  conditions:
+  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
+    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  labels:
+    osp-director.openstack.org/controller: osp-openstacknet
+    osp-director.openstack.org/namespace: openstack
+  name: br-osp
+spec:
+  desiredState:
+    interfaces:
+    - bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: enp7s0
+      description: Linux bridge with enp7s0 as a port
+      name: br-osp
+      state: up
+      type: linux-bridge
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+status:
+  conditions:
+  - reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+  - reason: SuccessfullyConfigured
+    status: "False"
+    type: Degraded
+

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/01-create_openstacknets.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/01-create_openstacknets.yaml
@@ -1,0 +1,11 @@
+#
+# Create two OpenStackNets
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: oc apply -f ../../../../config/samples/osp-director_v1beta1_openstacknet_ctlplane.yaml
+    namespaced: true
+  - command: oc apply -f ../../../../config/samples/osp-director_v1beta1_openstacknet_tenant.yaml
+    namespaced: true

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/02-assert.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/02-assert.yaml
@@ -1,0 +1,74 @@
+#
+# Check for:
+#
+# - 1 OpenStackNet
+# - 1 NNCP
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNet
+metadata:
+  finalizers:
+  - openstacknet.osp-director.openstack.org
+  name: ctlplane
+  namespace: openstack
+spec:
+  allocationEnd: 192.168.25.250
+  allocationStart: 192.168.25.100
+  attachConfiguration:
+    nodeNetworkConfigurationPolicy:
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: enp7s0
+          description: Linux bridge with enp7s0 as a port
+          name: br-osp
+          state: up
+          type: linux-bridge
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+  cidr: 192.168.25.0/24
+  gateway: 192.168.25.1
+status:
+  conditions:
+  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  labels:
+    osp-director.openstack.org/controller: osp-openstacknet
+    osp-director.openstack.org/namespace: openstack
+  name: br-osp
+spec:
+  desiredState:
+    interfaces:
+    - bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: enp7s0
+      description: Linux bridge with enp7s0 as a port
+      name: br-osp
+      state: up
+      type: linux-bridge
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+status:
+  conditions:
+  - reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+  - reason: SuccessfullyConfigured
+    status: "False"
+    type: Degraded
+

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/02-delete_openstacknet.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/02-delete_openstacknet.yaml
@@ -1,0 +1,9 @@
+#
+# Delete one of the OpenStackNets
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: oc delete -f ../../../../config/samples/osp-director_v1beta1_openstacknet_tenant.yaml
+    namespaced: true

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/02-errors.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/02-errors.yaml
@@ -1,0 +1,11 @@
+#
+# Check for:
+#
+# - OpenStackNet "tenant" has been deleted
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNet
+metadata:
+  name: tenant
+  namespace: openstack

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/03-delete_openstacknet.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/03-delete_openstacknet.yaml
@@ -1,0 +1,9 @@
+#
+# Delete the remaining OpenStackNet
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: oc delete -f ../../../../config/samples/osp-director_v1beta1_openstacknet_ctlplane.yaml
+    namespaced: true

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/03-errors.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/03-errors.yaml
@@ -1,0 +1,20 @@
+#
+# Check for:
+#
+# - OpenStackNet "ctlplane" has been deleted
+# - NNCP has been deleted
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNet
+metadata:
+  name: ctlplane
+  namespace: openstack
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  labels:
+    osp-director.openstack.org/controller: osp-openstacknet
+    osp-director.openstack.org/namespace: openstack
+  name: br-osp


### PR DESCRIPTION
Adds a finalizer to handle the case when all OSNets specifying a particular bridge have been deleted.  If an OSNet is deleted and no other OSNets remain that target that bridge, the underlying NNCP will be removed.  NOTE: This does not handle the case where the user might change the name of the bridge in an OSNet.  We'll need to address that in another patch, one way or another.