### PR TITLE
Increase golangci timeout

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -39,4 +39,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.38.0
-          args: --timeout 3m
+          args: --timeout 5m


### PR DESCRIPTION
Increase github golangci timeout to 5m as 3m is not enough.