### PR TITLE
Use lowercase role names to get VMs for fence CM generation

### DIFF
--- a/controllers/openstackplaybookgenerator_controller.go
+++ b/controllers/openstackplaybookgenerator_controller.go
@@ -240,7 +240,7 @@ func (r *OpenStackPlaybookGeneratorReconciler) Reconcile(ctx context.Context, re
 			if common.StringInSlice(roleParams.RoleName, fencingRoles) && roleParams.RoleCount == 3 {
 				// Get the associated VM instances
 				virtualMachineInstanceList, err := common.GetVirtualMachineInstances(r, instance.Namespace, map[string]string{
-					common.OwnerNameLabelSelector: roleName,
+					common.OwnerNameLabelSelector: strings.ToLower(roleName),
 				})
 
 				if err != nil {


### PR DESCRIPTION
Role names for VMs belonging to `OsVMSets` for `OsControlPlanes` are ultimately stored as a lowercase label value in the child `VirtualMachineInstance` resources.  This might have changed in the past month or so, as we used to query against the capitalized role name for fencing data generation purposes (and it worked).  Anyhow, using lowercase role names fixes the problem and allows proper fencing config YAML generation.