### PR TITLE
[OSPK8-422] generate ctlplane Ansible inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,22 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
     * `-a` - accept the new available rendered playbooks and tag them as `latest`
     * `-p` - run the ansible driven OpenStack deployment
 
-    a) check for new version of rendered playbooks and accept them
+    a) register the overcloud systems to required channels
+
+    Use the procedure as described in [5.9. Running Ansible-based registration manually](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html-single/advanced_overcloud_customization/index#running-ansible-based-registration-manually-portal) do do so. The inventory file for all hosts on the ctlplane network has been generated within the openstackclient pod at /home/cloud-admin/ctlplane-inventory.yaml.
+
+    ```bash
+    oc rsh openstackclient
+    bash
+    cd /home/cloud-admin
+
+    <create the ansible playbook for the overcloud nodes - e.g. rhsm.yaml>
+
+    # register the overcloud nodes to required repositories
+    ansible-playpook -i /home/cloud-admin/ctlplane-inventory.yaml ./rhsm.yaml
+    ```
+
+    b) check for new version of rendered playbooks and accept them
 
     ```bash
     oc rsh openstackclient
@@ -586,21 +601,6 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
 
     # accept the new available rendered playbooks (if available) and tag them as `latest`
     ./tripleo-deploy.sh -a
-    ```
-
-    b) register the overcloud systems to required channels
-
-    The command in step a) to accept the current available rendered playbooks contain the latest inventory file of the overcloud and can be used to register the overcloud nodes to the required repositories for deployment. Use the procedure as described in [5.9. Running Ansible-based registration manually](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html-single/advanced_overcloud_customization/index#running-ansible-based-registration-manually-portal) do do so.
-
-    ```bash
-    oc rsh openstackclient
-    bash
-    cd /home/cloud-admin
-
-    <create the ansible playbook for the overcloud nodes - e.g. rhsm.yaml>
-
-    # register the overcloud nodes to required repositories
-    ansible-playpook -i /home/cloud-admin/playbooks/tripleo-ansible/inventory.yaml ./rhsm.yaml
     ```
 
     c) run ansible driven OpenStack deployment

--- a/pkg/openstackclient/volumes.go
+++ b/pkg/openstackclient/volumes.go
@@ -51,6 +51,12 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volu
 			ReadOnly:  true,
 		},
 		{
+			Name:      "openstackclient-scripts",
+			MountPath: "/home/cloud-admin/ctlplane-inventory.yaml",
+			SubPath:   "ctlplane-inventory.yaml",
+			ReadOnly:  true,
+		},
+		{
 			Name:      "kolla-config",
 			MountPath: "/var/lib/kolla/config_files",
 			ReadOnly:  true,
@@ -181,6 +187,10 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 						{
 							Key:  "init.sh",
 							Path: "init.sh",
+						},
+						{
+							Key:  "ctlplane-inventory.yaml",
+							Path: "ctlplane-inventory.yaml",
 						},
 					},
 				},

--- a/pkg/openstacknet/funcs.go
+++ b/pkg/openstacknet/funcs.go
@@ -85,3 +85,25 @@ func GetOpenStackNetWithLabel(r common.ReconcilerCommon, namespace string, label
 	}
 	return &osNetList.Items[0], nil
 }
+
+// GetOpenStackNetworkRoleHostnameIPs - Return a map of hostname/IPs for the specified network selector
+func GetOpenStackNetworkRoleHostnameIPs(r common.ReconcilerCommon, namespace string, labelSelector map[string]string) (map[string]map[string]string, error) {
+	ctlplaneIps := map[string]map[string]string{}
+
+	ctlplane, err := GetOpenStackNetWithLabel(
+		r,
+		namespace,
+		labelSelector,
+	)
+	if err != nil {
+		return ctlplaneIps, err
+	}
+	for val, roleReservation := range ctlplane.Status.RoleReservations {
+		roleReservations := map[string]string{}
+		for _, ipReservation := range roleReservation.Reservations {
+			roleReservations[ipReservation.Hostname] = ipReservation.IP
+		}
+		ctlplaneIps[val] = roleReservations
+	}
+	return ctlplaneIps, err
+}

--- a/templates/openstackclient/bin/ctlplane-inventory.yaml
+++ b/templates/openstackclient/bin/ctlplane-inventory.yaml
@@ -1,0 +1,9 @@
+overcloud:
+{{- if .RoleCtlplaneNetworkHostnameIPs }}
+{{- range $role, $hostIps := .RoleCtlplaneNetworkHostnameIPs }}
+  {{ $role }}:
+{{- range $hostname, $ip := $hostIps }}
+    {{ $ip }}:
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This patch creates an Ansible inventory of the cltplane
IPs within the openstackclient pod. The intent is for this
to be used for RH node registration instead of relying
on the ConfigGenerator/TripleO inventory to be generated
which doesn't actually exist at the time we need it with
the new workflow.