### PR TITLE
[OSPK8-413] convert osbmset to defer

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -78,6 +78,8 @@ const (
 	CommonCondReasonSecretMissing ConditionReason = "SecretMissing"
 	// CommonCondReasonSecretError - secret error
 	CommonCondReasonSecretError ConditionReason = "SecretError"
+	// CommonCondReasonSecretDeleteError - secret deletion error
+	CommonCondReasonSecretDeleteError ConditionReason = "SecretDeleteError"
 	// CommonCondReasonConfigMapMissing - config map does not exist
 	CommonCondReasonConfigMapMissing ConditionReason = "ConfigMapMissing"
 	// CommonCondReasonConfigMapError - config map error
@@ -104,6 +106,10 @@ const (
 	CommonCondReasonOSNetAvailable ConditionReason = "OSNetAvailable"
 	// CommonCondReasonControllerReferenceError - error set controller reference on object
 	CommonCondReasonControllerReferenceError ConditionReason = "ControllerReferenceError"
+	// CommonCondReasonOwnerRefLabeledObjectsDeleteError - error deleting object using OwnerRef label
+	CommonCondReasonOwnerRefLabeledObjectsDeleteError ConditionReason = "OwnerRefLabeledObjectsDeleteError"
+	// CommonCondReasonRemoveFinalizerError - error removing finalizer from object
+	CommonCondReasonRemoveFinalizerError ConditionReason = "RemoveFinalizerError"
 )
 
 // Hash - struct to add hashes to status

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -136,17 +136,6 @@ const (
 	BaremetalSetCondReasonVirtualMachineProvisioned ConditionReason = "BaremetalHostProvisioed"
 	// BaremetalSetCondReasonVirtualMachineCountZero - no bmh requested
 	BaremetalSetCondReasonVirtualMachineCountZero ConditionReason = "BaremetalHostCountZero"
-
-	/*
-		// BaremetalSetReasonListError - osbms list objects error
-		BaremetalSetReasonListError ConditionReason = "BaremetalSetReasonListError"
-		// BaremetalSetReasonNotFound - osbms object not found
-		BaremetalSetReasonNotFound ConditionReason = "BaremetalSetReasonNotFound"
-		// BaremetalSetReasonNotReady - osbms not yet ready
-		BaremetalSetReasonNotReady ConditionReason = "BaremetalSetReasonNotReady"
-		// BaremetalSetReasonReady - osbms ready
-		BaremetalSetReasonReady ConditionReason = "BaremetalSetReasonReady"
-	*/
 )
 
 // GetHostnames -

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -80,20 +80,73 @@ type OpenStackBaremetalSetProvisioningStatus struct {
 }
 
 const (
-	// BaremetalSetEmpty - special state for 0 requested BaremetalHosts and 0 already provisioned
-	BaremetalSetEmpty ProvisioningState = "Empty"
-	// BaremetalSetWaiting - something other than BaremetalHost availability is causing the OpenStackBaremetalSet to wait
-	BaremetalSetWaiting ProvisioningState = "Waiting"
-	// BaremetalSetProvisioning - one or more BaremetalHosts are provisioning
-	BaremetalSetProvisioning ProvisioningState = "Provisioning"
-	// BaremetalSetProvisioned - the requested BaremetalHosts count has been satisfied
-	BaremetalSetProvisioned ProvisioningState = "Provisioned"
-	// BaremetalSetDeprovisioning - one or more BaremetalHosts are deprovisioning
-	BaremetalSetDeprovisioning ProvisioningState = "Deprovisioning"
-	// BaremetalSetInsufficient - one or more BaremetalHosts not found (either for scale-up or scale-down) to satisfy count request
-	BaremetalSetInsufficient ProvisioningState = "Insufficient availability"
-	// BaremetalSetError - general catch-all for actual errors
-	BaremetalSetError ProvisioningState = "Error"
+	// BaremetalSetCondTypeEmpty - special state for 0 requested BaremetalHosts and 0 already provisioned
+	BaremetalSetCondTypeEmpty ProvisioningState = "Empty"
+	// BaremetalSetCondTypeWaiting - something other than BaremetalHost availability is causing the OpenStackBaremetalSet to wait
+	BaremetalSetCondTypeWaiting ProvisioningState = "Waiting"
+	// BaremetalSetCondTypeProvisioning - one or more BaremetalHosts are provisioning
+	BaremetalSetCondTypeProvisioning ProvisioningState = "Provisioning"
+	// BaremetalSetCondTypeProvisioned - the requested BaremetalHosts count has been satisfied
+	BaremetalSetCondTypeProvisioned ProvisioningState = "Provisioned"
+	// BaremetalSetCondTypeDeprovisioning - one or more BaremetalHosts are deprovisioning
+	BaremetalSetCondTypeDeprovisioning ProvisioningState = "Deprovisioning"
+	// BaremetalSetCondTypeInsufficient - one or more BaremetalHosts not found (either for scale-up or scale-down) to satisfy count request
+	BaremetalSetCondTypeInsufficient ProvisioningState = "Insufficient availability"
+	// BaremetalSetCondTypeError - general catch-all for actual errors
+	BaremetalSetCondTypeError ProvisioningState = "Error"
+
+	//
+	// condition reasones
+	//
+
+	//
+	// metal3
+	//
+
+	// BaremetalHostCondReasonListError - metal3 bmh list objects error
+	BaremetalHostCondReasonListError ConditionReason = "BaremetalHostListError"
+	// BaremetalHostCondReasonGetError - error get metal3 bmh object
+	BaremetalHostCondReasonGetError ConditionReason = "BaremetalHostGetError"
+	// BaremetalHostCondReasonUpdateError - error updating metal3 bmh object
+	BaremetalHostCondReasonUpdateError ConditionReason = "BaremetalHostUpdateError"
+	// BaremetalHostCondReasonCloudInitSecretError - error creating cloud-init secrets for metal3
+	BaremetalHostCondReasonCloudInitSecretError ConditionReason = "BaremetalHostCloudInitSecretError"
+
+	//
+	// osbms
+	//
+
+	// BaremetalSetCondReasonBaremetalHostStatusNotFound - bare metal host status not found
+	BaremetalSetCondReasonBaremetalHostStatusNotFound ConditionReason = "BaremetalHostStatusNotFound"
+	// BaremetalSetCondReasonUserDataSecretDeleteError - error deleting user data secret
+	BaremetalSetCondReasonUserDataSecretDeleteError ConditionReason = "BaremetalSetUserDataSecretDeleteError"
+	// BaremetalSetCondReasonNetworkDataSecretDeleteError - error deleting network data secret
+	BaremetalSetCondReasonNetworkDataSecretDeleteError ConditionReason = "BaremetalSetNetworkDataSecretDeleteError"
+	// BaremetalSetCondReasonScaleDownInsufficientAnnotatedHosts - not enough nodes annotated for deletion
+	BaremetalSetCondReasonScaleDownInsufficientAnnotatedHosts ConditionReason = "BaremetalSetScaleDownInsufficientAnnotatedHosts"
+	// BaremetalSetCondReasonScaleUpInsufficientHosts - not enough nodes for requested host count
+	BaremetalSetCondReasonScaleUpInsufficientHosts ConditionReason = "BaremetalSetScaleUpInsufficientHosts"
+	// BaremetalSetCondReasonProvisioningErrors - errors during bmh provisioning
+	BaremetalSetCondReasonProvisioningErrors ConditionReason = "BaremetalSetProvisioningErrors"
+	// BaremetalSetCondReasonVirtualMachineProvisioning - bmh provisioning in progress
+	BaremetalSetCondReasonVirtualMachineProvisioning ConditionReason = "BaremetalHostProvisioning"
+	// BaremetalSetCondReasonVirtualMachineDeprovisioning - bmh deprovisioning in progress
+	BaremetalSetCondReasonVirtualMachineDeprovisioning ConditionReason = "BaremetalHostDeprovisioning"
+	// BaremetalSetCondReasonVirtualMachineProvisioned - bmh provisioned
+	BaremetalSetCondReasonVirtualMachineProvisioned ConditionReason = "BaremetalHostProvisioed"
+	// BaremetalSetCondReasonVirtualMachineCountZero - no bmh requested
+	BaremetalSetCondReasonVirtualMachineCountZero ConditionReason = "BaremetalHostCountZero"
+
+	/*
+		// BaremetalSetReasonListError - osbms list objects error
+		BaremetalSetReasonListError ConditionReason = "BaremetalSetReasonListError"
+		// BaremetalSetReasonNotFound - osbms object not found
+		BaremetalSetReasonNotFound ConditionReason = "BaremetalSetReasonNotFound"
+		// BaremetalSetReasonNotReady - osbms not yet ready
+		BaremetalSetReasonNotReady ConditionReason = "BaremetalSetReasonNotReady"
+		// BaremetalSetReasonReady - osbms ready
+		BaremetalSetReasonReady ConditionReason = "BaremetalSetReasonReady"
+	*/
 )
 
 // GetHostnames -

--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -166,7 +166,9 @@ const (
 	// ControlPlaneReasonNotSupportedVersion - osctlplane not found
 	ControlPlaneReasonNotSupportedVersion ConditionReason = "CtlPlaneNotSupportedVersion"
 	// ControlPlaneReasonTripleoPasswordsSecretError - Tripleo password secret error
-	ControlPlaneReasonTripleoPasswordsSecretError ConditionReason = "TripleoPasswordsSecretCError"
+	ControlPlaneReasonTripleoPasswordsSecretError ConditionReason = "TripleoPasswordsSecretError"
+	// ControlPlaneReasonTripleoPasswordsSecretNotFound - Tripleo password secret not found
+	ControlPlaneReasonTripleoPasswordsSecretNotFound ConditionReason = "TripleoPasswordsSecretNotFound"
 	// ControlPlaneReasonTripleoPasswordsSecretCreateError - Tripleo password secret create error
 	ControlPlaneReasonTripleoPasswordsSecretCreateError ConditionReason = "TripleoPasswordsSecretCreateError"
 	// ControlPlaneReasonDeploymentSSHKeysSecretError - Deployment SSH Keys Secret Error

--- a/api/v1beta1/openstackprovisionserver_webhook.go
+++ b/api/v1beta1/openstackprovisionserver_webhook.go
@@ -79,8 +79,7 @@ func (r *OpenStackProvisionServer) ValidateUpdate(old runtime.Object) error {
 }
 
 func (r *OpenStackProvisionServer) validateCr() error {
-	existingPorts, err := r.GetExistingProvServerPorts(webhookClient)
-
+	existingPorts, err := r.GetExistingProvServerPorts(&Condition{}, webhookClient)
 	if err != nil {
 		return err
 	}

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -2630,8 +2630,8 @@ spec:
                                     reason:
                                       type: string
                                     state:
-                                      description: ProvisionServerProvisioningState
-                                        - the overall state of this OpenStackProvisionServer
+                                      description: ProvisioningState - the overall
+                                        state of all VMs in this OpenStackVmSet
                                       type: string
                                   type: object
                               type: object

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -122,8 +122,8 @@ spec:
                   reason:
                     type: string
                   state:
-                    description: ProvisionServerProvisioningState - the overall state
-                      of this OpenStackProvisionServer
+                    description: ProvisioningState - the overall state of all VMs
+                      in this OpenStackVmSet
                     type: string
                 type: object
             type: object

--- a/controllers/openstackbackuprequest_controller.go
+++ b/controllers/openstackbackuprequest_controller.go
@@ -421,7 +421,7 @@ func (r *OpenStackBackupRequestReconciler) ensureLoadBackup(instance *ospdirecto
 		}
 
 		// Now try to update the status
-		item.Status.ProvisioningStatus.State = ospdirectorv1beta1.ProvisionServerWaiting
+		item.Status.ProvisioningStatus.State = ospdirectorv1beta1.ProvisionServerCondTypeWaiting
 		item.Status.ProvisioningStatus.Reason = msg
 		item.Status.Conditions.UpdateCurrentCondition(ospdirectorv1beta1.ConditionType(item.Status.ProvisioningStatus.State), ospdirectorv1beta1.ConditionReason(msg), msg)
 		if err := r.Client.Status().Update(context.TODO(), &item, &client.UpdateOptions{}); err != nil {
@@ -436,7 +436,7 @@ func (r *OpenStackBackupRequestReconciler) ensureLoadBackup(instance *ospdirecto
 		}
 
 		// Now try to update the status
-		item.Status.ProvisioningStatus.State = ospdirectorv1beta1.BaremetalSetWaiting
+		item.Status.ProvisioningStatus.State = ospdirectorv1beta1.BaremetalSetCondTypeWaiting
 		item.Status.ProvisioningStatus.Reason = msg
 		item.Status.Conditions.UpdateCurrentCondition(ospdirectorv1beta1.ConditionType(item.Status.ProvisioningStatus.State), ospdirectorv1beta1.ConditionReason(msg), msg)
 		if err := r.Client.Status().Update(context.TODO(), &item, &client.UpdateOptions{}); err != nil {

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -131,12 +131,11 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
-			} else {
-				// log status changed messages also to operator log
-				common.LogForObject(r, cond.Message, instance)
 			}
 		}
 
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	// If we determine that a backup is overriding this reconcile, requeue after a longer delay

--- a/controllers/openstackconfiggenerator.go
+++ b/controllers/openstackconfiggenerator.go
@@ -155,12 +155,11 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
-			} else {
-				// log status changed messages also to operator log
-				common.LogForObject(r, cond.Message, instance)
 			}
 		}
 
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	envVars := make(map[string]common.EnvSetter)

--- a/controllers/openstackconfiggenerator.go
+++ b/controllers/openstackconfiggenerator.go
@@ -657,8 +657,8 @@ func (r *OpenStackConfigGeneratorReconciler) verifyNodeResourceStatus(instance *
 		//
 		// wait for all BMS be provisioned if baremetalhosts for the bms are requested
 		//
-		if bmset.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisioningState(ospdirectorv1beta1.BaremetalSetProvisioned) &&
-			bmset.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisioningState(ospdirectorv1beta1.BaremetalSetEmpty) {
+		if bmset.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisioningState(ospdirectorv1beta1.BaremetalSetCondTypeProvisioned) &&
+			bmset.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisioningState(ospdirectorv1beta1.BaremetalSetCondTypeEmpty) {
 			msg := fmt.Sprintf("Waiting on OpenStackBaremetalSet %s to be provisioned...", bmset.Name)
 			return msg, false, nil
 		}

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -162,12 +162,11 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
-			} else {
-				// log status changed messages also to operator log
-				common.LogForObject(r, cond.Message, instance)
 			}
 		}
 
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	envVars := make(map[string]common.EnvSetter)

--- a/controllers/openstackipset_controller.go
+++ b/controllers/openstackipset_controller.go
@@ -138,6 +138,8 @@ func (r *OpenStackIPSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 		}
 
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	// examine DeletionTimestamp to determine if object is under deletion

--- a/controllers/openstackipset_controller.go
+++ b/controllers/openstackipset_controller.go
@@ -152,7 +152,7 @@ func (r *OpenStackIPSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			if err := r.Update(ctx, instance); err != nil {
 				return ctrl.Result{}, err
 			}
-			r.Log.Info(fmt.Sprintf("Finalizer %s added to CR %s", common.FinalizerName, instance.Name))
+			common.LogForObject(r, fmt.Sprintf("Finalizer %s added to CR %s", common.FinalizerName, instance.Name), instance)
 		}
 	} else {
 		// 1. check if finalizer is there
@@ -174,6 +174,12 @@ func (r *OpenStackIPSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		controllerutil.RemoveFinalizer(instance, common.FinalizerName)
 		err = r.Client.Update(context.TODO(), instance)
 		if err != nil {
+			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonRemoveFinalizerError)
+			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
 			return ctrl.Result{}, err
 		}
 		r.Log.Info(fmt.Sprintf("CR %s deleted", instance.Name))

--- a/controllers/openstackmacaddress_controller.go
+++ b/controllers/openstackmacaddress_controller.go
@@ -133,6 +133,8 @@ func (r *OpenStackMACAddressReconciler) Reconcile(ctx context.Context, req ctrl.
 			}
 		}
 
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	// examine DeletionTimestamp to determine if object is under deletion

