### PR TITLE
Fix controller VM DNS config

### DIFF
--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -787,6 +787,16 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 		},
 	}
 
+	if len(instance.Spec.BootstrapDNS) != 0 {
+		vmTemplate.Spec.DNSPolicy = corev1.DNSNone
+		vmTemplate.Spec.DNSConfig = &corev1.PodDNSConfig{
+			Nameservers: instance.Spec.BootstrapDNS,
+		}
+		if len(instance.Spec.DNSSearchDomains) != 0 {
+			vmTemplate.Spec.DNSConfig.Searches = instance.Spec.DNSSearchDomains
+		}
+	}
+
 	// This run strategy ensures that the VM boots upon creation and reboots upon
 	// failure, but also allows us to issue manual power commands to the Kubevirt API.
 	// The default strategy, "Always", disallows the direct power command API calls


### PR DESCRIPTION
/etc/resolv.conf on the controller VMs is still referencing the OCP
cluster DNS server on 172.30.0.10, which is not responding.

This is resulting in slow DNS queries as it wait to timeout before
trying the next/correct server in resolv.conf.

This disables the default DNS config when BootstrapDNS is set, similar
to the baremetal node.