### PR TITLE
OsProvServer port fixes + must-gather secret label, OSP 16

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -797,13 +797,18 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(instance *ospdi
 
 	networkDataSecretName := fmt.Sprintf(baremetalset.CloudInitNetworkDataSecretName, instance.Name, bmh)
 
+	// Flag the network data secret as safe to collect with must-gather
+	secretLabelsWithMustGather := common.GetLabels(instance, baremetalset.AppLabel, map[string]string{
+		common.MustGatherSecret: "yes",
+	})
+
 	networkDataSt := common.Template{
 		Name:           networkDataSecretName,
 		Namespace:      "openshift-machine-api",
 		Type:           common.TemplateTypeConfig,
 		InstanceType:   instance.Kind,
 		AdditionalData: map[string]string{"networkData": "/baremetalset/cloudinit/networkdata"},
-		Labels:         secretLabels,
+		Labels:         secretLabelsWithMustGather,
 		ConfigOptions:  templateParameters,
 	}
 

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -527,6 +527,11 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// We will fill this map with newly-added hosts as well as existing ones
 	vmDetails := map[string]ospdirectorv1beta1.Host{}
 
+	// Flag the network data secret as safe to collect with must-gather
+	secretLabelsWithMustGather := common.GetLabels(instance, vmset.AppLabel, map[string]string{
+		common.MustGatherSecret: "yes",
+	})
+
 	// Func to help increase DRY below in NetworkData loops
 	generateNetworkData := func(instance *ospdirectorv1beta1.OpenStackVMSet, vm *ospdirectorv1beta1.HostStatus) error {
 		// TODO: multi nic support with bindata template
@@ -539,7 +544,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			DomainNameUniq:    fmt.Sprintf("%s-%s", vm.Hostname, instance.UID[0:4]),
 			IPAddress:         ipset.Status.HostIPs[vm.Hostname].IPAddresses[netName],
 			NetworkDataSecret: fmt.Sprintf("%s-%s-networkdata", instance.Name, vm.Hostname),
-			Labels:            secretLabels,
+			Labels:            secretLabelsWithMustGather,
 			NAD:               nadMap,
 		}
 

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -35,6 +35,9 @@ const (
 	// HostRemovalAnnotation - Annotation key placed on VM or BMH resources to target them for scale-down
 	HostRemovalAnnotation = GroupLabel + "/delete-host"
 
+	// MustGatherSecret - Label placed on secrets that are safe to collect with must-gather
+	MustGatherSecret = GroupLabel + "/must-gather-secret"
+
 	// FinalizerName -
 	FinalizerName = GroupLabel
 )

--- a/tests/kuttl/tests/openstackbaremetalset_scale/07-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/07-assert.yaml
@@ -62,6 +62,5 @@ status:
   provisioning:
     bootMode: legacy
     image:
-      checksum: ""
       url: ""
     state: ready

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/00-prep.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/00-prep.yaml
@@ -1,0 +1,24 @@
+#
+# Q: WHAT IS TESTED HERE?
+#
+# A: 
+#
+# - Create 1 OpenStackProvisionServer
+# - Create another OpenStackProvisionServer with a different port
+# - Create a third OpenStackProvisionServer with a duplicate port, which should fail
+# - Create 1 OpenStackNet
+# - Create 1 OpenStackBaremetalSet with a count of 1, and make sure it succeeds and has a unique port
+# - Create another OpenStackBaremetalSet with a count 1, and make sure it succeeds and has a unique port
+#
+# NOTE: This test assumes you have two (and only two!) extra OCP workers allocated to your cluster as 
+#       BaremetalHosts, that are not in-use as actual cluster nodes
+#
+
+#
+# Attempt to "clear the field" if necessary
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: ../../common/scripts/prep.sh

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/01-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/01-assert.yaml
@@ -1,0 +1,26 @@
+#
+# Check for:
+#
+# - 1 OpenStackProvisionServer
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackProvisionServer
+metadata:
+  name: openstack
+  namespace: openstack
+spec:
+  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
+  port: 8080
+  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1
+status:
+  conditions:
+  - message: ProvisionServer openstack has been provisioned
+    reason: ProvisionServer openstack has been provisioned
+    status: "True"
+    type: Provisioned
+  provisioningStatus:
+    reason: ProvisionServer openstack has been provisioned
+    state: Provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/01-create_openstackprovisionserver.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/01-create_openstackprovisionserver.yaml
@@ -1,0 +1,9 @@
+#
+# Create an OpenStackProvisionServer with a user-defined httpd port
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: oc apply -f ../../../../config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
+    namespaced: true

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
@@ -1,0 +1,26 @@
+#
+# Check for:
+#
+# - 1 OpenStackProvisionServer with a second user-defined httpd port
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackProvisionServer
+metadata:
+  name: goodprov
+  namespace: openstack
+spec:
+  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
+  port: 8081
+  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1
+status:
+  conditions:
+  - message: ProvisionServer goodprov has been provisioned
+    reason: ProvisionServer goodprov has been provisioned
+    status: "True"
+    type: Provisioned
+  provisioningStatus:
+    reason: ProvisionServer goodprov has been provisioned
+    state: Provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/02-create_openstackprovisionserver.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/02-create_openstackprovisionserver.yaml
@@ -1,0 +1,9 @@
+#
+# Create an OpenStackProvisionServer with another (valid) user-defined httpd port
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      sed 's/name: openstack/name: goodprov/g' ../../../../config/samples/osp-director_v1beta1_openstackprovisionserver.yaml | sed 's/port: 8080/port: 8081/g' | oc apply -f -

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/03-create_openstackprovisionserver.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/03-create_openstackprovisionserver.yaml
@@ -1,0 +1,9 @@
+#
+# Try to create an OpenStackProvisionServer with another (invalid) user-defined httpd port
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      sed 's/name: openstack/name: badprov/g' ../../../../config/samples/osp-director_v1beta1_openstackprovisionserver.yaml | oc apply -f - || true

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/03-errors.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/03-errors.yaml
@@ -1,0 +1,11 @@
+#
+# Check for:
+#
+# - No OpenStackProvisionServer called "badprov" was created
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackProvisionServer
+metadata:
+  name: badprov
+  namespace: openstack

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/04-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/04-assert.yaml
@@ -1,0 +1,66 @@
+#
+# Check for:
+#
+# - 1 OpenStackNet
+# - 1 NodeNetworkConfigurationPolicy
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNet
+metadata:
+  finalizers:
+  - openstacknet.osp-director.openstack.org
+  name: ctlplane
+  namespace: openstack
+spec:
+  allocationEnd: 192.168.25.250
+  allocationStart: 192.168.25.100
+  attachConfiguration:
+    nodeNetworkConfigurationPolicy:
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: enp7s0
+          description: Linux bridge with enp7s0 as a port
+          name: br-osp
+          state: up
+          type: linux-bridge
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+  cidr: 192.168.25.0/24
+  gateway: 192.168.25.1
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  labels:
+    osp-director.openstack.org/controller: osp-openstacknet
+    osp-director.openstack.org/namespace: openstack
+  name: br-osp
+spec:
+  desiredState:
+    interfaces:
+    - bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: enp7s0
+      description: Linux bridge with enp7s0 as a port
+      name: br-osp
+      state: up
+      type: linux-bridge
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+status:
+  conditions:
+  - reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+  - reason: SuccessfullyConfigured
+    status: "False"
+    type: Degraded

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/04-create_openstacknet.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/04-create_openstacknet.yaml
@@ -1,0 +1,9 @@
+#
+# Create 1 OpenStackNet
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: oc apply -f ../../../../config/samples/osp-director_v1beta1_openstacknet_ctlplane.yaml
+    namespaced: true

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/05-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/05-assert.yaml
@@ -1,0 +1,26 @@
+#
+# Check for:
+#
+# - 1 OpenStackProvisionServer (we don't actually care about the OpenStackBaremetalSet resource) with an auto-assigned httpd port
+# 
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackProvisionServer
+metadata:
+  name: compute-provisionserver
+  namespace: openstack
+spec:
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
+  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1
+  port: 6190
+status:
+  conditions:
+  - message: ProvisionServer compute-provisionserver has been provisioned
+    reason: ProvisionServer compute-provisionserver has been provisioned
+    status: "True"
+    type: Provisioned
+  provisioningStatus:
+    reason: ProvisionServer compute-provisionserver has been provisioned
+    state: Provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/05-create_openstackbaremetalset.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/05-create_openstackbaremetalset.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Create the required userpassword Secret
+  - command: oc apply -f ../../common/manifests/userpassword.yaml
+    namespaced: true
+  # Create fake SSH Secret
+  - command: oc apply -f ../../common/manifests/osp-controlplane-ssh-keys.yaml
+    namespaced: true
+  # Create the OpenStackBaremetalSet from sample YAML
+  - command: oc apply -f ../../../../config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
+    namespaced: true
+  # Remove the OpenStackBaremetalSet tenant network from sample YAML
+  - command: |
+      oc patch openstackbaremetalset compute --type='json' -p='[{"op": "replace", "path": "/spec/networks", "value": ["ctlplane"]}]'
+    namespaced: true
+  # Remove sample YAML's bmhLabelSelector from spec
+  - command: |
+      oc patch openstackbaremetalset compute --type='json' -p='[{"op": "remove", "path": "/spec/bmhLabelSelector"}]'
+    namespaced: true
+  # Remove sample YAML's hardwareReqs from spec
+  - command: |
+      oc patch openstackbaremetalset compute --type='json' -p='[{"op": "remove", "path": "/spec/hardwareReqs"}]'
+    namespaced: true

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/06-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/06-assert.yaml
@@ -1,0 +1,26 @@
+#
+# Check for:
+#
+# - 1 OpenStackProvisionServer (we don't actually care about the OpenStackBaremetalSet resource) with an auto-assigned httpd port
+# 
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackProvisionServer
+metadata:
+  name: compute2-provisionserver
+  namespace: openstack
+spec:
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
+  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1
+  port: 6191
+status:
+  conditions:
+  - message: ProvisionServer compute2-provisionserver has been provisioned
+    reason: ProvisionServer compute2-provisionserver has been provisioned
+    status: "True"
+    type: Provisioned
+  provisioningStatus:
+    reason: ProvisionServer compute2-provisionserver has been provisioned
+    state: Provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/06-create_openstackbaremetalset.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/06-create_openstackbaremetalset.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Create the OpenStackBaremetalSet from sample YAML
+  - script: |
+      sed 's/name: compute/name: compute2/g' ../../../../config/samples/osp-director_v1beta1_openstackbaremetalset.yaml | sed 's/roleName: Compute/roleName: Compute2/g' | oc apply -f -
+  # Remove the OpenStackBaremetalSet tenant network from sample YAML
+  - command: |
+      oc patch openstackbaremetalset compute2 --type='json' -p='[{"op": "replace", "path": "/spec/networks", "value": ["ctlplane"]}]'
+    namespaced: true
+  # Remove sample YAML's bmhLabelSelector from spec
+  - command: |
+      oc patch openstackbaremetalset compute2 --type='json' -p='[{"op": "remove", "path": "/spec/bmhLabelSelector"}]'
+    namespaced: true
+  # Remove sample YAML's hardwareReqs from spec
+  - command: |
+      oc patch openstackbaremetalset compute2 --type='json' -p='[{"op": "remove", "path": "/spec/hardwareReqs"}]'
+    namespaced: true


### PR DESCRIPTION
Adds `OsProvServer` httpd port improvements for OSP 16, and also adds missing `must-gather` secret labelling for network data `Secrets`