### PR TITLE
Make sure OpenStackClient creates IPset with uniq Role

### DIFF
--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -149,7 +149,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	ipsetDetails := common.IPSet{
 		Networks:            instance.Spec.Networks,
-		Role:                openstackclient.Role,
+		Role:                fmt.Sprintf("%s%s", openstackclient.Role, instance.Name),
 		HostCount:           openstackclient.Count,
 		AddToPredictableIPs: false,
 		HostNameRefs:        hostnameRefs,


### PR DESCRIPTION
If multiple OpenStackClient CRs get created the created right now
the IPset with the same Role parameter. This results in the
OpenStackClient pods to use the same IP addresses because the
OSNet reservations are grouped by the Roles.
This change adds the OpenStackClient CR name to the OpenStackClient
Role name const to make sure the Role name passed to create the
IPSet CR is uniq.