### PR TITLE
Fix kubevirt fencing agent SA perms

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -153,6 +153,13 @@ rules:
   - virtualmachineinstances
   verbs:
   - get
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Adds missing `get` and `list` permissions for `virtualmachines` for the Kubevirt fencing agent service account