### PR TITLE
Add label for must-gather-safe secrets

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -790,13 +790,18 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(instance *ospdi
 
 	networkDataSecretName := fmt.Sprintf(baremetalset.CloudInitNetworkDataSecretName, instance.Name, bmh)
 
+	// Flag the network data secret as safe to collect with must-gather
+	secretLabelsWithMustGather := common.GetLabels(instance, baremetalset.AppLabel, map[string]string{
+		common.MustGatherSecret: "yes",
+	})
+
 	networkDataSt := common.Template{
 		Name:           networkDataSecretName,
 		Namespace:      "openshift-machine-api",
 		Type:           common.TemplateTypeConfig,
 		InstanceType:   instance.Kind,
 		AdditionalData: map[string]string{"networkData": "/baremetalset/cloudinit/networkdata"},
-		Labels:         secretLabels,
+		Labels:         secretLabelsWithMustGather,
 		ConfigOptions:  templateParameters,
 	}
 

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -527,6 +527,11 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// We will fill this map with newly-added hosts as well as existing ones
 	vmDetails := map[string]ospdirectorv1beta1.Host{}
 
+	// Flag the network data secret as safe to collect with must-gather
+	secretLabelsWithMustGather := common.GetLabels(instance, vmset.AppLabel, map[string]string{
+		common.MustGatherSecret: "yes",
+	})
+
 	// Func to help increase DRY below in NetworkData loops
 	generateNetworkData := func(instance *ospdirectorv1beta1.OpenStackVMSet, vm *ospdirectorv1beta1.HostStatus) error {
 		// TODO: multi nic support with bindata template
@@ -539,7 +544,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			DomainNameUniq:    fmt.Sprintf("%s-%s", vm.Hostname, instance.UID[0:4]),
 			IPAddress:         ipset.Status.HostIPs[vm.Hostname].IPAddresses[netName],
 			NetworkDataSecret: fmt.Sprintf("%s-%s-networkdata", instance.Name, vm.Hostname),
-			Labels:            secretLabels,
+			Labels:            secretLabelsWithMustGather,
 			NAD:               nadMap,
 		}
 

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -35,6 +35,9 @@ const (
 	// HostRemovalAnnotation - Annotation key placed on VM or BMH resources to target them for scale-down
 	HostRemovalAnnotation = GroupLabel + "/delete-host"
 
+	// MustGatherSecret - Label placed on secrets that are safe to collect with must-gater
+	MustGatherSecret = GroupLabel + "/must-gather-secret"
+
 	// FinalizerName -
 	FinalizerName = GroupLabel
 )


### PR DESCRIPTION
Adds a label to network data secrets in `VMSets` and `BMSets` to indicate that they are safe to collect via `must-gather`.