### PR TITLE
Use 16.2 instead of more specific tags

### DIFF
--- a/api/v1beta1/openstackephemeralheat_webhook.go
+++ b/api/v1beta1/openstackephemeralheat_webhook.go
@@ -50,16 +50,16 @@ func (r *OpenStackEphemeralHeat) Default() {
 		r.Spec.ConfigHash = r.Name
 	}
 	if r.Spec.HeatAPIImageURL == "" {
-		r.Spec.HeatAPIImageURL = "registry.redhat.io/rhosp-beta/openstack-heat-api:16.2.0-56"
+		r.Spec.HeatAPIImageURL = "registry.redhat.io/rhosp-beta/openstack-heat-api:16.2"
 	}
 	if r.Spec.HeatEngineImageURL == "" {
-		r.Spec.HeatEngineImageURL = "registry.redhat.io/rhosp-beta/openstack-heat-engine:16.2.0-58"
+		r.Spec.HeatEngineImageURL = "registry.redhat.io/rhosp-beta/openstack-heat-engine:16.2"
 	}
 	if r.Spec.MariadbImageURL == "" {
-		r.Spec.MariadbImageURL = "registry.redhat.io/rhosp-beta/openstack-mariadb:16.2.0-70"
+		r.Spec.MariadbImageURL = "registry.redhat.io/rhosp-beta/openstack-mariadb:16.2"
 	}
 	if r.Spec.RabbitImageURL == "" {
-		r.Spec.RabbitImageURL = "registry.redhat.io/rhosp-beta/openstack-rabbitmq:16.2.0-71"
+		r.Spec.RabbitImageURL = "registry.redhat.io/rhosp-beta/openstack-rabbitmq:16.2"
 	}
 
 }

--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -32,13 +32,13 @@ type OpenStackProvisionServerSpec struct {
 	// URL for RHEL qcow2 image (compressed as gz, or uncompressed)
 	BaseImageURL string `json:"baseImageUrl"`
 	// Container image URL for init container that downloads the RHEL qcow2 image (baseImageUrl)
-	// +kubebuilder:default="registry.redhat.io/rhosp-beta-rhel8/osp-director-downloader:1.0.0-1"
+	// +kubebuilder:default="registry.redhat.io/rhosp-beta-rhel8/osp-director-downloader:1.0"
 	DownloaderImageURL string `json:"downloaderImageUrl,omitempty"`
 	// Container image URL for the main container that serves the downloaded RHEL qcow2 image (baseImageUrl)
-	// +kubebuilder:default="registry.redhat.io/rhel8/httpd-24:1-152"
+	// +kubebuilder:default="registry.redhat.io/rhel8/httpd-24:latest"
 	ApacheImageURL string `json:"apacheImageUrl,omitempty"`
 	// Container image URL for the sidecar container that discovers provisioning network IPs
-	// +kubebuilder:default="registry.redhat.io/rhosp-beta-rhel8/osp-director-provisioner:1.0.0-1"
+	// +kubebuilder:default="registry.redhat.io/rhosp-beta-rhel8/osp-director-provisioner:1.0"
 	ProvisioningAgentImageURL string `json:"provisioningAgentImageUrl,omitempty"`
 }
 

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -51,7 +51,7 @@ spec:
               OpenStackProvisionServer
             properties:
               apacheImageUrl:
-                default: registry.redhat.io/rhel8/httpd-24:1-152
+                default: registry.redhat.io/rhel8/httpd-24:latest
                 description: Container image URL for the main container that serves
                   the downloaded RHEL qcow2 image (baseImageUrl)
                 type: string
@@ -59,7 +59,7 @@ spec:
                 description: URL for RHEL qcow2 image (compressed as gz, or uncompressed)
                 type: string
               downloaderImageUrl:
-                default: registry.redhat.io/rhosp-beta-rhel8/osp-director-downloader:1.0.0-1
+                default: registry.redhat.io/rhosp-beta-rhel8/osp-director-downloader:1.0
                 description: Container image URL for init container that downloads
                   the RHEL qcow2 image (baseImageUrl)
                 type: string
@@ -71,7 +71,7 @@ spec:
                 description: The port on which the Apache server should listen
                 type: integer
               provisioningAgentImageUrl:
-                default: registry.redhat.io/rhosp-beta-rhel8/osp-director-provisioner:1.0.0-1
+                default: registry.redhat.io/rhosp-beta-rhel8/osp-director-provisioner:1.0
                 description: Container image URL for the sidecar container that discovers
                   provisioning network IPs
                 type: string

--- a/config/samples/osp-director_v1beta1_openstackclient.yaml
+++ b/config/samples/osp-director_v1beta1_openstackclient.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstackclient
   namespace: openstack
 spec:
-  imageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2.0-4
+  imageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
     - ctlplane

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   gitSecret: git-secret
-  openStackClientImageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2.0-4
+  openStackClientImageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
   openStackClientNetworks:
     - ctlplane
     - external

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: overcloud
   namespace: openstack
 spec:
-  openStackClientImageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2.0-4
+  openStackClientImageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
   openStackClientNetworks:
     - ctlplane
     - external

--- a/config/samples/osp-director_v1beta1_openstackplaybookgenerator.yaml
+++ b/config/samples/osp-director_v1beta1_openstackplaybookgenerator.yaml
@@ -3,7 +3,7 @@ kind: OpenStackPlaybookGenerator
 metadata:
   name: default
 spec:
-  imageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2.0-4
+  imageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
   gitSecret: git-secret
   heatEnvConfigMap: heat-env-config
   tarballConfigMap: tripleo-tarball-config


### PR DESCRIPTION
This should act as the 'latest' 16.2 and is what we default
to in containers-image-prepare via tripleoclient so it should be
a better default.

Also, use the 'latest' tag for the rhel8/httpd-24.