### PR TITLE
Update OSP images to release version with 16.2 tag

### DIFF
--- a/api/v1beta1/openstackephemeralheat_webhook.go
+++ b/api/v1beta1/openstackephemeralheat_webhook.go
@@ -50,16 +50,16 @@ func (r *OpenStackEphemeralHeat) Default() {
 		r.Spec.ConfigHash = r.Name
 	}
 	if r.Spec.HeatAPIImageURL == "" {
-		r.Spec.HeatAPIImageURL = "registry.redhat.io/rhosp-beta/openstack-heat-api:16.2"
+		r.Spec.HeatAPIImageURL = "registry.redhat.io/rhosp-rhel8/openstack-heat-api:16.2"
 	}
 	if r.Spec.HeatEngineImageURL == "" {
-		r.Spec.HeatEngineImageURL = "registry.redhat.io/rhosp-beta/openstack-heat-engine:16.2"
+		r.Spec.HeatEngineImageURL = "registry.redhat.io/rhosp-rhel8/openstack-heat-engine:16.2"
 	}
 	if r.Spec.MariadbImageURL == "" {
-		r.Spec.MariadbImageURL = "registry.redhat.io/rhosp-beta/openstack-mariadb:16.2"
+		r.Spec.MariadbImageURL = "registry.redhat.io/rhosp-rhel8/openstack-mariadb:16.2"
 	}
 	if r.Spec.RabbitImageURL == "" {
-		r.Spec.RabbitImageURL = "registry.redhat.io/rhosp-beta/openstack-rabbitmq:16.2"
+		r.Spec.RabbitImageURL = "registry.redhat.io/rhosp-rhel8/openstack-rabbitmq:16.2"
 	}
 
 }

--- a/config/samples/osp-director_v1beta1_openstackclient.yaml
+++ b/config/samples/osp-director_v1beta1_openstackclient.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstackclient
   namespace: openstack
 spec:
-  imageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
+  imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2.0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
     - ctlplane

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   gitSecret: git-secret
-  openStackClientImageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
+  openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2.0
   openStackClientNetworks:
     - ctlplane
     - external

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane_with_additional_custom_role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: overcloud
   namespace: openstack
 spec:
-  openStackClientImageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
+  openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2.0
   openStackClientNetworks:
     - ctlplane
     - external

--- a/config/samples/osp-director_v1beta1_openstackplaybookgenerator.yaml
+++ b/config/samples/osp-director_v1beta1_openstackplaybookgenerator.yaml
@@ -3,7 +3,7 @@ kind: OpenStackPlaybookGenerator
 metadata:
   name: default
 spec:
-  imageURL: registry.redhat.io/rhosp-beta/openstack-tripleoclient:16.2
+  imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2.0
   gitSecret: git-secret
   heatEnvConfigMap: heat-env-config
   tarballConfigMap: tripleo-tarball-config


### PR DESCRIPTION
NOTE: I have pinned the tripleoclient to 16.2.0 instead
of 16.2 because that tag doesn't yet exist. See also:
https://bugzilla.redhat.com/show_bug.cgi?id=2005107