### PR TITLE
Use github action to build osp-director-operator images

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+CLUSTER_BUNDLE_FILE="bundle/manifests/osp-director-operator.clusterserviceversion.yaml"
+
+echo "Creating OSP director operator bundle"
+cd ..
+echo "${GITHUB_SHA}"
+echo "${BASE_IMAGE}"
+skopeo --version
+
+echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
+DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
+# Output: 
+# Calculating image digest for docker://quay.io/openstack-k8s-operators/osp-director-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
+# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
+echo "Digest: ${DIGEST}"
+
+RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
+OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
+
+echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
+echo "Release Version: $RELEASE_VERSION"
+
+echo "Creating bundle image..."
+VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
+
+echo "Applying work-arounds..."
+sed -i '/^    webhookPath:.*/a #added\n    containerPort: 4343\n    targetPort: 4343' "${CLUSTER_BUNDLE_FILE}"
+sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controller-manager/g' "${CLUSTER_BUNDLE_FILE}"
+
+# We do not want to exit here. Some images are in different registries, so
+# error will be reported to the console.
+set +e
+for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
+  digest_image=""
+  base_image=$(echo $csv_image | cut -f 1 -d':')
+  tag_image=$(echo $csv_image | cut -f 2 -d':')
+  digest_image=$(skopeo inspect docker://$base_image:$tag_image | jq '.Digest' -r)
+  if [ ! -z "$digest_image" ]; then
+    echo "Base image: $base_image"
+    echo "$base_image:$tag_image becomes $base_image@$digest_image"
+    sed -i "s|$base_image:$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
+  fi
+done

--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -1,0 +1,148 @@
+name: OSP Director Operator image builder
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - .gitignore
+      - .pull_request_pipeline
+      - changelog.txt
+      - kuttl-test.yaml
+      - LICENSE
+      - Makefile
+      - OWNERS
+      - PROJECT
+      - README.md
+      - .github/
+      - build/
+      - docs/
+      - tests/
+
+jobs:
+  build-osp-director-operator:
+    name: Build osp-director-operator image using buildah
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Buildah Action
+      id: build-osp-director-operator
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: osp-director-operator
+        tags: latest ${{ github.sha }}
+        containerfiles: |
+          ./Dockerfile
+
+    - name: Push osp-director-operator To Quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-osp-director-operator.outputs.image }}
+        tags: ${{ steps.build-osp-director-operator.outputs.tags }}
+        registry: quay.io/openstack-k8s-operators
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+  build-osp-director-downloader:
+    name: Build rhel-downloader image using buildah
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Buildah Action
+      id: build-osp-director-downloader
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: rhel-downloader
+        tags: latest ${{ github.sha }}
+        containerfiles: |
+          ./containers/image_downloader/Dockerfile
+        build-args: |
+          REMOTE_SOURCE=containers/image_downloader
+
+    - name: Push rhel-downloader To Quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-osp-director-downloader.outputs.image }}
+        tags: ${{ steps.build-osp-director-downloader.outputs.tags }}
+        registry: quay.io/openstack-k8s-operators
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+  build-osp-director-provisioner:
+    name: Build provision-ip-discovery-agent image using buildah
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Buildah Action
+      id: build-osp-director-provisioner
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: provision-ip-discovery-agent
+        tags: latest ${{ github.sha }}
+        containerfiles: |
+          ./Dockerfile.provision-ip-discovery-agent
+
+    - name: Push provision-ip-discovery-agent To Quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-osp-director-provisioner.outputs.image }}
+        tags: ${{ steps.build-osp-director-provisioner.outputs.tags }}
+        registry: quay.io/openstack-k8s-operators
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+  build-osp-director-operator-bundle:
+    needs: [ build-osp-director-operator, build-osp-director-downloader, build-osp-director-provisioner ]
+    name: osp-director-operator-bundle
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout osp-director-operator repository
+      uses: actions/checkout@v2
+
+    - name: Install operator-sdk
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        operator-sdk: 'latest'
+
+    - name: Log in to Red Hat Registry
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Create bundle image
+      run: |
+        pushd "${GITHUB_WORKSPACE}"/.github/
+        chmod +x "create_bundle.sh"
+        "./create_bundle.sh"
+        popd
+      env:
+        REGISTRY: quay.io/openstack-k8s-operators
+        GITHUB_SHA: ${{ github.sha }}
+        BASE_IMAGE: osp-director-operator
+
+    - name: Build osp-director-operator-bundle using buildah
+      id: build-osp-director-operator-bundle
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: osp-director-operator-bundle
+        tags: latest ${{ github.sha }}
+        containerfiles: |
+          ./bundle.Dockerfile
+
+    - name: Push osp-director-operator To Quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-osp-director-operator-bundle.outputs.image }}
+        tags: ${{ steps.build-osp-director-operator-bundle.outputs.tags }}
+        registry: quay.io/openstack-k8s-operators
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Red Hat github action is used to build osp-director-operator
images:
  - osp-director-operator
  - rhel-downloader
  - provision-ip-discovery-agent
  - osp-director-operator-bundle

The images are tagged with the sha and latest.