--- a/controllers/openstacknet_controller.go
+++ b/controllers/openstacknet_controller.go
@@ -137,6 +137,9 @@ func (r *OpenStackNetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				}
 			}
 		}
+
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	// examine DeletionTimestamp to determine if object is under deletion

--- a/controllers/openstacknetattachment_controller.go
+++ b/controllers/openstacknetattachment_controller.go
@@ -137,11 +137,11 @@ func (r *OpenStackNetAttachmentReconciler) Reconcile(ctx context.Context, req ct
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
-			} else {
-				// log status changed messages also to operator log
-				common.LogForObject(r, cond.Message, instance)
 			}
 		}
+
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	// examine DeletionTimestamp to determine if object is under deletion

--- a/controllers/openstacknetattachment_controller.go
+++ b/controllers/openstacknetattachment_controller.go
@@ -188,6 +188,12 @@ func (r *OpenStackNetAttachmentReconciler) Reconcile(ctx context.Context, req ct
 		controllerutil.RemoveFinalizer(instance, openstacknetattachment.FinalizerName)
 		err = r.Client.Update(context.TODO(), instance)
 		if err != nil {
+			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonRemoveFinalizerError)
+			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
 			return ctrl.Result{}, err
 		}
 		common.LogForObject(r, fmt.Sprintf("CR %s deleted", instance.Name), instance)
