### PR TITLE
Use go 1.15 for github actions

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.16.x]
         os: [ubuntu-latest]
 
     name: govet, golint and gotest
@@ -34,7 +34,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.16.x]
         os: [ubuntu-latest]
 
     name: golangci


### PR DESCRIPTION
Move to go 1.15 for github actions from 1.14.