### PR TITLE
[OSPK8-324 OSPK8-325] DeployedNetworkEnvironment and CtlplaneNetworkAttributes

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -57,8 +57,8 @@ resources:
   path: github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1
   version: v1beta1
   webhooks:
-    validation: true
     defaulting: true
+    validation: true
     webhookVersion: v1
 - controller: true
   domain: openstack.org
@@ -117,6 +117,10 @@ resources:
   kind: OpenStackNetConfig
   path: github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1
   version: v1beta1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
                 state: up
                 type: linux-bridge
                 mtu: 1500
+      # optional DnsServers list
+      dnsServers:
+      - 192.168.25.1
+      # optional DnsSearchDomains list
+      dnsSearchDomains:
+      - osptest.test.metalkube.org
+      - some.other.domain
+      # DomainName of the OSP environment
+      domainName: osptest.test.metalkube.org
       networks:
       - name: Control
         nameLower: ctlplane
@@ -209,6 +218,15 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
                 state: up
                 type: linux-bridge
                 mtu: 1500
+      # optional DnsServers list
+      dnsServers:
+      - 192.168.25.1
+      # optional DnsSearchDomains list
+      dnsSearchDomains:
+      - osptest.test.metalkube.org
+      - some.other.domain
+      # DomainName of the OSP environment
+      domainName: osptest.test.metalkube.org
       networks:
       - name: Control
         nameLower: ctlplane
@@ -920,6 +938,15 @@ spec:
             state: up
             type: linux-bridge
             mtu: 1500
+  # optional DnsServers list
+  dnsServers:
+  - 192.168.25.1
+  # optional DnsSearchDomains list
+  dnsSearchDomains:
+  - osptest.test.metalkube.org
+  - some.other.domain
+  # DomainName of the OSP environment
+  domainName: osptest.test.metalkube.org
   networks:
   - name: Control
     nameLower: ctlplane

