### PR TITLE
Use consolidated img URLs in KUTTL

### DIFF
--- a/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
+++ b/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
@@ -7,7 +7,7 @@ spec:
   # How many nodes to provision
   count: 1
   # The image to install on the provisioned nodes
-  baseImageUrl: http://192.168.111.1:8081/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-baremetalset-ssh-keys
   # Networks to associate with this host

--- a/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
+++ b/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: openstack
 spec:
   port: 8080
-  baseImageUrl: http://192.168.111.1:8080/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2

--- a/tests/kuttl/tests/openstackbaremetalset_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/02-assert.yaml
@@ -14,7 +14,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1:8081/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 0
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-baremetalset-ssh-keys
@@ -39,7 +39,7 @@ metadata:
   name: compute-provisionserver
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1:8081/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   port: 6190
 # TODO: Check for status once we add that to prov server
 ---

--- a/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
@@ -19,7 +19,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1:8081/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 2
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-baremetalset-ssh-keys

--- a/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
@@ -15,7 +15,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1:8081/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 1
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-baremetalset-ssh-keys

--- a/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
@@ -19,7 +19,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1:8081/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 2
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-baremetalset-ssh-keys


### PR DESCRIPTION
Adjusts KUTTL tests to use the shared URL structure for RHEL image locations

Depends-on: https://github.com/openstack-k8s-operators/osp-director-dev-tools/pull/172