### PR TITLE
Drop SRIOV version dep from provserver container

### DIFF
--- a/containers/provision_ip_discovery_agent/start.go
+++ b/containers/provision_ip_discovery_agent/start.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/openshift/sriov-network-operator/pkg/version"
 	"github.com/spf13/cobra"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,9 +57,6 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 
 	glog.V(0).Info("Starting ProvisionIpDiscoveryAgent")
-
-	// To help debugging, immediately log version
-	glog.V(2).Infof("Version: %+v", version.Version)
 
 	if startOpts.provIntf == "" {
 		name, ok := os.LookupEnv("PROV_INTF")


### PR DESCRIPTION
This drops the sriov version dependency and log
statement from the provisionserver container
(shouldn't be needed)