### PR TITLE
Re-add must-gather secret label to OSBMS controller

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -797,13 +797,18 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(instance *ospdi
 
 	networkDataSecretName := fmt.Sprintf(baremetalset.CloudInitNetworkDataSecretName, instance.Name, bmh)
 
+	// Flag the network data secret as safe to collect with must-gather
+	secretLabelsWithMustGather := common.GetLabels(instance, baremetalset.AppLabel, map[string]string{
+		common.MustGatherSecret: "yes",
+	})
+
 	networkDataSt := common.Template{
 		Name:           networkDataSecretName,
 		Namespace:      "openshift-machine-api",
 		Type:           common.TemplateTypeConfig,
 		InstanceType:   instance.Kind,
 		AdditionalData: map[string]string{"networkData": "/baremetalset/cloudinit/networkdata"},
-		Labels:         secretLabels,
+		Labels:         secretLabelsWithMustGather,
 		ConfigOptions:  templateParameters,
 	}
 

--- a/tests/kuttl/tests/openstackbaremetalset_scale/07-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/07-assert.yaml
@@ -62,6 +62,5 @@ status:
   provisioning:
     bootMode: legacy
     image:
-      checksum: ""
       url: ""
     state: ready


### PR DESCRIPTION
Somehow I removed the `must-gather` label for secrets for OSBMS.  This PR puts it back.