### PR TITLE
OSPK8-373 Render network_data.yaml from osnets

### DIFF
--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -69,7 +69,7 @@ type OpenStackControlPlaneSpec struct {
 	DomainName string `json:"domainName,omitempty"`
 
 	// Upstream DNS servers
-	DNSServers []string `json:"dnsServers,omitempty"`
+	DNSServers       []string `json:"dnsServers,omitempty"`
 	DNSSearchDomains []string `json:"dnsSearchDomains,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/openstacknet_types.go
+++ b/api/v1beta1/openstacknet_types.go
@@ -85,6 +85,16 @@ type OpenStackNetSpec struct {
 	// Gateway optional gateway for the network
 	Gateway string `json:"gateway"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=1500
+	// MTU of the network
+	MTU int `json:"mtu"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
+	// VIP create virtual ip on the network
+	VIP bool `json:"vip"`
+
 	// +kubebuilder:validation:Required
 	// AttachConfiguration used for NodeNetworkConfigurationPolicy and NetworkAttachmentDefinition
 	AttachConfiguration NetworkConfiguration `json:"attachConfiguration"`
@@ -135,7 +145,9 @@ const (
 // +kubebuilder:resource:shortName=osnet;osnets
 // +operator-sdk:csv:customresourcedefinitions:displayName="OpenStack Net"
 // +kubebuilder:printcolumn:name="CIDR",type=string,JSONPath=`.spec.cidr`
+// +kubebuilder:printcolumn:name="MTU",type=string,JSONPath=`.spec.mtu`
 // +kubebuilder:printcolumn:name="VLAN",type=string,JSONPath=`.spec.vlan`
+// +kubebuilder:printcolumn:name="VIP",type=boolean,JSONPath=`.spec.vip`
 // +kubebuilder:printcolumn:name="Gateway",type=string,JSONPath=`.spec.gateway`
 // +kubebuilder:printcolumn:name="Reserved IPs",type="integer",JSONPath=".status.reservedIpCount"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.currentState`,description="Status"

--- a/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
@@ -23,9 +23,15 @@ spec:
     - jsonPath: .spec.cidr
       name: CIDR
       type: string
+    - jsonPath: .spec.mtu
+      name: MTU
+      type: string
     - jsonPath: .spec.vlan
       name: VLAN
       type: string
+    - jsonPath: .spec.vip
+      name: VIP
+      type: boolean
     - jsonPath: .spec.gateway
       name: Gateway
       type: string
@@ -136,6 +142,14 @@ spec:
               gateway:
                 description: Gateway optional gateway for the network
                 type: string
+              mtu:
+                default: 1500
+                description: MTU of the network
+                type: integer
+              vip:
+                default: true
+                description: VIP create virtual ip on the network
+                type: boolean
               vlan:
                 description: Vlan ID of the network
                 type: integer

--- a/controllers/openstackplaybookgenerator_controller.go
+++ b/controllers/openstackplaybookgenerator_controller.go
@@ -144,6 +144,8 @@ func (r *OpenStackPlaybookGeneratorReconciler) Reconcile(ctx context.Context, re
 	}
 
 	tripleoDeployFiles := tripleoDeployCM.Data
+	// Delete network_data.yaml from tripleoDeployFiles as it is not an ooo parameter env file
+	delete(tripleoDeployFiles, "network_data.yaml")
 	// Also add fencing.yaml to the tripleoDeployFiles (just need the file name)
 	templateParameters["TripleoDeployFiles"] = tripleoDeployFiles
 	templateParameters["HeatServiceName"] = "heat-" + instance.Name

--- a/pkg/common/funcs.go
+++ b/pkg/common/funcs.go
@@ -52,3 +52,8 @@ func isJSON(s string) error {
 	var js map[string]interface{}
 	return json.Unmarshal([]byte(s), &js)
 }
+
+// RemoveIndex - remove int from slice
+func RemoveIndex(s []string, index int) []string {
+	return append(s[:index], s[index+1:]...)
+}

--- a/pkg/common/template_util.go
+++ b/pkg/common/template_util.go
@@ -75,6 +75,19 @@ func GetAllTemplates(path string, kind string, templateType string, version stri
 		fmt.Print(err)
 		os.Exit(1)
 	}
+
+	// remove any subdiretories from templatesFiles
+	for index, file := range templatesFiles {
+		fi, err := os.Stat(file)
+		if err != nil {
+			fmt.Print(err)
+			os.Exit(1)
+		}
+		if fi.Mode().IsDir() {
+			RemoveIndex(templatesFiles, index)
+		}
+	}
+
 	return templatesFiles
 }
 

