### PR TITLE
Rework of Dockerfiles to allow osbs translation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GOLANG_BUILDER=golang:1.14
 ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary
-FROM ${GOLANG_BUILDER} AS builder
+FROM $GOLANG_BUILDER AS builder
 
 #Arguments required by OSBS build system
 ARG CACHITO_ENV_FILE=/remote-source/cachito.env
@@ -15,7 +15,7 @@ ARG DEST_ROOT=/dest-root
 ARG GO_BUILD_EXTRA_ARGS=
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
-WORKDIR ${REMOTE_SOURCE_DIR}/${REMOTE_SOURCE_SUBDIR}
+WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 
 RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
@@ -30,18 +30,31 @@ RUN cp -r templates ${DEST_ROOT}/templates
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM ${OPERATOR_BASE_IMAGE}
+FROM $OPERATOR_BASE_IMAGE
 
 ARG DEST_ROOT=/dest-root
 ARG USER_ID=nonroot:nonroot
 
-LABEL com.redhat.component="osp-director-operator-container" \
-      name="osp-director-operator" \
-      version="1.0.0" \
-      summary="OSP Director Operator" \
-      io.k8s.name="osp-director-operator" \
-      io.k8s.description="This image includes the osp-director-operator" \
-      io.openshift.tags="cn-openstack openstack"
+ARG IMAGE_COMPONENT="osp-director-operator-container"
+ARG IMAGE_NAME="osp-director-operator"
+ARG IMAGE_VERSION="1.0.0"
+ARG IMAGE_SUMMARY="OSP Director Operator"
+ARG IMAGE_DESC="This image includes the osp-director-operator"
+ARG IMAGE_TAGS="cn-openstack openstack"
+
+### DO NOT EDIT LINES BELOW
+# Auto generated using CI tools from
+# https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+
+# Labels required by upstream and osbs build system
+LABEL com.redhat.component="${IMAGE_COMPONENT}" \
+      name="${IMAGE_NAME}" \
+      version="${IMAGE_VERSION}" \
+      summary="${IMAGE_SUMMARY}" \
+      io.k8s.name="${IMAGE_NAME}" \
+      io.k8s.description="${IMAGE_DESC}" \
+      io.openshift.tags="${IMAGE_TAGS}"
+### DO NOT EDIT LINES ABOVE
 
 ENV USER_UID=1001 \
     OPERATOR_TEMPLATES=/usr/share/osp-director-operator/templates/ \
@@ -55,7 +68,7 @@ COPY --from=builder ${DEST_ROOT}/manager .
 # Install templates
 COPY --from=builder ${DEST_ROOT}/templates ${OPERATOR_TEMPLATES}
 
-USER ${USER_ID}
+USER $USER_ID
 
 ENV PATH="/:${PATH}"
 

--- a/Dockerfile.provision-ip-discovery-agent
+++ b/Dockerfile.provision-ip-discovery-agent
@@ -2,7 +2,7 @@ ARG GOLANG_BUILDER=golang:1.14
 ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/base
 
 # Build the manager binary
-FROM ${GOLANG_BUILDER} AS builder
+FROM $GOLANG_BUILDER AS builder
 
 #Arguments required by OSBS build system
 ARG CACHITO_ENV_FILE=/remote-source/cachito.env
@@ -16,26 +16,38 @@ ARG WHAT=provision-ip-discovery-agent
 ARG GO_BUILD_EXTRA_ARGS=
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
-WORKDIR ${REMOTE_SOURCE_DIR}/${REMOTE_SOURCE_SUBDIR}
+WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 
 RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=1 go build ${GO_BUILD_EXTRA_ARGS} -o ${DEST_ROOT}/${WHAT} ./containers/provision_ip_discovery_agent
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM ${OPERATOR_BASE_IMAGE}
+FROM $OPERATOR_BASE_IMAGE
 
 # Those arguments must match ones from builder
 ARG DEST_ROOT=/dest-root
 ARG WHAT=provision-ip-discovery-agent
 
