### PR TITLE
Revert "Use go 1.15 for github actions (#422)"

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.14.x]
         os: [ubuntu-latest]
 
     name: govet, golint and gotest
@@ -34,7 +34,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.14.x]
         os: [ubuntu-latest]
 
     name: golangci


### PR DESCRIPTION
This reverts commit 7bd4c80b8449d6ca8293e339467aa9aaf8cd9683.