### PR TITLE
Configure IPA client on openstackclient pod

### DIFF
--- a/api/v1beta1/openstackclient_types.go
+++ b/api/v1beta1/openstackclient_types.go
@@ -58,6 +58,9 @@ type OpenStackClientSpec struct {
 	// Upstream DNS servers
 	DNSServers       []string `json:"dnsServers,omitempty"`
 	DNSSearchDomains []string `json:"dnsSearchDomains,omitempty"`
+
+	// Idm secret used to register openstack client in IPA
+	IdmSecret string `json:"idmSecret,omitempty"`
 }
 
 // OpenStackClientStatus defines the observed state of OpenStackClient

--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -76,6 +76,9 @@ type OpenStackControlPlaneSpec struct {
 	// +kubebuilder:validation:Enum={"train","wallaby","16.2","17.0"}
 	// OpenStackRelease to overwrite OSPrelease auto detection from tripleoclient container image
 	OpenStackRelease string `json:"openStackRelease"`
+
+	// Idm secret used to register openstack client in IPA
+	IdmSecret string `json:"idmSecret,omitempty"`
 }
 
 // OpenStackVirtualMachineRoleSpec - defines the desired state of VMs

--- a/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
@@ -63,6 +63,9 @@ spec:
                   playbooks into the openstackclient pod. This secret should contain
                   an entry for both 'git_url' and 'git_ssh_identity'
                 type: string
+              idmSecret:
+                description: Idm secret used to register openstack client in IPA
+                type: string
               imageURL:
                 description: Name of the image
                 type: string

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -83,6 +83,9 @@ spec:
                 description: GitSecret used to pull playbooks into the openstackclient
                   pod
                 type: string
+              idmSecret:
+                description: Idm secret used to register openstack client in IPA
+                type: string
               openStackClientImageURL:
                 description: OpenstackClient image
                 type: string

--- a/pkg/openstackclient/const.go
+++ b/pkg/openstackclient/const.go
@@ -34,6 +34,8 @@ const (
 	HostsPersistentStorageSize = "1G"
 	// CloudAdminPersistentStorageSize - size in GB
 	CloudAdminPersistentStorageSize = "4G"
+	// KollaSrcPersistentStorageSize - size in GB
+	KollaSrcPersistentStorageSize = "1G"
 	// Count - openstackclient count is atm fixed to 1
 	Count = 1
 	// Role - openstackclient has not tripleo role, set it as const

--- a/pkg/openstackclient/volumes.go
+++ b/pkg/openstackclient/volumes.go
@@ -50,6 +50,16 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volu
 			SubPath:   "tripleo-deploy.sh",
 			ReadOnly:  true,
 		},
+		{
+			Name:      "kolla-config",
+			MountPath: "/var/lib/kolla/config_files",
+			ReadOnly:  true,
+		},
+		{
+			Name:      fmt.Sprintf("%s-kolla-src", instance.Name),
+			MountPath: "/var/lib/kolla/src",
+			ReadOnly:  true,
+		},
 	}
 
 	if instance.Spec.DeploymentSSHSecret != "" {
@@ -86,6 +96,16 @@ func GetInitVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.
 			Name:      "root-ssh",
 			MountPath: "/root/.ssh",
 			ReadOnly:  false,
+		},
+		{
+			Name:      fmt.Sprintf("%s-kolla-src", instance.Name),
+			MountPath: "/var/lib/kolla/src",
+			ReadOnly:  false,
+		},
+		{
+			Name:      "kolla-config-init",
+			MountPath: "/var/lib/kolla/config_files",
+			ReadOnly:  true,
 		},
 	}
 
@@ -171,6 +191,48 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: fmt.Sprintf("%s-cloud-admin", instance.Name),
+				},
+			},
+		},
+		{
+			Name: fmt.Sprintf("%s-kolla-src", instance.Name),
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: fmt.Sprintf("%s-kolla-src", instance.Name),
+				},
+			},
+		},
+		{
+			Name: "kolla-config-init",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: &config0644AccessMode,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "openstackclient-sh",
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "kolla_config_init.json",
+							Path: "config.json",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "kolla-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: &config0644AccessMode,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "openstackclient-sh",
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "kolla_config.json",
+							Path: "config.json",
+						},
+					},
 				},
 			},
 		},

--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -24,15 +24,6 @@ fi
 # if the pvc is an empty volume, copy the existing hosts file to it
 if [ ! -f /mnt/etc/hosts ]; then
   cp /etc/hosts /mnt/etc/
-
-  # Ensure hostname -f and python socket.getfqdn() return the FQDN
-  if [ -v FQDN ]; then
-    SHORT_HOSTNAME=$(hostname -s)
-    LONG_HOSTNAME=$(hostname -f)
-    if [ "$LONG_HOSTNAME" != "$FQDN" ]; then
-      sed -i -e "s/^\([0-9.]\+\)\s\+\(.*\)${SHORT_HOSTNAME}\$/\1\t\2${FQDN} ${SHORT_HOSTNAME}/" /mnt/etc/hosts
-    fi
-  fi
 fi
 
 mkdir -p /home/cloud-admin/tripleo-deploy/validations