-LABEL io.k8s.display-name="OSP-Director-Operator provision-ip-discovery-agent" \
-      io.k8s.description="This is an agent that discovers the IP of a designated provisioning interface on a given host" \
-      io.openshift.tags="openstack,director" \
-      maintainer="Andrew Bays <abays@redhat.com>"
+ARG IMAGE_COMPONENT="osp-director-provisioner-container"
+ARG IMAGE_NAME="osp-director-provisioner-container"
+ARG IMAGE_VERSION="1.0.0"
+ARG IMAGE_SUMMARY="OSP-Director-Operator provision-ip-discovery-agent"
+ARG IMAGE_DESC="This is an agent that discovers the IP of a designated provisioning interface on a given host"
+ARG IMAGE_TAGS="openstack director"
 
-LABEL com.redhat.component="osp-director-provisioner-container" \
-      name="osp-director-provisioner-container" \
-      version="1.0.0"
+### DO NOT EDIT LINES BELOW
+# Auto generated using CI tools from
+# https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+
+# Labels required by upstream and osbs build system
+LABEL com.redhat.component="${IMAGE_COMPONENT}" \
+      name="${IMAGE_NAME}" \
+      version="${IMAGE_VERSION}" \
+      summary="${IMAGE_SUMMARY}" \
+      io.k8s.name="${IMAGE_NAME}" \
+      io.k8s.description="${IMAGE_DESC}" \
+      io.openshift.tags="${IMAGE_TAGS}"
+### DO NOT EDIT LINES ABOVE
 
 WORKDIR /
 

--- a/containers/image_downloader/Dockerfile
+++ b/containers/image_downloader/Dockerfile
@@ -1,6 +1,6 @@
-ARG IMAGE_DOWNLOADER_BASE=centos:centos7
+ARG BASE_IMAGE=centos:centos7
 
-FROM ${IMAGE_DOWNLOADER_BASE} as build
+FROM $BASE_IMAGE
 
 ARG PKG_CMD=yum
 ARG REMOTE_SOURCE=
@@ -10,16 +10,29 @@ ARG ENTRYPOINT_PATH=entrypoint.sh
 
 RUN ${PKG_CMD} install -y qemu-img
 
-LABEL   com.redhat.component="osp-director-downloader-container" \
-        name="osp-director-downloader" \
-        version="1.0" \
-        summary="OSP Director Image Downloader" \
-        io.k8s.name="osp director image downloader" \
-        io.k8s.description="This image includes the osp-director-downloader" \
-        io.openshift.tags="cn-openstack openstack"
+ARG IMAGE_COMPONENT="osp-director-downloader-container"
+ARG IMAGE_NAME="osp-director-downloader"
+ARG IMAGE_VERSION="1.0.0"
+ARG IMAGE_SUMMARY="OSP Director Image Downloader"
+ARG IMAGE_DESC="This image includes the osp-director-downloader"
+ARG IMAGE_TAGS="openstack director"
+
+### DO NOT EDIT LINES BELOW
+# Auto generated using CI tools from
+# https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+
+# Labels required by upstream and osbs build system
+LABEL com.redhat.component="${IMAGE_COMPONENT}" \
+      name="${IMAGE_NAME}" \
+      version="${IMAGE_VERSION}" \
+      summary="${IMAGE_SUMMARY}" \
+      io.k8s.name="${IMAGE_NAME}" \
+      io.k8s.description="${IMAGE_DESC}" \
+      io.openshift.tags="${IMAGE_TAGS}"
+### DO NOT EDIT LINES ABOVE
 
 WORKDIR /
 
-COPY ${REMOTE_SOURCE}/${ENTRYPOINT_PATH} /entrypoint.sh
+COPY $REMOTE_SOURCE/$ENTRYPOINT_PATH /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
CI translation of upstream Dockerfiles to downstream
osbs ready ones requires some unification around LABEL
naming and supported ARGS.

dockerfile_to_osbs.sh from openstack-k8s-operators-ci
repository will do the translation properly.