### PR TITLE
Generate tripleo-passwords only once

### DIFF
--- a/pkg/controlplane/const.go
+++ b/pkg/controlplane/const.go
@@ -28,4 +28,7 @@ const (
 
 	// Role - controlplane has not tripleo role, set it as const
 	Role = "ControlPlane"
+
+	// TripleoPasswordSecret - name of the generated tripleo password secret
+	TripleoPasswordSecret = "tripleo-passwords"
 )

--- a/pkg/openstackplaybookgenerator/volumes.go
+++ b/pkg/openstackplaybookgenerator/volumes.go
@@ -18,6 +18,7 @@ package openstackplaybookgenerator
 
 import (
 	ospdirectorv1beta1 "github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1"
+	controlplane "github.com/openstack-k8s-operators/osp-director-operator/pkg/controlplane"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -30,7 +31,7 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackPlaybookGenerator) []
 			ReadOnly:  true,
 		},
 		{
-			Name:      "tripleo-passwords",
+			Name:      controlplane.TripleoPasswordSecret,
 			MountPath: "/home/cloud-admin/config-passwords",
 			ReadOnly:  true,
 		},
@@ -95,11 +96,11 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackPlaybookGenerator) []corev
 			},
 		},
 		{
-			Name: "tripleo-passwords",
+			Name: controlplane.TripleoPasswordSecret,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0644AccessMode,
-					SecretName:  "tripleo-passwords",
+					SecretName:  controlplane.TripleoPasswordSecret,
 				},
 			},
 		},


### PR DESCRIPTION
Right now on every reconcile the tripleo-passwords get created
and the secret updated. The tripleo-passwords should only be created
once if the secret don't exist.