### PR TITLE
Kubeconfig for fencing, part 2

### DIFF
--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -56,8 +56,9 @@ type OpenStackControlPlaneSpec struct {
 	// If the macPrefix is not specified for a physnet, the default macPrefix "fa:16:3a" is used.
 	PhysNetworks []Physnet `json:"physNetworks"`
 
-	// +kubebuilder:default=true
+	// +kubebuilder:default=false
 	// EnableFencing is provided so that users have the option to disable fencing if desired
+	// FIXME: Defaulting to false until Kubevirt agent merged into RHEL overcloud image
 	EnableFencing bool `json:"enableFencing"`
 }
 

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -62,9 +62,10 @@ spec:
             description: OpenStackControlPlaneSpec defines the desired state of OpenStackControlPlane
             properties:
               enableFencing:
-                default: true
-                description: EnableFencing is provided so that users have the option
-                  to disable fencing if desired
+                default: false
+                description: 'EnableFencing is provided so that users have the option
+                  to disable fencing if desired FIXME: Defaulting to false until Kubevirt
+                  agent merged into RHEL overcloud image'
                 type: boolean
               gitSecret:
                 description: GitSecret used to pull playbooks into the openstackclient

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -171,11 +171,3 @@ subjects:
 - kind: ServiceAccount
   name: kubevirtagent
   namespace: openstack
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubevirtfencing
-  annotations:
-    kubernetes.io/service-account.name: osp-director-operator-kubevirtagent
-type: kubernetes.io/service-account-token

--- a/pkg/common/configmap.go
+++ b/pkg/common/configmap.go
@@ -37,8 +37,9 @@ func createOrUpdateConfigMap(r ReconcilerCommon, obj metav1.Object, cm Template)
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cm.Name,
-			Namespace: cm.Namespace,
+			Name:        cm.Name,
+			Namespace:   cm.Namespace,
+			Annotations: cm.Annotations,
 		},
 		Data: data,
 	}
@@ -76,9 +77,10 @@ func createOrGetCustomConfigMap(r ReconcilerCommon, obj metav1.Object, cm Templa
 	// Check if this configMap already exists
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cm.Name,
-			Namespace: cm.Namespace,
-			Labels:    cm.Labels,
+			Name:        cm.Name,
+			Namespace:   cm.Namespace,
+			Labels:      cm.Labels,
+			Annotations: cm.Annotations,
 		},
 		Data: map[string]string{},
 	}

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -40,4 +40,16 @@ const (
 
 	// FinalizerName -
 	FinalizerName = GroupLabel
+
+	// ServiceAccountAnnotationName -
+	ServiceAccountAnnotationName = "kubernetes.io/service-account.name"
+
+	// TripleOServicesDefaultKeyName -
+	TripleOServicesDefaultKeyName = "ServicesDefault"
+
+	// TripleOPacemakerServiceName -
+	TripleOPacemakerServiceName = "OS::TripleO::Services::Pacemaker"
+
+	// TripleORolesDataFile -
+	TripleORolesDataFile = "roles_data.yaml"
 )

--- a/pkg/common/fencing.go
+++ b/pkg/common/fencing.go
@@ -1,0 +1,102 @@
+package common
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/tidwall/gjson"
+	"sigs.k8s.io/yaml"
+)
+
+// GetFencingRoles - roles that normally require fencing
+func GetFencingRoles() []string {
+	// Can't create an array constant, so this is what we'll do instead
+	return []string{
+		"CellController",
+		"ControllerAllNovaStandalone",
+		"ControllerNoCeph",
+		"ControllerNovaStandalone",
+		"ControllerOpenstack",
+		"ControllerSriov",
+		"ControllerStorageDashboard",
+		"ControllerStorageNfs",
+		"Controller",
+		"Database",
+		"Messaging",
+		"Standalone",
+		"Telemetry",
+	}
+}
+
+// GetCustomFencingRoles - return a list of any custom roles included in custom tarball that require fencing support
+func GetCustomFencingRoles(customBinaryData map[string][]byte) ([]string, error) {
+	customFencingRoles := []string{}
+
+	for _, binaryData := range customBinaryData {
+		reader := bytes.NewReader(binaryData)
+		uncompressedStream, err := gzip.NewReader(reader)
+
+		if err != nil {
+			return nil, err
+		}
+
+		tarReader := tar.NewReader(uncompressedStream)
+
+		for {
+			header, err := tarReader.Next()
+
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+
+				return nil, err
+			}
+
+			switch header.Typeflag {
+			case tar.TypeReg:
+				if header.Name == TripleORolesDataFile {
+					buf, err := ioutil.ReadAll(tarReader)
+
+					if err != nil {
+						return nil, err
+					}
+
+					jsonBytes, err := yaml.YAMLToJSON(buf)
+
+					if err != nil {
+						return nil, err
+					}
+
+					jsonStr := string(jsonBytes)
+
+					if !gjson.Valid(jsonStr) {
+						return nil, fmt.Errorf("invalid YAML detected in custom tarball")
+					}
+
+					res := gjson.Parse(jsonStr)
+
+					res.ForEach(func(key gjson.Result, value gjson.Result) bool {
+						if value.Get(TripleOServicesDefaultKeyName).Exists() {
+							res2 := value.Get(TripleOServicesDefaultKeyName)
+							res2.ForEach(func(key2 gjson.Result, value2 gjson.Result) bool {
+								if value2.String() == TripleOPacemakerServiceName {
+									customFencingRoles = append(customFencingRoles, value.Get("name").String())
+									return false
+								}
+								return true
+							})
+						}
+						return true
+					})
+				}
+			}
+		}
+	}
+
+	return customFencingRoles, nil
+}

