### PR TITLE
Bump ctrl-gen version for OpSDK 1.13.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ CI_TOOLS_REPO := https://github.com/openstack-k8s-operators/openstack-k8s-operat
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
-# Produce CRDs with apiextensions.k8s.io/v1
-CRD_OPTIONS ?= "crd:crdVersions=v1"
+# Produce CRDs with apiextensions.k8s.io/v1 and generate embedded metadata
+CRD_OPTIONS ?= "crd:crdVersions=v1,generateEmbeddedObjectMeta=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -121,7 +121,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/api/v1beta1/openstackbaremetalset_webhook.go
+++ b/api/v1beta1/openstackbaremetalset_webhook.go
@@ -44,7 +44,7 @@ func (r *OpenStackBaremetalSet) SetupWebhookWithManager(mgr ctrl.Manager) error 
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-osp-director-openstack-org-v1beta1-openstackbaremetalset,mutating=false,failurePolicy=fail,groups=osp-director.openstack.org,resources=openstackbaremetalsets,versions=v1beta1,name=vopenstackbaremetalset.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-osp-director-openstack-org-v1beta1-openstackbaremetalset,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackbaremetalsets,versions=v1beta1,name=vopenstackbaremetalset.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &OpenStackBaremetalSet{}
 

--- a/api/v1beta1/openstackcontrolplane_webhook.go
+++ b/api/v1beta1/openstackcontrolplane_webhook.go
@@ -46,7 +46,7 @@ func (r *OpenStackControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error 
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-osp-director-openstack-org-v1beta1-openstackcontrolplane,mutating=false,failurePolicy=fail,groups=osp-director.openstack.org,resources=openstackcontrolplanes,versions=v1beta1,name=vopenstackcontrolplane.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-osp-director-openstack-org-v1beta1-openstackcontrolplane,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackcontrolplanes,versions=v1beta1,name=vopenstackcontrolplane.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &OpenStackControlPlane{}
 

--- a/api/v1beta1/openstackephemeralheat_webhook.go
+++ b/api/v1beta1/openstackephemeralheat_webhook.go
@@ -37,7 +37,7 @@ func (r *OpenStackEphemeralHeat) SetupWebhookWithManager(mgr ctrl.Manager) error
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstackephemeralheat,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackephemeralheats,verbs=create;update,versions=v1beta1,name=mopenstackephemeralheat.kb.io
+// +kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstackephemeralheat,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackephemeralheats,verbs=create;update,versions=v1beta1,name=mopenstackephemeralheat.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &OpenStackEphemeralHeat{}
 

--- a/api/v1beta1/openstacknet_webhook.go
+++ b/api/v1beta1/openstacknet_webhook.go
@@ -42,7 +42,7 @@ func (r *OpenStackNet) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstacknet,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstacknets,verbs=create;update,versions=v1beta1,name=mopenstacknet.kb.io
+//+kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstacknet,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstacknets,verbs=create;update,versions=v1beta1,name=mopenstacknet.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &OpenStackNet{}
 
@@ -61,7 +61,7 @@ func (r *OpenStackNet) Default() {
 	}
 }
 
-//+kubebuilder:webhook:path=/validate-osp-director-openstack-org-v1beta1-openstacknet,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstacknets,verbs=create;update,versions=v1beta1,name=vopenstacknet.kb.io
+//+kubebuilder:webhook:path=/validate-osp-director-openstack-org-v1beta1-openstacknet,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstacknets,verbs=create;update,versions=v1beta1,name=vopenstacknet.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &OpenStackNet{}
 

--- a/api/v1beta1/openstackprovisionserver_webhook.go
+++ b/api/v1beta1/openstackprovisionserver_webhook.go
@@ -44,7 +44,7 @@ func (r *OpenStackProvisionServer) SetupWebhookWithManager(mgr ctrl.Manager) err
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-osp-director-openstack-org-v1beta1-openstackprovisionserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackprovisionservers,verbs=create;update,versions=v1beta1,name=vopenstackprovisionserver.kb.io
+//+kubebuilder:webhook:path=/validate-osp-director-openstack-org-v1beta1-openstackprovisionserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackprovisionservers,verbs=create;update,versions=v1beta1,name=vopenstackprovisionserver.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &OpenStackProvisionServer{}
 

--- a/api/v1beta1/openstackvmset_webhook.go
+++ b/api/v1beta1/openstackvmset_webhook.go
@@ -42,7 +42,7 @@ func (r *OpenStackVMSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-osp-director-openstack-org-v1beta1-openstackvmset,mutating=false,failurePolicy=fail,groups=osp-director.openstack.org,resources=openstackvmsets,versions=v1beta1,name=vopenstackvmset.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-osp-director-openstack-org-v1beta1-openstackvmset,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackvmsets,versions=v1beta1,name=vopenstackvmset.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &OpenStackVMSet{}
 

--- a/config/crd/bases/osp-director.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbaremetalsets.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackbaremetalsets.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackclients.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackconfigversions.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackcontrolplanes.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackephemeralheats.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackephemeralheats.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackephemeralheats.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackipsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackipsets.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackipsets.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackmacaddresses.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackmacaddresses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackmacaddresses.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstacknets.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackplaybookgenerators.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackplaybookgenerators.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackplaybookgenerators.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackprovisionservers.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: openstackvmsets.osp-director.openstack.org
 spec:

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,6 +1,6 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,13 +1,15 @@
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -25,8 +27,10 @@ webhooks:
     resources:
     - openstackephemeralheats
   sideEffects: None
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -46,14 +50,16 @@ webhooks:
   sideEffects: None
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -70,8 +76,11 @@ webhooks:
     - UPDATE
     resources:
     - openstackbaremetalsets
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -88,8 +97,11 @@ webhooks:
     - UPDATE
     resources:
     - openstackcontrolplanes
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -107,8 +119,10 @@ webhooks:
     resources:
     - openstacknets
   sideEffects: None
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -126,8 +140,10 @@ webhooks:
     resources:
     - openstackprovisionservers
   sideEffects: None
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -144,3 +160,4 @@ webhooks:
     - UPDATE
     resources:
     - openstackvmsets
+  sideEffects: None


### PR DESCRIPTION
Updates to make operator SDK 1.13.1 function properly with our existing operator config and code