### PR TITLE
provisionserver: default to rhel8/httpd-24:1-152

### DIFF
--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -35,7 +35,7 @@ type OpenStackProvisionServerSpec struct {
 	// +kubebuilder:default="quay.io/openstack-k8s-operators/rhel-downloader:0.0.1"
 	DownloaderImageURL string `json:"downloaderImageUrl,omitempty"`
 	// Container image URL for the main container that serves the downloaded RHEL qcow2 image (baseImageUrl)
-	// +kubebuilder:default="quay.io/openstack-k8s-operators/httpd-24-centos7:2.4"
+	// +kubebuilder:default="registry.redhat.io/rhel8/httpd-24:1-152"
 	ApacheImageURL string `json:"apacheImageUrl,omitempty"`
 	// Container image URL for the sidecar container that discovers provisioning network IPs
 	// +kubebuilder:default="quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1"

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -51,7 +51,7 @@ spec:
               OpenStackProvisionServer
             properties:
               apacheImageUrl:
-                default: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+                default: registry.redhat.io/rhel8/httpd-24:1-152
                 description: Container image URL for the main container that serves
                   the downloaded RHEL qcow2 image (baseImageUrl)
                 type: string

--- a/templates/openstackprovisionserver/config/httpd.conf
+++ b/templates/openstackprovisionserver/config/httpd.conf
@@ -28,7 +28,7 @@
 # same ServerRoot for multiple httpd daemons, you will need to change at
 # least PidFile.
 #
-ServerRoot "/opt/rh/httpd24/root/etc/httpd"
+ServerRoot "/etc/httpd"
 
 #
 # Listen: Allows you to bind Apache to specific IP addresses and/or


### PR DESCRIPTION
Update the OpenStackProvisionServer defaults so that we use
registry.redhat.io/rhel8/httpd-24:1-152 as our default image.

Also fixes a functional issue with this image so that ServerRoot
is set correctly.