@@ -68,4 +59,60 @@ EOF
 
   git config --global user.email "dev@null.io"
   git config --global user.name "OSP Director Operator"
+fi
+
+
+# Skip the rest on tempest pod
+if cat /etc/hostname | grep ^tempest 2>&1 > /dev/null; then exit 0; fi
+
+if [ "$IPA_SERVER" != "" -a ! -f /var/lib/ipa-client/sysrestore/sysrestore.index ]; then
+
+  # Ensure hostname is correct for ipa-client install
+  sudo bash -c "cat /mnt/etc/hostname > /etc/hostname"
+  # Ensure hostname -f and python socket.getfqdn() return the FQDN
+  SHORT_HOSTNAME=$(hostname -s)
+  LONG_HOSTNAME=$(hostname -f)
+  if [ "$LONG_HOSTNAME" != "$FQDN" ]; then
+    sed -i -e "s/^\([0-9.]\+\)\s\+\(.*\)${SHORT_HOSTNAME}\$/\1\t\2${FQDN} ${SHORT_HOSTNAME}/" /mnt/etc/hosts
+    sudo bash -c "cat /mnt/etc/hosts > /etc/hosts"
+  fi
+
+  cat <<EOF > /home/cloud-admin/openstackclient_ipa_install.yaml
+{{`---
+- hosts: localhost
+  become: true
+  environment:
+    IPA_USER: "{{ ipa_server_user }}"
+    IPA_HOST: "{{ ipa_server_hostname }}"
+    IPA_PASS: "{{ ipa_server_password }}"
+  vars:
+    undercloud_fqdn: "{{ lookup('env', 'FQDN') }}"
+    ipa_server_password: "{{ lookup('env', 'IPA_SERVER_PASSWORD') }}"
+    ipa_domain: "{{ lookup('env', 'IPA_DOMAIN') }}"
+  tasks:
+    - name: IPA Client install
+      command: "ipa-client-install -U --force-join --no-ntp --no-nisdomain --no-sshd --no-ssh --no-sudo --no-dns-sshfp --principal='{{ ipa_server_user }}' --domain='{{ ipa_domain }}' --realm='{{ ipa_realm }}' --server '{{ ipa_server_hostname }}'"
+      args:
+        stdin: "{{ ipa_server_password }}"
+    - name: Disable sssd
+      command: "authselect select minimal"
+    - name: kinit to get admin credentials
+      command: kinit "{{ ipa_server_user }}@{{ ipa_realm }}"
+      args:
+        stdin: "{{ ipa_server_password }}"
+      register: kinit
+      changed_when: kinit.rc == 0
+      no_log: true
+
+    - name: setup the undercloud and get keytab
+      include_role:
+        name: tripleo_ipa_setup
+EOF`}}
+
+  sudo touch /run/ipa-epoch
+  ansible-playbook -e ipa_server_user=${IPA_SERVER_USER} -e ipa_realm=${IPA_REALM} -e ipa_server_hostname=${IPA_SERVER} -e ipa_domain=${IPA_DOMAIN} /home/cloud-admin/openstackclient_ipa_install.yaml
+
+  # Add all files modified by ipa client install to kolla src
+  # TODO: could use overlayfs mounts instead?
+  sudo bash -c 'find /etc/krb5* /etc/sssd /etc/authselect /etc/novajoin /etc/openldap /etc/ipa /etc/pki /var/lib/ipa-client /var/lib/authselect /var/log/ipaclient-install.log -newer /run/ipa-epoch -print0 | tar -c --null -T - | tar -C /var/lib/kolla/src -xvf -'
 fi

--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -62,9 +62,6 @@ EOF
 fi
 
 
-# Skip the rest on tempest pod
-if cat /etc/hostname | grep ^tempest 2>&1 > /dev/null; then exit 0; fi
-
 if [ "$IPA_SERVER" != "" -a ! -f /var/lib/ipa-client/sysrestore/sysrestore.index ]; then
 
   # Ensure hostname is correct for ipa-client install

--- a/templates/openstackclient/bin/kolla_config.json
+++ b/templates/openstackclient/bin/kolla_config.json
@@ -1,0 +1,13 @@
+{
+    "command": "/bin/sleep infinity",
+
+    "config_files": [
+        {
+            "source": "/var/lib/kolla/src/*",
+            "dest": "/",
+            "merge": true,
+            "preserve_properties": true,
+            "optional": true
+        }
+    ]
+}

--- a/templates/openstackclient/bin/kolla_config_init.json
+++ b/templates/openstackclient/bin/kolla_config_init.json
@@ -1,0 +1,12 @@
+{
+    "command": "/usr/local/bin/init.sh",
+    "config_files": [
+        {
+            "source": "/var/lib/kolla/src/*",
+            "dest": "/",
+            "merge": true,
+            "preserve_properties": true,
+            "optional": true
+        }
+    ]
+}


### PR DESCRIPTION
Add secret to pass IPA config and admin creds to configure IPA client on
openstackclient pod.
Use kolla-config to persist files created/modified by IPA client install.