--- a/pkg/openstackipset/configmap.go
+++ b/pkg/openstackipset/configmap.go
@@ -32,11 +32,13 @@ type networkType struct {
 	Cidr            string // e.g. 192.168.24.0/24
 	NetAddr         string // e.g. 192.168.24.0
 	CidrSuffix      int    // e.g. 24
-	MTU             int
+	MTU             int    // default 1500
 	AllocationStart string
 	AllocationEnd   string
 	Gateway         string
+	VIP             bool // allocate VIP on network, defaut true
 	Vlan            int
+	NetType         string
 }
 
 // information to build NodePortMap entry:
@@ -108,17 +110,25 @@ func CreateConfigMapParams(overcloudNetList ospdirectorv1beta1.OpenStackNetList,
 			if err != nil {
 				return templateParameters, err
 			}
+
+			netType := "ipv4"
+			if common.IsIPv6(net.ParseIP(osnet.Spec.Cidr)) {
+				netType = "ipv6"
+			}
+
 			networksMap[osnetName] = &networkType{
 				Name:            GetNetName(osnetName),
 				NameLower:       osnetName,
 				Cidr:            osnet.Spec.Cidr,
 				CidrSuffix:      cidrSuffix,
 				NetAddr:         netAddr,
-				MTU:             1500, //TODO custom MTU per network
+				MTU:             osnet.Spec.MTU,
 				AllocationStart: osnet.Spec.AllocationStart,
 				AllocationEnd:   osnet.Spec.AllocationEnd,
 				Gateway:         osnet.Spec.Gateway,
+				VIP:             osnet.Spec.VIP,
 				Vlan:            osnet.Spec.Vlan,
+				NetType:         netType,
 			}
 		}
 

--- a/templates/openstackipset/config/16.2/network_data.yaml
+++ b/templates/openstackipset/config/16.2/network_data.yaml
@@ -1,0 +1,26 @@
+{{- range $netname, $net := .NetworksMap }}
+{{- if ne $net.Name "Control" }}
+- name: {{ $net.Name }}
+  vip: {{ $net.VIP }}
+  name_lower: {{ $net.NameLower }}
+{{- if eq $net.NetType "ipv4" }}
+  ip_subnet: '{{ $net.Cidr }}'
+  allocation_pools: [{'start': '{{ $net.AllocationStart }}', 'end': '{{ $net.AllocationEnd }}'}]
+{{- if ne $net.Gateway "" }}
+  gateway_ip: '{{ $net.Gateway }}'
+{{- end }}
+{{- end }}
+{{- if eq $net.NetType "ipv6" }}
+  ipv6: true
+  ipv6_subnet: '{{ $net.Cidr }}'
+  ipv6_allocation_pools: [{'start': '{{ $net.AllocationStart }}', 'end': '{{ $net.AllocationEnd }}'}]
+{{- if ne $net.Gateway "" }}
+  gateway_ipv6: '{{ $net.Gateway }}'
+{{- end }}
+{{- end }}
+  mtu: {{ $net.MTU }}
+{{- if ne $net.Vlan 0 }}
+  vlan: {{ $net.Vlan }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/openstackipset/config/17.0/network_data.yaml
+++ b/templates/openstackipset/config/17.0/network_data.yaml
@@ -1,0 +1,31 @@
+{{- range $netname, $net := .NetworksMap }}
+{{- if ne $net.Name "Control" }}
+- name: {{ $net.Name }}
+  vip: {{ $net.VIP }}
+  name_lower: {{ $net.NameLower }}
+  mtu: {{ $net.MTU }}
+{{- if eq $net.NetType "ipv6" }}
+  ipv6: true
+{{- end }}
+  subnets:
+    {{ $net.NameLower }}_subnet:
+      enable_dhcp: false
+{{- if ne $net.Vlan 0 }}
+      vlan: {{ $net.Vlan }}
+{{- end }}
+{{- if eq $net.NetType "ipv4" }}
+      ip_subnet: '{{ $net.Cidr }}'
+      allocation_pools: [{'start': '{{ $net.AllocationStart }}', 'end': '{{ $net.AllocationEnd }}'}]
+{{- if ne $net.Gateway "" }}
+      gateway_ip: '{{ $net.Gateway }}'
+{{- end }}
+{{- end }}
+{{- if eq $net.NetType "ipv6" }}
+      ipv6_subnet: '{{ $net.Cidr }}'
+      ipv6_allocation_pools: [{'start': '{{ $net.AllocationStart }}', 'end': '{{ $net.AllocationEnd }}'}]
+{{- if ne $net.Gateway "" }}
+      gateway_ipv6: '{{ $net.Gateway }}'
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This allows rendering of network_data.yaml using the information of the osnets.
Also adds parameters for MTU and VIP to the osnet. With the VIP parameter
it can be controlled if a VIP should be requested for this network. E.g. there is
no need to have a VIP on the tenant network.