### PR TITLE
Update CI job to use 1.16 without changing job names

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -4,19 +4,14 @@ on: [push, pull_request]
 
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.14.x]
-        os: [ubuntu-latest]
-
-    name: govet, golint and gotest
-    runs-on: ${{ matrix.os }}
-
+    #FIXME: Remove the 1.14... here once we update https://github.com/openshift/release/blob/master/core-services/prow/02_config/openstack-k8s-operators/osp-director-operator/_prowconfig.yaml#L10-L11 
+    name: govet, golint and gotest (1.14.x, ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.16.x
       - name: Checkout project code
         uses: actions/checkout@v2
       - name: Checkout openstack-k8s-operators-ci project
@@ -32,19 +27,14 @@ jobs:
         run: ./openstack-k8s-operators-ci/test-runner/gotest.sh
 
   golangci:
-    strategy:
-      matrix:
-        go-version: [1.14.x]
-        os: [ubuntu-latest]
-
-    name: golangci
-    runs-on: ${{ matrix.os }}
-
+    #FIXME: Remove the 1.14... here once we update https://github.com/openshift/release/blob/master/core-services/prow/02_config/openstack-k8s-operators/osp-director-operator/_prowconfig.yaml#L10-L11 
+    name: golangci (1.14.x, ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.16.x
       - name: Checkout project code
         uses: actions/checkout@v2
       - name: Run golangci lint


### PR DESCRIPTION
The job names in prow are hard coded like this:
 - govet, golint and gotest (1.14.x, ubuntu-latest)
 - golangci (1.14.x, ubuntu-latest)

This is because matrix is being appended to the custom job names.
I might suggest we drop the use of matrix in the future and just
hard code the parameters which gives us more control without
requiring updates to openshift/release.