--- a/api/v1beta1/openstacknet_types.go
+++ b/api/v1beta1/openstacknet_types.go
@@ -43,11 +43,11 @@ type Route struct {
 type OpenStackNetSpec struct {
 
 	// +kubebuilder:validation:Required
-	// Name of the tripleo network this network belongs to, e.g. External, InternalApi, ...
+	// Name of the tripleo network this network belongs to, e.g. Control, External, InternalApi, ...
 	Name string `json:"name"`
 
 	// +kubebuilder:validation:Required
-	// NameLower the name of the subnet, name_lower name of the tripleo subnet, e.g. external, internal_api, internal_api_leaf1
+	// NameLower the name of the subnet, name_lower name of the tripleo subnet, e.g. ctlplane, external, internal_api, internal_api_leaf1
 	NameLower string `json:"nameLower"`
 
 	// +kubebuilder:validation:Required
@@ -87,6 +87,10 @@ type OpenStackNetSpec struct {
 	// +kubebuilder:validation:Required
 	// AttachConfiguration, used for virtual machines to attach to this network
 	AttachConfiguration string `json:"attachConfiguration"`
+
+	// +kubebuilder:validation:Required
+	// DomainName the name of the domain for this network, usually lower(Name)."OSNetConfig.Spec.DomainName"
+	DomainName string `json:"domainName"`
 }
 
 // OpenStackNetRoleStatus defines the observed state of the Role Net status
@@ -134,6 +138,7 @@ const (
 // +kubebuilder:resource:shortName=osnet;osnets
 // +operator-sdk:csv:customresourcedefinitions:displayName="OpenStack Net"
 // +kubebuilder:printcolumn:name="CIDR",type=string,JSONPath=`.spec.cidr`
+// +kubebuilder:printcolumn:name="DOMAIN",type=string,JSONPath=`.spec.domainName`
 // +kubebuilder:printcolumn:name="MTU",type=string,JSONPath=`.spec.mtu`
 // +kubebuilder:printcolumn:name="VLAN",type=string,JSONPath=`.spec.vlan`
 // +kubebuilder:printcolumn:name="VIP",type=boolean,JSONPath=`.spec.vip`

--- a/api/v1beta1/openstacknet_webhook.go
+++ b/api/v1beta1/openstacknet_webhook.go
@@ -22,6 +22,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -46,9 +49,18 @@ var _ webhook.Defaulter = &OpenStackNet{}
 func (r *OpenStackNet) Default() {
 	openstacknetlog.Info("default", "name", r.Name)
 
+	//
 	// The OpenStackNet "XYZ" is invalid: spec.routes: Invalid value: "null": spec.routes in body must be of type array: "null"
+	//
 	if r.Spec.Routes == nil {
 		r.Spec.Routes = []Route{}
+	}
+
+	//
+	// The default domain name if non specified
+	//
+	if r.Spec.DomainName == "" {
+		r.Spec.DomainName = fmt.Sprintf("%s.%s", strings.ToLower(r.Spec.Name), DefaultDomainName)
 	}
 }
 

--- a/api/v1beta1/openstacknetconfig_types.go
+++ b/api/v1beta1/openstacknetconfig_types.go
@@ -20,6 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// ControlPlaneName -
+	ControlPlaneName string = "Control"
+	// ControlPlaneNameLower -
+	ControlPlaneNameLower string = "ctlplane"
+	// DefaultDomainName -
+	DefaultDomainName string = "localdomain"
+)
+
 // NetDetails of a subnet
 type NetDetails struct {
 	// +kubebuilder:validation:Required
@@ -78,6 +87,11 @@ type Network struct {
 	NameLower string `json:"nameLower"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// IsControlPlane indicates if this network is the overcloud control plane network
+	IsControlPlane bool `json:"isControlPlane"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1500
 	// MTU of the network
 	MTU int `json:"mtu"`
@@ -99,17 +113,26 @@ type OpenStackNetConfigSpec struct {
 	// AttachConfigurations used for NodeNetworkConfigurationPolicy or NodeSriovConfigurationPolicy
 	AttachConfigurations map[string]NodeConfigurationPolicy `json:"attachConfigurations"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=localdomain
+	// DomainName the name of the dns domain for the OSP environment
+	DomainName string `json:"domainName"`
+
+	// +kubebuilder:validation:Optional
+	// DNSServers, list of dns servers
+	DNSServers []string `json:"dnsServers"`
+
+	// +kubebuilder:validation:Optional
+	// DNSSearchDomains, list of DNS search domains
+	DNSSearchDomains []string `json:"dnsSearchDomains,omitempty"`
+
+	// +kubebuilder:validation:Required
 	// Networks, list of all tripleo networks of the deployment
 	Networks []Network `json:"networks"`
 }
 
 // OpenStackNetConfigStatus defines the observed state of OpenStackNetConfig
 type OpenStackNetConfigStatus struct {
-	// CurrentState - the overall state of this network
-	//CurrentState NetConfigState `json:"currentState"`
-
-	// TODO: It would be simpler, perhaps, to just have Conditions and get rid of CurrentState,
-	// but we are using the same approach in other CRDs for now anyhow
 	// Conditions - conditions to display in the OpenShift GUI, which reflect CurrentState
 	Conditions         ConditionList                        `json:"conditions,omitempty" optional:"true"`
 	ProvisioningStatus OpenStackNetConfigProvisioningStatus `json:"provisioningStatus,omitempty"`

--- a/api/v1beta1/openstacknetconfig_webhook.go
+++ b/api/v1beta1/openstacknetconfig_webhook.go
@@ -1,0 +1,140 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var openstacknetconfiglog = logf.Log.WithName("openstacknetconfig-resource")
+
+// SetupWebhookWithManager - register this webhook with the controller manager
+func (r *OpenStackNetConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstacknetconfig,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstacknetconfigs,verbs=create;update,versions=v1beta1,name=mopenstacknetconfig.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-osp-director-openstack-org-v1beta1-openstackprovisionserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackprovisionservers,verbs=create;update,versions=v1beta1,name=vopenstackprovisionserver.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Defaulter = &OpenStackNetConfig{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *OpenStackNetConfig) Default() {
+	openstacknetconfiglog.Info("default", "name", r.Name)
+
+	for netIdx := range r.Spec.Networks {
+		//
+		// Auto flag IsControlPlane if Name and NameLower matches ControlPlane network names
+		//
+		if r.Spec.Networks[netIdx].Name == ControlPlaneName && r.Spec.Networks[netIdx].NameLower == ControlPlaneNameLower {
+			r.Spec.Networks[netIdx].IsControlPlane = true
+		}
+
+		//
+		// The OpenStackNetConfig "XYZ" is invalid: spec.routes: Invalid value: "null": spec.routes in body must be of type array: "null"
+		//
+		for subnetIdx := range r.Spec.Networks[netIdx].Subnets {
+			if r.Spec.Networks[netIdx].Subnets[subnetIdx].IPv4.Routes == nil {
+				r.Spec.Networks[netIdx].Subnets[subnetIdx].IPv4.Routes = []Route{}
+			}
+			if r.Spec.Networks[netIdx].Subnets[subnetIdx].IPv6.Routes == nil {
+				r.Spec.Networks[netIdx].Subnets[subnetIdx].IPv6.Routes = []Route{}
+			}
+		}
+	}
+
+	//
+	// The default domain name if non specified
+	//
+	if r.Spec.DomainName == "" {
+		r.Spec.DomainName = DefaultDomainName
+	}
+
+	//
+	//  spec.dnsServers in body must be of type array
+	//
+	if r.Spec.DNSServers == nil {
+		r.Spec.DNSServers = []string{}
+	}
+
+	//
+	//  spec.dnsSearchDomains in body must be of type array
+	//
+	if r.Spec.DNSSearchDomains == nil {
+		r.Spec.DNSSearchDomains = []string{}
+	}
+}
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-osp-director-openstack-org-v1beta1-openstacknetconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstacknetconfigs,verbs=create;update,versions=v1beta1,name=vopenstacknetconfig.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Validator = &OpenStackNetConfig{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *OpenStackNetConfig) ValidateCreate() error {
+	openstacknetconfiglog.Info("validate create", "name", r.Name)
+
+	//
+	// Verify that the specified control plane network name and name_lower match the expected ooo names
+	//
+	err := r.validateControlPlaneNetworkNames()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *OpenStackNetConfig) ValidateUpdate(old runtime.Object) error {
+	openstacknetconfiglog.Info("validate update", "name", r.Name)
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *OpenStackNetConfig) ValidateDelete() error {
+	openstacknetconfiglog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}
+
+// validateControlPlaneNetworkNames - validate that the specified control plane network name and name_lower match the expected ooo names
+func (r *OpenStackNetConfig) validateControlPlaneNetworkNames() error {
+	// Verify that the specified control plane network name and name_lower match the expected ooo names
+	for _, net := range r.Spec.Networks {
+		if net.IsControlPlane {
+			if net.Name != ControlPlaneName {
+				return fmt.Errorf(fmt.Sprintf("control plane network name %s does not match %s", net.Name, ControlPlaneName))
+			}
+			if net.NameLower != ControlPlaneNameLower {
+				return fmt.Errorf(fmt.Sprintf("control plane network name_lower  %s does not match %s", net.NameLower, ControlPlaneNameLower))
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1476,6 +1476,16 @@ func (in *OpenStackNetConfigSpec) DeepCopyInto(out *OpenStackNetConfigSpec) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.DNSServers != nil {
+		in, out := &in.DNSServers, &out.DNSServers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.DNSSearchDomains != nil {
+		in, out := &in.DNSSearchDomains, &out.DNSSearchDomains
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Networks != nil {
 		in, out := &in.Networks, &out.Networks
 		*out = make([]Network, len(*in))

--- a/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
@@ -136,11 +136,30 @@ spec:
                 description: AttachConfigurations used for NodeNetworkConfigurationPolicy
                   or NodeSriovConfigurationPolicy
                 type: object
+              dnsSearchDomains:
+                description: DNSSearchDomains, list of DNS search domains
+                items:
+                  type: string
+                type: array
+              dnsServers:
+                description: DNSServers, list of dns servers
+                items:
+                  type: string
+                type: array
+              domainName:
+                default: localdomain
+                description: DomainName the name of the dns domain for the OSP environment
+                type: string
               networks:
                 description: Networks, list of all tripleo networks of the deployment
                 items:
                   description: Network describes a tripleo network
                   properties:
+                    isControlPlane:
+                      default: false
+                      description: IsControlPlane indicates if this network is the
+                        overcloud control plane network
+                      type: boolean
                     mtu:
                       default: 1500
                       description: MTU of the network
@@ -270,10 +289,8 @@ spec:
             description: OpenStackNetConfigStatus defines the observed state of OpenStackNetConfig
             properties:
               conditions:
-                description: 'TODO: It would be simpler, perhaps, to just have Conditions
-                  and get rid of CurrentState, but we are using the same approach
-                  in other CRDs for now anyhow Conditions - conditions to display
-                  in the OpenShift GUI, which reflect CurrentState'
+                description: Conditions - conditions to display in the OpenShift GUI,
+                  which reflect CurrentState
                 items:
                   description: Condition - A particular overall condition of a certain
                     resource

--- a/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .spec.cidr
       name: CIDR
       type: string
+    - jsonPath: .spec.domainName
+      name: DOMAIN
+      type: string
     - jsonPath: .spec.mtu
       name: MTU
       type: string
@@ -81,6 +84,10 @@ spec:
               cidr:
                 description: Cidr the cidr to use for this network
                 type: string
+              domainName:
+                description: DomainName the name of the domain for this network, usually
+                  lower(Name)."OSNetConfig.Spec.DomainName"
+                type: string
               gateway:
                 description: Gateway optional gateway for the network
                 type: string
@@ -90,11 +97,11 @@ spec:
                 type: integer
               name:
                 description: Name of the tripleo network this network belongs to,
-                  e.g. External, InternalApi, ...
+                  e.g. Control, External, InternalApi, ...
                 type: string
               nameLower:
                 description: NameLower the name of the subnet, name_lower name of
-                  the tripleo subnet, e.g. external, internal_api, internal_api_leaf1
+                  the tripleo subnet, e.g. ctlplane, external, internal_api, internal_api_leaf1
                 type: string
               routes:
                 description: Routes, list of networks that should be routed via network
@@ -125,6 +132,7 @@ spec:
             - allocationStart
             - attachConfiguration
             - cidr
+            - domainName
             - name
             - nameLower
             type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -479,7 +479,13 @@ rules:
   resources:
   - openstacknetconfigs/finalizers
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
+  - watch
 - apiGroups:
   - osp-director.openstack.org
   resources:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -97,6 +97,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-osp-director-openstack-org-v1beta1-openstacknetconfig
+  failurePolicy: Fail
+  name: mopenstacknetconfig.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstacknetconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-osp-director-openstack-org-v1beta1-openstackplaybookgenerator
   failurePolicy: Fail
   name: mopenstackplaybookgenerator.kb.io
@@ -223,6 +244,48 @@ webhooks:
     - UPDATE
     resources:
     - openstacknetattachments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-osp-director-openstack-org-v1beta1-openstackprovisionserver
+  failurePolicy: Fail
+  name: vopenstackprovisionserver.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackprovisionservers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-osp-director-openstack-org-v1beta1-openstacknetconfig
+  failurePolicy: Fail
+  name: vopenstacknetconfig.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstacknetconfigs
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/controllers/openstackipset_controller.go
+++ b/controllers/openstackipset_controller.go
@@ -253,24 +253,11 @@ func (r *OpenStackIPSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	// get all VMset which are tripleo role
-	osVMsetList := &ospdirectorv1beta1.OpenStackVMSetList{}
-	osVMsetListOpts := []client.ListOption{
-		client.InNamespace(instance.Namespace),
-		client.MatchingFields{
-			"spec.isTripleoRole": "true",
-		},
-	}
-	err = r.Client.List(context.TODO(), osVMsetList, osVMsetListOpts...)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// write it all to a configmap
 	envVars := make(map[string]common.EnvSetter)
 	cmLabels := common.GetLabels(instance, openstackipset.AppLabel, map[string]string{})
 
-	templateParameters, rolesMap, err := openstackipset.CreateConfigMapParams(r, *instance, *osNetList, *osMACList)
+	templateParameters, rolesMap, err := openstackipset.CreateConfigMapParams(r, instance, osNetList, osMACList)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -271,27 +271,12 @@ func main() {
 	}
 
 	if enableWebhooks {
-		if err = (&ospdirectorv1beta1.OpenStackBaremetalSet{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackBaremetalSet")
-			os.Exit(1)
-		}
-
+		//
+		// DEFAULTS
+		//
 		openstackControlPlaneDefaults := ospdirectorv1beta1.OpenStackControlPlaneDefaults{
 			OpenStackClientImageURL: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
 			OpenStackRelease:        os.Getenv("OPENSTACK_RELEASE_DEFAULT"),
-		}
-
-		if err = (&ospdirectorv1beta1.OpenStackControlPlane{}).SetupWebhookWithManager(mgr, openstackControlPlaneDefaults); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackControlPlane")
-			os.Exit(1)
-		}
-		if err = (&ospdirectorv1beta1.OpenStackVMSet{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackVMSet")
-			os.Exit(1)
-		}
-		if err = (&ospdirectorv1beta1.OpenStackNet{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackNet")
-			os.Exit(1)
 		}
 
 		ephemeralHeatDefaults := ospdirectorv1beta1.OpenStackEphemeralHeatDefaults{
@@ -300,23 +285,43 @@ func main() {
 			MariaDBImageURL:    os.Getenv("MARIADB_IMAGE_URL_DEFAULT"),
 			RabbitImageURL:     os.Getenv("RABBITMQ_IMAGE_URL_DEFAULT"),
 		}
-		if err = (&ospdirectorv1beta1.OpenStackEphemeralHeat{}).SetupWebhookWithManager(mgr, ephemeralHeatDefaults); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackEphemeralHeat")
-			os.Exit(1)
-		}
 
 		provisionServerDefaults := ospdirectorv1beta1.OpenStackProvisionServerDefaults{
 			DownloaderImageURL:        os.Getenv("DOWNLOADER_IMAGE_URL_DEFAULT"),
 			ProvisioningAgentImageURL: os.Getenv("PROVISIONING_AGENT_IMAGE_URL_DEFAULT"),
 			ApacheImageURL:            os.Getenv("APACHE_IMAGE_URL_DEFAULT"),
 		}
+
+		//
+		// Register webhooks
+		//
+		openstackPlaybookGeneratorDefaults := ospdirectorv1beta1.OpenStackPlaybookGeneratorDefaults{
+			ImageURL: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
+		}
+
+		if err = (&ospdirectorv1beta1.OpenStackBaremetalSet{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackBaremetalSet")
+			os.Exit(1)
+		}
+
+		if err = (&ospdirectorv1beta1.OpenStackEphemeralHeat{}).SetupWebhookWithManager(mgr, ephemeralHeatDefaults); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackEphemeralHeat")
+			os.Exit(1)
+		}
+
 		if err = (&ospdirectorv1beta1.OpenStackProvisionServer{}).SetupWebhookWithManager(mgr, provisionServerDefaults); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackProvisionServer")
 			os.Exit(1)
 		}
 
-		openstackPlaybookGeneratorDefaults := ospdirectorv1beta1.OpenStackPlaybookGeneratorDefaults{
-			ImageURL: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
+		if err = (&ospdirectorv1beta1.OpenStackControlPlane{}).SetupWebhookWithManager(mgr, openstackControlPlaneDefaults); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackControlPlane")
+			os.Exit(1)
+		}
+
+		if err = (&ospdirectorv1beta1.OpenStackVMSet{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackVMSet")
+			os.Exit(1)
 		}
 
 		if err = (&ospdirectorv1beta1.OpenStackPlaybookGenerator{}).SetupWebhookWithManager(mgr, openstackPlaybookGeneratorDefaults); err != nil {
@@ -324,8 +329,18 @@ func main() {
 			os.Exit(1)
 		}
 
+		if err = (&ospdirectorv1beta1.OpenStackNetConfig{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackNetConfig")
+			os.Exit(1)
+		}
+
 		if err = (&ospdirectorv1beta1.OpenStackNetAttachment{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackNetAttachment")
+			os.Exit(1)
+		}
+
+		if err = (&ospdirectorv1beta1.OpenStackNet{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackNet")
 			os.Exit(1)
 		}
 	}

--- a/pkg/common/template_util.go
+++ b/pkg/common/template_util.go
@@ -110,12 +110,20 @@ func add(x, y int) int {
 	return x + y
 }
 
+// template function to lower a string
+func lower(s string) string {
+	return strings.ToLower(s)
+}
+
 // ExecuteTemplateData creates a template from string and
 // execute it with the specified data
 func ExecuteTemplateData(templateData string, data interface{}) string {
 
 	var buff bytes.Buffer
-	funcs := template.FuncMap{"add": add}
+	funcs := template.FuncMap{
+		"add":   add,
+		"lower": lower,
+	}
 	tmpl, err := template.New("tmp").Funcs(funcs).Parse(templateData)
 	if err != nil {
 		panic(err)
@@ -150,7 +158,10 @@ func ExecuteTemplateFile(filename string, data interface{}) string {
 	}
 	file := string(b)
 	var buff bytes.Buffer
-	funcs := template.FuncMap{"add": add}
+	funcs := template.FuncMap{
+		"add":   add,
+		"lower": lower,
+	}
 	tmpl, err := template.New("tmp").Funcs(funcs).Parse(file)
 	if err != nil {
 		panic(err)

--- a/pkg/openstacknet/const.go
+++ b/pkg/openstacknet/const.go
@@ -29,4 +29,6 @@ const (
 	NetworkNameLowerLabelSelector = "ooo-netname-lower"
 	// SubNetNameLabelSelector -
 	SubNetNameLabelSelector = "ooo-subnetname"
+	// ControlPlaneNetworkLabelSelector - is the network a ctlplane network?
+	ControlPlaneNetworkLabelSelector = "ooo-ctlplane-network"
 )

--- a/templates/openstackipset/config/16.2/network_data.yaml
+++ b/templates/openstackipset/config/16.2/network_data.yaml
@@ -1,6 +1,6 @@
 {{- /* golang template - https://pkg.go.dev/text/template */ -}}
 {{- range $netname, $net := .NetworksMap }}
-{{- if ne $net.Name "Control" }}
+{{- if not $net.IsControlPlane }}
 - name: {{ $net.Name }}
   name_lower: {{ $net.NameLower }}
   vip: {{ $net.VIP }}

--- a/templates/openstackipset/config/16.2/rendered-tripleo-config.yaml
+++ b/templates/openstackipset/config/16.2/rendered-tripleo-config.yaml
@@ -19,9 +19,9 @@ resource_registry:
 {{- if and $role.IsVMType $role.IsTripleoRole }}
   OS::TripleO::{{ $role.Name }}::Net::SoftwareConfig: {{ $role.NameLower }}-nic-template.yaml
 {{- end }}
-{{- if ne $role.Name "ControlPlane" }}
+{{- if not $role.IsControlPlane }}
 {{- range $netid, $net := $role.Networks }}
-{{- if ne $net.NameLower "ctlplane" }}
+{{- if not $net.IsControlPlane }}
   OS::TripleO::{{ $role.Name }}::Ports::{{ $net.Name }}Port: network/ports/{{ $net.NameLower }}_from_pool.yaml
 {{- end }}
 {{- end }}
@@ -44,7 +44,7 @@ parameter_defaults:
 {{- range $roleid, $role := .RolesMap }}
 {{- range $nodeid, $node := $role.Nodes }}
 {{- range $netname, $ip := $node.IPaddr }}
-{{- if eq $netname "ctlplane" }}
+{{- if $ip.Network.IsControlPlane }}
 {{- if $node.VIP }}
     control_virtual_ip:
 {{- else }}
@@ -64,7 +64,7 @@ parameter_defaults:
   #
   # Per ctlplane details
 {{- range $netid, $net := .NetworksMap }}
-{{- if eq $net.Name "Control" }}
+{{- if $net.IsControlPlane }}
 {{- if ne $net.DefaultSubnet.IPv4.Cidr "" }}
   ControlPlaneDefaultRoute: {{ $net.DefaultSubnet.IPv4.Gateway }}
   ControlPlaneSubnetCidr: {{ $net.DefaultSubnet.IPv4.CidrSuffix }}
@@ -77,7 +77,7 @@ parameter_defaults:
 {{- range $nodeid, $node := $role.Nodes }}
 {{- range $netname, $ip := $node.IPaddr }}
 {{- if $node.VIP }}
-{{- if eq $netname "ctlplane" }}
+{{- if $ip.Network.IsControlPlane }}
   ControlPlaneIP: {{ $ip.IPaddr }}
 {{- else }}
   {{ with (index $.NetworksMap $netname) }}{{ .Name }}{{ end }}NetworkVip: {{ $ip.IPaddr }}
@@ -89,7 +89,7 @@ parameter_defaults:
   #
   # HostnameFormat and RoleCount
 {{- range $roleid, $role := .RolesMap }}
-{{- if ne $role.Name "ControlPlane" }}
+{{- if not $role.IsControlPlane }}
   {{ $role.Name }}HostnameFormat: "{{ $role.NameLower }}-%index%"
   {{- $roleCount := len $role.Nodes }}
   {{ $role.Name }}Count: {{ $roleCount }}
@@ -100,7 +100,7 @@ parameter_defaults:
   HostnameMap:
 {{- range $roleid, $role := .RolesMap }}
 {{- range $nodeid, $node := $role.Nodes }}
-{{- if and (not $node.VIP) }}
+{{- if not $node.VIP }}
     {{ $role.NameLower }}-{{ $node.Index }}: {{ $node.Hostname }}
 {{- end }}
 {{- end }}
@@ -108,14 +108,14 @@ parameter_defaults:
   #
   # ips-from-pool
 {{- range $roleid, $role := .RolesMap }}
-{{- if ne $role.Name "ControlPlane" }}
+{{- if not $role.IsControlPlane }}
   {{ $role.Name }}IPs:
-{{- range $networkid, $network := $role.Networks }}
-{{- if ne $network.NameLower "ctlplane" }}
-      {{ $network.NameLower }}:
+{{- range $netid, $net := $role.Networks }}
+{{- if not $net.IsControlPlane }}
+      {{ $net.NameLower }}:
 {{- range $nodeid, $node := $role.Nodes }}
 {{- range $netname, $ip := $node.IPaddr }}
-{{- if eq $ip.Network.Cidr $network.Cidr }}
+{{- if eq $ip.Network.Cidr $net.Cidr }}
         - {{ $ip.IPaddr }}
 {{- end }}
 {{- end }}

--- a/templates/openstackipset/config/17.0/network_data.yaml
+++ b/templates/openstackipset/config/17.0/network_data.yaml
@@ -1,15 +1,11 @@
 {{- /* golang template - https://pkg.go.dev/text/template */ -}}
 {{- range $netname, $net := .NetworksMap }}
-{{- if ne $net.Name "Control" }}
+{{- if not $net.IsControlPlane }}
 - name: {{ $net.Name }}
   name_lower: {{ $net.NameLower }}
   vip: {{ $net.VIP }}
   mtu: {{ $net.MTU }}
-{{- /* TODO: ipv6 only
-{{- if eq $net.NetType "ipv6" }}
-  ipv6: true
-{{- end }}
-*/ -}}
+  ipv6: {{ if $net.IPv6 }}true{{ else }}false{{ end }}
 {{- /* subnets start */ -}}
 {{- if not (eq (len $net.Subnets) 0) }}
   subnets:

--- a/templates/openstackipset/config/17.0/rendered-tripleo-config.yaml
+++ b/templates/openstackipset/config/17.0/rendered-tripleo-config.yaml
@@ -10,9 +10,9 @@ resource_registry:
   OS::TripleO::Network::Ports::StorageMgmtVipPort: network/ports/deployed_vip_storage_mgmt.yaml
   OS::TripleO::Network::Ports::StorageVipPort: network/ports/deployed_vip_storage.yaml
 {{- range $roleid, $role := .RolesMap }}
-{{- if ne $role.Name "ControlPlane" }}
+{{- if not $role.IsControlPlane }}
 {{- range $netid, $net := $role.Networks }}
-{{- if ne $net.NameLower "ctlplane" }}
+{{- if not $net.IsControlPlane }}
   OS::TripleO::{{ $role.Name }}::Ports::{{ $net.Name }}Port: network/ports/deployed_{{ $net.NameLower }}.yaml
 {{- end}}
 {{- end }}
@@ -29,7 +29,7 @@ parameter_defaults:
   NeutronPublicInterface: nic3
 {{- /* HostnameFormat and RoleCount */ -}}
 {{- range $roleid, $role := .RolesMap }}
-{{- if ne $role.Name "ControlPlane" }}
+{{- if not $role.IsControlPlane }}
   {{ $role.Name }}HostnameFormat: "{{ $role.NameLower }}-%index%"
   {{- $roleCount := len $role.Nodes }}
   {{ $role.Name }}Count: {{ $roleCount }}
@@ -90,7 +90,7 @@ parameter_defaults:
   # VipPortMap
   VipPortMap:
 {{- range $netname, $ip := $node.IPaddr }}
-{{- if and (ne $netname "ctlplane") (ne $netname "tenant") }}
+{{- if not $ip.Network.IsControlPlane }}
     {{ $netname }}:
       ip_address: {{ $ip.IPaddr }}
       ip_address_uri: '{{ $ip.IPAddrURI }}'
@@ -104,10 +104,10 @@ parameter_defaults:
   # ControlPlaneVipData
   ControlPlaneVipData:
 {{- range $roleid, $role := .RolesMap }}
-{{- if eq $role.Name "ControlPlane" }}
+{{- if $role.IsControlPlane }}
 {{- range $nodeid, $node := $role.Nodes }}
 {{- range $netname, $ip := $node.IPaddr }}
-{{- if and ($node.VIP) (eq $netname "ctlplane") }}
+{{- if and ($node.VIP) ($ip.Network.IsControlPlane) }}
     fixed_ips:
     - ip_address: {{ $ip.IPaddr }}
     name: control_virtual_ip
@@ -134,10 +134,133 @@ parameter_defaults:
 {{- end }}
 {{- end }}
 {{- end }}
+  #
+  # DeployedNetworkEnvironment
+  DeployedNetworkEnvironment:
+    {{- /* net_attributes_map start */}}
+    net_attributes_map:
+      {{- $net_idx := 0 }}
+      {{- range $netname, $net := .NetworksMap }}
+      {{- $netname_lower := lower $net.Name }}
+      {{- if not $net.IsControlPlane }}
+      {{ $net.NameLower }}:
+        network:
+          dns_domain: {{ $net.DomainName }}.
+          mtu: {{ $net.MTU }}
+          name: {{ $net.NameLower }}
+          tags:
+          - tripleo_network_name={{$net.Name }}
+          - tripleo_net_idx={{ $net_idx }}
+          {{- $net_idx = add $net_idx 1 }}
+          - tripleo_vip={{ $net.VIP }}
+        {{- /* subnets start */}}
+        subnets:
+        {{- range $subnetname, $subnet := $net.Subnets }}
+          {{ $subnetname }}_subnet:
+          {{- /* IPv4 subnet start */ -}}
+          {{- if ne $subnet.IPv4.Cidr "" }}
+            cidr: '{{ $subnet.IPv4.Cidr }}'
+            dns_nameservers: []
+            gateway_ip: {{ $subnet.IPv4.Gateway }}
+            host_routes: {{ if eq (len $subnet.IPv4.Routes) 0 }}[]{{ else }}
+              {{- range $netname, $route := $subnet.IPv4.Routes }}
+              - destination: '{{ $route.Destination }}'
+                nexthop: '{{ $route.Nexthop }}'
+              {{- end }}
+              {{- end }}
+            ip_version: 4
+            name: {{ $subnetname }}
+            tags: {{ if eq $subnet.Vlan 0 }}[]{{ else }}
+              - tripleo_vlan_id={{ $subnet.Vlan }}
+            {{- end }}
+          {{- end }}
+          {{- /* IPv4 subnet end */}}
+          {{- /* IPv6 subnet start */ -}}
+          {{- if ne $subnet.IPv6.Cidr "" }}
+            cidr: '{{ $subnet.IPv6.Cidr }}'
+            dns_nameservers: []
+            gateway_ip: {{ $subnet.IPv6.Gateway }}
+            host_routes: {{ if eq (len $subnet.IPv6.Routes) 0 }}[]{{ else }}
+              {{- range $netname, $route := $subnet.IPv6.Routes }}
+              - destination: '{{ $route.Destination }}'
+                nexthop: '{{ $route.Nexthop }}'
+              {{- end }}
+              {{- end }}
+            ip_version: 6
+            name: {{ $subnetname }}
+            tags: {{ if eq $subnet.Vlan 0 }}[]{{ else }}
+              - tripleo_vlan_id={{ $subnet.Vlan }}
+            {{- end }}
+          {{- end }}
+          {{- /* IPv6 subnet end */ -}}
+        {{- end }}
+        {{- /* subnets end */ -}}
+      {{- end }}
+      {{- end }}
+    {{- /* net_attributes_map end */ -}}
+    {{- /* net_cidr_map start */}}
+    net_cidr_map:
+      {{- range $netname, $net := .NetworksMap }}
+      {{- if not $net.IsControlPlane }}
+      {{ $net.NameLower }}:
+      {{- range $subnetname, $subnet := $net.Subnets }}
+      {{- if $net.IPv6 }}
+      - '{{ $subnet.IPv6.Cidr }}'
+      {{-  else }}
+      - '{{ $subnet.IPv4.Cidr }}'
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+    {{- /* net_cidr_map end */ -}}
+    {{- /* net_ip_version_map start */}}
+    net_ip_version_map:
+      {{- range $netname, $net := .NetworksMap }}
+      {{- if not $net.IsControlPlane }}
+      {{ $net.NameLower }}: {{ if $net.IPv6 }}6{{ else }}4{{ end }}
+      {{- end }}
+      {{- end }}
+    {{- /* net_ip_version_map end */}}
+  #
+  # CtlplaneNetworkAttributes
+  CtlplaneNetworkAttributes:
+    {{- range $netname, $net := .NetworksMap }}
+    {{- $netname_lower := lower $net.Name }}
+    {{- if $net.IsControlPlane }}
+    network:
+      dns_domain: {{ $net.DomainName }}.
+      mtu: {{ $net.MTU }}
+      name: {{ $net.NameLower }}
+      tags:
+      {{- range $subnetname, $subnet := $net.Subnets }}
+      - {{ $subnet.IPv4.Cidr }}
+      {{- end }}
+    {{- /* subnets start */}}
+    subnets:
+    {{- range $subnetname, $subnet := $net.Subnets }}
+      {{ $subnetname }}-subnet:
+        cidr: {{ $subnet.IPv4.Cidr }}
+        dns_nameservers: {{ if eq (len $net.DNSServers) 0 }}[]{{ else }}
+          {{- range $idx, $dnsServer := $net.DNSServers }}
+          - {{ $dnsServer }}
+          {{- end }}
+          {{- end }}
+        gateway_ip: {{ $subnet.IPv4.Gateway }}
+        host_routes: {{ if eq (len $subnet.IPv4.Routes) 0 }}[]{{ else }}
+          {{- range $netname, $route := $subnet.IPv4.Routes }}
+          - destination: '{{ $route.Destination }}'
+            nexthop: '{{ $route.Nexthop }}'
+          {{- end }}
+          {{- end }}
+        ip_version: 4
+        name: {{ $subnetname }}-subnet
+    {{- end }}
+    {{- end }}
+    {{- end }}
 {{/*
 # Set VIP's for redis and OVN
 {{- range $roleid, $role := .RolesMap }}
-{{- if eq $role.Name "ControlPlane" }}
+{{- if $role.IsControlPlane }}
 {{- range $nodeid, $node := $role.Nodes }}
 {{- range $netname, $ip := $node.IPaddr }}
 {{- if and ($node.VIP) (eq $netname "internal_api") }}


### PR DESCRIPTION
Renders DeployedNetworkEnvironment and CtlplaneNetworkAttributes from network information required by wallaby/OSP17 networkv2.

New Parameters:
 - IsControlPlane to make it easier to identify controlplane network which is kind of special network from ooo side. The webhook sets the parameter automatically for the default ctlplane names when Name is "Control" or NameLower "ctlplane".
  Parameters required to render DeployedNetworkEnvironment and CtlplaneNetworkAttributes:
 - DomainName the name of the dns domain, this is used to create the per ooo network domain name, like `internalapi.osptest.test.metalkube.org`
 - DNSServers list of dns servers
 - DNSSearchDomains list of DNS search domains

TODO - in a follow up we probably want to:
* change osctlplane and osbms to get the dns servers from the osnetcfg.
* add DnsServers + DnsSearchDomain in parameter_defaults of the rendered 
* set CloudName and CloudName<NetworkName> fro the provided DomainName

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/452