### PR TITLE
Increase KUTTL test timeout

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -34,4 +34,4 @@ manifestDirs: []               # YAMLs to apply before each test
 reportFormat: JSON
 reportName: kuttl-test
 namespace: openstack
-timeout: 120
+timeout: 180

--- a/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
@@ -76,8 +76,9 @@ spec:
   userData:
     namespace: openshift-machine-api
 status:
-  errorCount: 0
-  errorMessage: ""
+  # Taking error fields out here and elsewhere in this test, as it's possible we hit transitory errors on the way to "provisioned" state
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   poweredOn: true
@@ -113,8 +114,8 @@ spec:
   userData:
     namespace: openshift-machine-api
 status:
-  errorCount: 0
-  errorMessage: ""
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   poweredOn: true

--- a/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
@@ -55,8 +55,8 @@ spec:
   rootDeviceHints:
     deviceName: /dev/sda
 status:
-  errorCount: 0
-  errorMessage: ""
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   provisioning:
@@ -91,8 +91,8 @@ spec:
   userData:
     namespace: openshift-machine-api
 status:
-  errorCount: 0
-  errorMessage: ""
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   poweredOn: true

--- a/tests/kuttl/tests/openstackbaremetalset_scale/05-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/05-assert.yaml
@@ -30,8 +30,8 @@ spec:
   userData:
     namespace: openshift-machine-api
 status:
-  errorCount: 0
-  errorMessage: ""
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   poweredOn: true
@@ -55,8 +55,8 @@ spec:
   rootDeviceHints:
     deviceName: /dev/sda
 status:
-  errorCount: 0
-  errorMessage: ""
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   provisioning:

--- a/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
@@ -76,8 +76,8 @@ spec:
   userData:
     namespace: openshift-machine-api
 status:
-  errorCount: 0
-  errorMessage: ""
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   poweredOn: true
@@ -113,8 +113,8 @@ spec:
   userData:
     namespace: openshift-machine-api
 status:
-  errorCount: 0
-  errorMessage: ""
+  # errorCount: 0
+  # errorMessage: ""
   hardwareProfile: unknown
   operationalStatus: OK
   poweredOn: true

--- a/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
@@ -6,6 +6,7 @@
 # - 1 OpenStackClient
 # - 6 OpenStackNet (IP reservations for OpenStackControlPlane and OpenStackClient)
 # - 3 OpenStackIPSets (IP reservations for OpenStackControlPlane and OpenStackClient)
+# - 1 Secret (TripleO passwords)
 #
 
 apiVersion: osp-director.openstack.org/v1beta1
@@ -137,7 +138,7 @@ status:
         hostname: controlplane
         ip: 192.168.25.100
         vip: true
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
@@ -190,7 +191,7 @@ status:
         hostname: controlplane
         ip: 10.0.0.4
         vip: true
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
@@ -486,7 +487,7 @@ spec:
   networks:
   - ctlplane
   - external
-  roleName: OpenstackClient
+  roleName: OpenstackClientopenstackclient
   vip: false
 status:
   hosts:
@@ -507,4 +508,14 @@ status:
       cidr: 10.0.0.0/24
       gateway: 10.0.0.1
       vlan: 10
-
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    osp-director.openstack.org/controller: osp-controlplane
+    osp-director.openstack.org/name: overcloud
+    osp-director.openstack.org/namespace: openstack
+  name: tripleo-passwords
+  namespace: openstack
+type: Opaque

--- a/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
@@ -167,7 +167,7 @@ status:
         hostname: controller-2
         ip: 192.168.25.104
         vip: false
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
@@ -235,7 +235,7 @@ status:
         hostname: controller-2
         ip: 10.0.0.8
         vip: false
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false

--- a/tests/kuttl/tests/openstackcontrolplane_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/04-assert.yaml
@@ -122,7 +122,7 @@ status:
         hostname: controller-2
         ip: 192.168.25.104
         vip: false
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
@@ -190,7 +190,7 @@ status:
         hostname: controller-2
         ip: 10.0.0.8
         vip: false
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false

--- a/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
@@ -167,7 +167,7 @@ status:
         hostname: controller-2
         ip: 192.168.25.104
         vip: false
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
@@ -235,7 +235,7 @@ status:
         hostname: controller-2
         ip: 10.0.0.8
         vip: false
-    OpenstackClient:
+    OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false


### PR DESCRIPTION
Increases global timeout of KUTTL tests to 3 minutes.  Also fixes a few tests that needed updating due to recent changes.