@@ -491,8 +497,13 @@ func (r *OpenStackNetAttachmentReconciler) cleanupNodeNetworkConfigurationPolicy
 				condition.Reason == "SuccessfullyConfigured" {
 
 				controllerutil.RemoveFinalizer(networkConfigurationPolicy, openstacknetattachment.FinalizerName)
-				err = r.Client.Update(context.TODO(), networkConfigurationPolicy)
-				if err != nil && !k8s_errors.IsNotFound(err) {
+				if err := r.Client.Update(context.TODO(), networkConfigurationPolicy); err != nil && !k8s_errors.IsNotFound(err) {
+					cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
+					cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonRemoveFinalizerError)
+					cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+
+					err = common.WrapErrorForObject(cond.Message, instance, err)
+
 					return ctrl.Result{}, err
 				}
 

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -127,11 +127,11 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
-			} else {
-				// log status changed messages also to operator log
-				common.LogForObject(r, cond.Message, instance)
 			}
 		}
+
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	// examine DeletionTimestamp to determine if object is under deletion

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -219,6 +219,12 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		controllerutil.RemoveFinalizer(instance, openstacknetconfig.FinalizerName)
 		err = r.Client.Update(context.TODO(), instance)
 		if err != nil {
+			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonRemoveFinalizerError)
+			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
 			return ctrl.Result{}, err
 		}
 		common.LogForObject(r, fmt.Sprintf("CR %s deleted", instance.Name), instance)

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -160,12 +160,11 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				} else {
 					common.LogErrorForObject(r, updateErr, "Update status", instance)
 				}
