### PR TITLE
[OSPK8-416] reduce repeated condition message logging

### DIFF
--- a/controllers/openstackconfiggenerator.go
+++ b/controllers/openstackconfiggenerator.go
@@ -143,6 +143,9 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
+			} else {
+				// log status changed messages also to operator log
+				common.LogForObject(r, cond.Message, instance)
 			}
 		}
 
@@ -185,11 +188,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 		cond.Message = fmt.Sprintf("Control plane %s VMs are not yet provisioned. Requeing...", controlPlane.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMNotFound)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorWaiting)
-		common.LogForObject(
-			r,
-			cond.Message,
-			instance,
-		)
 
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -363,7 +361,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			cond.Message = fmt.Sprintf("OpenStackEphemeralHeat successfully created/updated - operation: %s", string(op))
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatUpdated)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorInitializing)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
@@ -372,7 +369,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			cond.Message = "Waiting on Ephemeral Heat instance to launch..."
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatLaunch)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorInitializing)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
@@ -392,7 +388,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			cond.Message = "ConfigMap has changed. Requeing to start again..."
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMUpdated)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorInitializing)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
@@ -406,7 +401,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			cond.Message = msg
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonWaitingNodesProvisioned)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorInitializing)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrl.Result{RequeueAfter: time.Second * 20}, err
 		}
@@ -426,7 +420,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			cond.Message = fmt.Sprintf("Job successfully created/updated - operation: %s", string(op))
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonJobCreated)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorInitializing)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
@@ -461,7 +454,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			cond.Message = "ConfigMap has changed. Requeing to start again..."
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMUpdated)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorInitializing)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 
@@ -482,7 +474,6 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			cond.Message = "Waiting on Config Generation..."
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonConfigCreate)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorGenerating)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}

--- a/controllers/openstacknetattachment_controller.go
+++ b/controllers/openstacknetattachment_controller.go
@@ -137,6 +137,9 @@ func (r *OpenStackNetAttachmentReconciler) Reconcile(ctx context.Context, req ct
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
+			} else {
+				// log status changed messages also to operator log
+				common.LogForObject(r, cond.Message, instance)
 			}
 		}
 	}(cond)
@@ -326,15 +329,12 @@ func (r *OpenStackNetAttachmentReconciler) createOrUpdateNodeNetworkConfiguratio
 	}
 
 	if op != controllerutil.OperationResultNone {
-		common.LogForObject(r, string(op), networkConfigurationPolicy)
-
 		cond.Message = fmt.Sprintf("NodeNetworkConfigurationPolicy %s is %s", networkConfigurationPolicy.Name, string(op))
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetAttachConfiguring)
-	} else {
-		cond.Message = fmt.Sprintf("NodeNetworkConfigurationPolicy %s configured targeted node(s)", networkConfigurationPolicy.Name)
-		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetAttachConfigured)
+
+		common.LogForObject(r, string(op), networkConfigurationPolicy)
+		common.LogForObject(r, cond.Message, instance)
 	}
-	common.LogForObject(r, cond.Message, instance)
 
 	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		if !controllerutil.ContainsFinalizer(networkConfigurationPolicy, openstacknetattachment.FinalizerName) {
@@ -383,7 +383,6 @@ func (r *OpenStackNetAttachmentReconciler) getNodeNetworkConfigurationPolicyStat
 			}
 		}
 	}
-	common.LogForObject(r, cond.Message, instance)
 
 	return nil
 }

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -127,6 +127,9 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
+			} else {
+				// log status changed messages also to operator log
+				common.LogForObject(r, cond.Message, instance)
 			}
 		}
 	}(cond)
@@ -253,7 +256,6 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		} else if !reflect.DeepEqual(ctrlResult, ctrl.Result{}) {
 			cond.Message = fmt.Sprintf("OpenStackNetConfig %s waiting for all OpenStackNetworkAttachments to be configured", instance.Name)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigWaiting)
-			common.LogForObject(r, cond.Message, instance)
 
 			return ctrlResult, nil
 		}
@@ -292,7 +294,6 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 			} else if !reflect.DeepEqual(ctrlResult, ctrl.Result{}) {
 				cond.Message = fmt.Sprintf("OpenStackNetConfig %s waiting for all OpenStackNetworks to be configured", instance.Name)
 				cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigWaiting)
-				common.LogForObject(r, cond.Message, instance)
 
 				return ctrlResult, nil
 			}
@@ -376,11 +377,9 @@ func (r *OpenStackNetConfigReconciler) applyNetAttachmentConfig(
 	if op != controllerutil.OperationResultNone {
 		cond.Message = fmt.Sprintf("OpenStackNetworkAttachment %s is %s", attachConfig.Name, string(op))
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigConfiguring)
-	} else {
-		cond.Message = fmt.Sprintf("OpenStackNetworkAttachment %s configured targeted node(s)", attachConfig.Name)
-		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigConfigured)
+
+		common.LogForObject(r, cond.Message, attachConfig)
 	}
-	common.LogForObject(r, cond.Message, attachConfig)
 
 	return attachConfig, nil
 }
@@ -563,7 +562,6 @@ func (r *OpenStackNetConfigReconciler) getNetStatus(
 
 	instance.Status.ProvisioningStatus.State = ospdirectorv1beta1.NetConfigState(cond.Type)
 	instance.Status.ProvisioningStatus.Reason = cond.Message
-	common.LogForObject(r, cond.Message, instance)
 
 	return ctrlResult, nil
 }

--- a/pkg/common/configmap.go
+++ b/pkg/common/configmap.go
@@ -129,6 +129,9 @@ func EnsureConfigMaps(r ReconcilerCommon, obj metav1.Object, cms []Template, env
 			hash, op, err = createOrUpdateConfigMap(r, obj, cm)
 		} else {
 			hash, err = createOrGetCustomConfigMap(r, obj, cm)
+			// set op to OperationResultNone because createOrGetCustomConfigMap does not return an op
+			// and it will add log entries bellow with none operation
+			op = controllerutil.OperationResult(controllerutil.OperationResultNone)
 		}
 		if err != nil {
 			return err

--- a/pkg/common/secret.go
+++ b/pkg/common/secret.go
@@ -249,6 +249,9 @@ func EnsureSecrets(r ReconcilerCommon, obj metav1.Object, sts []Template, envVar
 			hash, op, err = createOrUpdateSecret(r, obj, s)
 		} else {
 			hash, err = createOrGetCustomSecret(r, obj, s)
+			// set op to OperationResultNone because createOrGetCustomSecret does not return an op
+			// and it will add log entries bellow with none operation
+			op = controllerutil.OperationResult(controllerutil.OperationResultNone)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
Right now on every reconcile messages get logged, even if there
was no action.

To make logging better readable/ easier to follow, this change
logs the condition messages in the defer function where we check if
the condition changed. This should be used where we return from the
reconcile loop, and only in cases where this is possible log explicitely
at that place.