### PR TITLE
fixup references to rhosp-beta-rhel8 images

### DIFF
--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -32,13 +32,13 @@ type OpenStackProvisionServerSpec struct {
 	// URL for RHEL qcow2 image (compressed as gz, or uncompressed)
 	BaseImageURL string `json:"baseImageUrl"`
 	// Container image URL for init container that downloads the RHEL qcow2 image (baseImageUrl)
-	// +kubebuilder:default="registry.redhat.io/rhosp-beta-rhel8/osp-director-downloader:1.0"
+	// +kubebuilder:default="registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader:1.0"
 	DownloaderImageURL string `json:"downloaderImageUrl,omitempty"`
 	// Container image URL for the main container that serves the downloaded RHEL qcow2 image (baseImageUrl)
 	// +kubebuilder:default="registry.redhat.io/rhel8/httpd-24:latest"
 	ApacheImageURL string `json:"apacheImageUrl,omitempty"`
 	// Container image URL for the sidecar container that discovers provisioning network IPs
-	// +kubebuilder:default="registry.redhat.io/rhosp-beta-rhel8/osp-director-provisioner:1.0"
+	// +kubebuilder:default="registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-provisioner:1.0"
 	ProvisioningAgentImageURL string `json:"provisioningAgentImageUrl,omitempty"`
 }
 

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -59,7 +59,7 @@ spec:
                 description: URL for RHEL qcow2 image (compressed as gz, or uncompressed)
                 type: string
               downloaderImageUrl:
-                default: registry.redhat.io/rhosp-beta-rhel8/osp-director-downloader:1.0
+                default: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader:1.0
                 description: Container image URL for init container that downloads
                   the RHEL qcow2 image (baseImageUrl)
                 type: string
@@ -71,7 +71,7 @@ spec:
                 description: The port on which the Apache server should listen
                 type: integer
               provisioningAgentImageUrl:
-                default: registry.redhat.io/rhosp-beta-rhel8/osp-director-provisioner:1.0
+                default: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-provisioner:1.0
                 description: Container image URL for the sidecar container that discovers
                   provisioning network IPs
                 type: string


### PR DESCRIPTION
there were several images pointing to beta instead of tech-preview

Change-Id: Ia160f1737ef17c950fe0c579b52aa2d276f747d0