--- a/pkg/common/secret.go
+++ b/pkg/common/secret.go
@@ -130,10 +130,15 @@ func createOrUpdateSecret(r ReconcilerCommon, obj metav1.Object, st Template) (s
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      st.Name,
-			Namespace: st.Namespace,
+			Name:        st.Name,
+			Namespace:   st.Namespace,
+			Annotations: st.Annotations,
 		},
 		Data: data,
+	}
+
+	if st.SecretType != "" {
+		secret.Type = st.SecretType
 	}
 
 	// create or update the CM
@@ -184,12 +189,18 @@ func createOrGetCustomSecret(r ReconcilerCommon, obj metav1.Object, st Template)
 	// Check if this secret already exists
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      st.Name,
-			Namespace: st.Namespace,
-			Labels:    st.Labels,
+			Name:        st.Name,
+			Namespace:   st.Namespace,
+			Labels:      st.Labels,
+			Annotations: st.Annotations,
 		},
 		Data: map[string][]byte{},
 	}
+
+	if st.SecretType != "" {
+		secret.Type = st.SecretType
+	}
+
 	foundSecret := &corev1.Secret{}
 	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: st.Name, Namespace: st.Namespace}, foundSecret)
 	if err != nil && k8s_errors.IsNotFound(err) {

--- a/pkg/common/template_util.go
+++ b/pkg/common/template_util.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	ospdirectorv1beta1 "github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // TType - TemplateType
@@ -28,14 +29,16 @@ const (
 	TemplateTypeNone TType = "none"
 )
 
-// Template - config map details
+// Template - config map and secret details
 type Template struct {
 	Name           string
 	Namespace      string
 	Type           TType
 	InstanceType   string
+	SecretType     corev1.SecretType // Secrets only, defaults to "Opaque"
 	AdditionalData map[string]string
 	Labels         map[string]string
+	Annotations    map[string]string
 	ConfigOptions  map[string]interface{}
 	SkipSetOwner   bool // skip setting ownership on the associated configmap
 	Version        ospdirectorv1beta1.OSPVersion

--- a/pkg/vmset/const.go
+++ b/pkg/vmset/const.go
@@ -26,6 +26,9 @@ const (
 	// KubevirtFencingServiceAccount -
 	KubevirtFencingServiceAccount = "osp-director-operator-kubevirtagent"
 
-	// KubevirtFencingSecret -
-	KubevirtFencingSecret = "osp-director-operator-kubevirtfencing"
+	// KubevirtFencingServiceAccountSecret -
+	KubevirtFencingServiceAccountSecret = "osp-director-operator-fencing-sa"
+
+	// KubevirtFencingKubeconfigSecret -
+	KubevirtFencingKubeconfigSecret = "osp-director-operator-fencing-kubeconfig"
 )

--- a/templates/openstackplaybookgenerator/config/fencing.yaml
+++ b/templates/openstackplaybookgenerator/config/fencing.yaml
@@ -13,6 +13,6 @@ parameter_defaults:
           namespace: {{ $fencingConfig.Namespace }}
           ssl_insecure: true
           power_timeout: 30
-          kubeconfig: /home/cloud-admin/kubeconfig
+          kubeconfig: /root/kubeconfig/kubeconfig
 {{- end }}
 {{- end }}

--- a/templates/vmset/cloudinit/userdata
+++ b/templates/vmset/cloudinit/userdata
@@ -11,5 +11,10 @@ chpasswd:
   expire: False
 {{- end }}
 bootcmd:
-  - "mkdir /mnt/kubeconfig"
+  - "mkdir -p /mnt/kubeconfig"
+  - "mkdir -p /root/kubeconfig"
   - "mount /dev/disk/by-id/virtio-fencingdisk /mnt/kubeconfig"
+  - "cp -f /mnt/kubeconfig/* /root/kubeconfig/."
+  - "chown -R root:root /root/kubeconfig"
+  - "chmod -R 0600 /root/kubeconfig"
+  - "umount /mnt/kubeconfig"


### PR DESCRIPTION
1. OSVMSet controller creates namespace-scoped secrets needed for fencing considerations, instead of relying on OLM (which had a race condition)
2. Allows config maps and secrets to have annotations
3. Allows secrets to set a secret type (instead of only Opaque)
4. Adds functionality to unzip custom heat tarballs to detect custom roles that use Pacemaker