### PR TITLE
Update kuttl tests to latest env changes

### DIFF
--- a/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
+++ b/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
@@ -20,7 +20,7 @@ spec:
   # to the secret data
   passwordSecret: userpassword
   # The interface on the nodes that will be assigned an IP from the ctlCidr
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp8s0
   # Arbitrary label selector for BaremetalHosts (optional)
   bmhLabelSelector:
     arbitraryKey: arbitraryValue

--- a/config/samples/osp-director_v1beta1_openstacknet_ctlplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_ctlplane.yaml
@@ -18,8 +18,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/config/samples/osp-director_v1beta1_openstacknet_external.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_external.yaml
@@ -21,6 +21,6 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge

--- a/config/samples/osp-director_v1beta1_openstacknet_internalapi.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_internalapi.yaml
@@ -18,8 +18,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/config/samples/osp-director_v1beta1_openstacknet_storage.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_storage.yaml
@@ -18,8 +18,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/config/samples/osp-director_v1beta1_openstacknet_storagemgmt.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_storagemgmt.yaml
@@ -18,8 +18,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/config/samples/osp-director_v1beta1_openstacknet_tenant.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknet_tenant.yaml
@@ -18,8 +18,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -6,8 +6,8 @@
 # ASSUMPTIONS:
 #
 # 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
-#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.9.0/kubectl-kuttl_0.9.0_linux_x86_64
-#    - mv kubectl-kuttl_0.9.0_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
 #    - chmod 755 /usr/local/bin/kubectl-kuttl
 # 2. An OCP 4.6+ cluster with OSP Director Operator has been deployed via https://github.com/openstack-k8s-operators/osp-director-dev-tools
 # 3. CLI user has access to $KUBECONFIG
@@ -35,3 +35,4 @@ reportFormat: JSON
 reportName: kuttl-test
 namespace: openstack
 timeout: 180
+parallel: 1

--- a/tests/kuttl/tests/openstackbaremetalset_scale/01-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/01-assert.yaml
@@ -24,8 +24,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -60,7 +60,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
 ---
@@ -87,8 +87,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -108,8 +108,8 @@ spec:
           stp:
             enabled: false
         port:
-        - name: enp7s0
-      description: Linux bridge with enp7s0 as a port
+        - name: enp8s0
+      description: Linux bridge with enp8s0 as a port
       name: br-osp
       state: up
       type: linux-bridge

--- a/tests/kuttl/tests/openstackbaremetalset_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/02-assert.yaml
@@ -61,8 +61,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -108,7 +108,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
       nodeSelector:

--- a/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 0
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp8s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
   - ctlplane
@@ -41,7 +41,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
-  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24:latest
   provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1
   port: 6190
 status:

--- a/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 2
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp8s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
   - ctlplane
@@ -143,8 +143,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -201,8 +201,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 1
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp8s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
   - ctlplane
@@ -121,8 +121,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -178,8 +178,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackbaremetalset_scale/08-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/08-assert.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   count: 2
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp8s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
   - ctlplane
@@ -143,8 +143,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -200,8 +200,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackbaremetalset_scale/09-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/09-assert.yaml
@@ -47,8 +47,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
@@ -24,8 +24,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -60,7 +60,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
 ---
@@ -87,8 +87,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -116,8 +116,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -145,8 +145,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -174,8 +174,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -195,8 +195,8 @@ spec:
           stp:
             enabled: false
         port:
-        - name: enp7s0
-      description: Linux bridge with enp7s0 as a port
+        - name: enp8s0
+      description: Linux bridge with enp8s0 as a port
       name: br-osp
       state: up
       type: linux-bridge

--- a/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
@@ -111,8 +111,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -165,7 +165,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
       nodeSelector:
@@ -216,8 +216,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -261,8 +261,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -306,8 +306,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -351,8 +351,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
@@ -195,7 +195,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
       nodeSelector:
@@ -261,8 +261,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -321,8 +321,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -381,8 +381,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -441,8 +441,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
@@ -150,7 +150,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
       nodeSelector:
@@ -216,8 +216,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -276,8 +276,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -336,8 +336,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -396,8 +396,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
@@ -195,7 +195,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
       nodeSelector:
@@ -261,8 +261,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -322,8 +322,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -383,8 +383,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -444,8 +444,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackcontrolplane_scale/07-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/07-assert.yaml
@@ -42,7 +42,7 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          name: br-osp
+          name: br-ex
           state: up
           type: linux-bridge
       nodeSelector:
@@ -79,8 +79,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -118,8 +118,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -157,8 +157,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -196,8 +196,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/01-assert.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/01-assert.yaml
@@ -24,8 +24,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -64,8 +64,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -92,8 +92,8 @@ spec:
           stp:
             enabled: false
         port:
-        - name: enp7s0
-      description: Linux bridge with enp7s0 as a port
+        - name: enp8s0
+      description: Linux bridge with enp8s0 as a port
       name: br-osp
       state: up
       type: linux-bridge

--- a/tests/kuttl/tests/openstacknet_cleanup_nncp/02-assert.yaml
+++ b/tests/kuttl/tests/openstacknet_cleanup_nncp/02-assert.yaml
@@ -24,8 +24,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -56,8 +56,8 @@ spec:
           stp:
             enabled: false
         port:
-        - name: enp7s0
-      description: Linux bridge with enp7s0 as a port
+        - name: enp8s0
+      description: Linux bridge with enp8s0 as a port
       name: br-osp
       state: up
       type: linux-bridge

--- a/tests/kuttl/tests/openstacknet_immutable_bridge_name/01-assert.yaml
+++ b/tests/kuttl/tests/openstacknet_immutable_bridge_name/01-assert.yaml
@@ -23,8 +23,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstacknet_immutable_bridge_name/02-assert.yaml
+++ b/tests/kuttl/tests/openstacknet_immutable_bridge_name/02-assert.yaml
@@ -23,8 +23,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/01-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/01-assert.yaml
@@ -10,7 +10,7 @@ metadata:
   name: openstack
   namespace: openstack
 spec:
-  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24:latest
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
   port: 8080

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
@@ -10,7 +10,7 @@ metadata:
   name: goodprov
   namespace: openstack
 spec:
-  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24:latest
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
   port: 8081

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/04-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/04-assert.yaml
@@ -24,8 +24,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge
@@ -49,8 +49,8 @@ spec:
           stp:
             enabled: false
         port:
-        - name: enp7s0
-      description: Linux bridge with enp7s0 as a port
+        - name: enp8s0
+      description: Linux bridge with enp8s0 as a port
       name: br-osp
       state: up
       type: linux-bridge

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/05-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/05-assert.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
-  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24:latest
   provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1
   port: 6190
 status:

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/06-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/06-assert.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader:0.0.1
-  apacheImageUrl: quay.io/openstack-k8s-operators/httpd-24-centos7:2.4
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24:latest
   provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent:0.0.1
   port: 6191
 status:

--- a/tests/kuttl/tests/unique_role_name/01-assert.yaml
+++ b/tests/kuttl/tests/unique_role_name/01-assert.yaml
@@ -23,8 +23,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: enp7s0
-          description: Linux bridge with enp7s0 as a port
+            - name: enp8s0
+          description: Linux bridge with enp8s0 as a port
           name: br-osp
           state: up
           type: linux-bridge


### PR DESCRIPTION
Modify kuttl tests to:
- use updated images
- br-ex for external network
- update interfaces to match dev-tools interface mapping

Also updates kuttl config to make sure no tests run in parallel
(default 8) as this result in failures.