-			} else {
-				// log status changed messages also to operator log
-				common.LogForObject(r, cond.Message, instance)
 			}
 		}
 
+		// log current status message to operator log
+		common.LogForObject(r, cond.Message, instance)
 	}(cond)
 
 	// What VMs do we currently have for this OpenStackVMSet?

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	golang.org/x/tools v0.1.8 // indirect
 	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4
-	k8s.io/apiserver v0.21.4
+	k8s.io/apiserver v0.21.4 // indirect
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	kubevirt.io/client-go v0.34.2

--- a/pkg/openstackbackup/funcs.go
+++ b/pkg/openstackbackup/funcs.go
@@ -313,7 +313,7 @@ func GetAreControllersQuiesced(instance *ospdirectorv1beta1.OpenStackBackupReque
 
 	// Check provisioning status of all OpenStackBaremetalSets
 	for _, cr := range crLists.OpenStackBaremetalSets.Items {
-		if cr.Status.ProvisioningStatus.State != ospdirectorv1beta1.BaremetalSetProvisioned {
+		if cr.Status.ProvisioningStatus.State != ospdirectorv1beta1.BaremetalSetCondTypeProvisioned {
 			copy := cr.DeepCopy()
 			badCrs = append(badCrs, copy)
 		}
@@ -366,7 +366,7 @@ func GetAreControllersQuiesced(instance *ospdirectorv1beta1.OpenStackBackupReque
 
 	// Check the provisioning status of all OpenStackProvisionServers
 	for _, cr := range crLists.OpenStackProvisionServers.Items {
-		if cr.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisionServerProvisioned {
+		if cr.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisionServerCondTypeProvisioned {
 			copy := cr.DeepCopy()
 			badCrs = append(badCrs, copy)
 		}
@@ -464,7 +464,7 @@ func GetAreResourcesRestored(backup *ospdirectorv1beta1.OpenStackBackup, crLists
 			}
 		}
 
-		if found == nil || found.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisionServerProvisioned {
+		if found == nil || found.Status.ProvisioningStatus.State != ospdirectorv1beta1.ProvisionServerCondTypeProvisioned {
 			badCrs = append(badCrs, found)
 		}
 	}
@@ -480,7 +480,7 @@ func GetAreResourcesRestored(backup *ospdirectorv1beta1.OpenStackBackup, crLists
 			}
 		}
 
-		if found == nil || found.Status.ProvisioningStatus.State != ospdirectorv1beta1.BaremetalSetProvisioned {
+		if found == nil || found.Status.ProvisioningStatus.State != ospdirectorv1beta1.BaremetalSetCondTypeProvisioned {
 			badCrs = append(badCrs, found)
 		}
 	}

--- a/pkg/openstackipset/funcs.go
+++ b/pkg/openstackipset/funcs.go
@@ -29,43 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// OvercloudipsetCreateOrUpdate -
-// TODO: remove when all controllers migrated to use cond and CreateOrUpdateIPset
-func OvercloudipsetCreateOrUpdate(
-	r common.ReconcilerCommon,
-	obj metav1.Object,
-	ipset common.IPSet,
-) (*ospdirectorv1beta1.OpenStackIPSet, controllerutil.OperationResult, error) {
-	overcloudIPSet := &ospdirectorv1beta1.OpenStackIPSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      obj.GetName(),
-			Namespace: obj.GetNamespace(),
-			Labels: map[string]string{
-				AddToPredictableIPsLabel: strconv.FormatBool(ipset.AddToPredictableIPs),
-			},
-		},
-	}
-
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.GetClient(), overcloudIPSet, func() error {
-		overcloudIPSet.Spec.Networks = ipset.Networks
-		overcloudIPSet.Spec.RoleName = ipset.Role
-		overcloudIPSet.Spec.HostCount = ipset.HostCount
-		overcloudIPSet.Spec.VIP = ipset.VIP
-		overcloudIPSet.Spec.AddToPredictableIPs = ipset.AddToPredictableIPs
-		overcloudIPSet.Spec.HostNameRefs = ipset.HostNameRefs
-
-		err := controllerutil.SetControllerReference(obj, overcloudIPSet, r.GetScheme())
-
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	return overcloudIPSet, op, err
-}
-
 //
 // CreateOrUpdateIPset - Create/Update IPSet
 //


### PR DESCRIPTION
Converts the osbmset controller to use defer function to update/set conditions.

Also:
* Allign defer function of all controllers to log current cond msg
  The condition gets updated only if the condition of the CR
  changed, but we should log all of them to be able to follow the
  reconcilations from the operator log.

* Set condition if finalizer fails to be removed