### PR TITLE
[OSPK8-423] move osmacaddr CR create from osctlplane to osnetcfg and fix kuttl tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
             cidr: 192.168.25.0/24
             gateway: 192.168.25.1
           attachConfiguration: br-osp
+      # optional: (OSP17 only) specify all phys networks with optional MAC address prefix, used to
+      # create static OVN Bridge MAC address mappings. Unique OVN bridge mac address per node is
+      # dynamically allocated by creating OpenStackMACAddress resource and create a MAC per physnet per node.
+      # If not specfified the default datacentre phynet with "fa:16:3a" MAC prefix will be used.
+      physNetworks:
+            - name: datacentre
+              macPrefix: fa:16:3a
+            - name: datacentre2
+              macPrefix: fa:16:3b
     ```
 
     If you write the above YAML into a file called networkconfig.yaml you can create the OpenStackNetConfig via this command:
@@ -445,14 +454,6 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
       openStackClientStorageClass: host-nfs-storageclass
       passwordSecret: userpassword
       gitSecret: git-secret
-      # optional: specify all phys networks with optional MAC address prefix, used to create static OVN Bridge MAC address mappings.
-      # Unique OVN bridge mac address per node is dynamically allocated by creating OpenStackMACAddress resource and create a MAC per
-      # physnet per node.
-      physNetworks:
-            - name: datacentre
-              macPrefix: fa:16:3a
-            - name: datacentre2
-              macPrefix: fa:16:3b 
       virtualMachineRoles:
         controller:
           roleName: Controller

--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -58,14 +58,6 @@ type OpenStackControlPlaneSpec struct {
 	// OpenStackClientNetworks the name(s) of the OpenStackClientNetworks used to attach the openstackclient to
 	OpenStackClientNetworks []string `json:"openStackClientNetworks"`
 
-	// +kubebuilder:validation:Optional
-	// PhysNetworks - physical networks list with optional MAC address prefix, used to create static OVN Bridge MAC address mappings.
-	// Unique OVN bridge mac address is dynamically allocated by creating OpenStackMACAddress resource and create a MAC per physnet per OpenStack node.
-	// This information is used to create the OVNStaticBridgeMacMappings.
-	// If PhysNetworks is not provided, the tripleo default physnet datacentre gets created
-	// If the macPrefix is not specified for a physnet, the default macPrefix "fa:16:3a" is used.
-	PhysNetworks []Physnet `json:"physNetworks"`
-
 	// +kubebuilder:default=false
 	// EnableFencing is provided so that users have the option to disable fencing if desired
 	// FIXME: Defaulting to false until Kubevirt agent merged into RHEL overcloud image

--- a/api/v1beta1/openstackcontrolplane_webhook.go
+++ b/api/v1beta1/openstackcontrolplane_webhook.go
@@ -127,18 +127,6 @@ func (r *OpenStackControlPlane) Default() {
 	}
 
 	//
-	// set default PhysNetworks name/prefix if non speficied
-	//
-	if len(r.Spec.PhysNetworks) == 0 {
-		r.Spec.PhysNetworks = []Physnet{
-			{
-				Name:      DefaultOVNChassisPhysNetName,
-				MACPrefix: DefaultOVNChassisPhysNetMACPrefix,
-			},
-		}
-	}
-
-	//
 	// set OpenStackRelease if non provided
 	//
 	if r.Spec.OpenStackRelease == "" {

--- a/api/v1beta1/openstackmacaddress_types.go
+++ b/api/v1beta1/openstackmacaddress_types.go
@@ -59,10 +59,7 @@ type OpenStackMACNodeStatus struct {
 	Deleted bool `json:"deleted"`
 }
 
-// MACState - the state of this openstack mac reservation
-type MACState string
-
-// MACReason - the reason of the condition for this openstack ipset
+// MACReason - the reason of the condition for this openstack mac
 type MACReason string
 
 const (
@@ -71,13 +68,13 @@ const (
 	//
 
 	// MACCondTypeWaiting - the mac creation is blocked by prerequisite objects
-	MACCondTypeWaiting MACState = "Waiting"
+	MACCondTypeWaiting ProvisioningState = "Waiting"
 	// MACCondTypeCreating - we are waiting for mac addresses to be created
-	MACCondTypeCreating MACState = "Creating"
+	MACCondTypeCreating ProvisioningState = "Creating"
 	// MACCondTypeConfigured - the MAC addresses have been created
-	MACCondTypeConfigured MACState = "Created"
+	MACCondTypeConfigured ProvisioningState = "Created"
 	// MACCondTypeError - the mac creation hit a error
-	MACCondTypeError MACState = "Error"
+	MACCondTypeError ProvisioningState = "Error"
 
 	//
 	// condition reasones
@@ -102,7 +99,7 @@ type OpenStackMACAddressStatus struct {
 	ReservedMACCount int `json:"reservedMACCount"`
 
 	// CurrentState - the overall state of the OSMAC cr
-	CurrentState MACState `json:"currentState"`
+	CurrentState ProvisioningState `json:"currentState"`
 
 	// Conditions - conditions to display in the OpenShift GUI, which reflect CurrentState
 	Conditions ConditionList `json:"conditions,omitempty" optional:"true"`

--- a/api/v1beta1/openstacknet_types.go
+++ b/api/v1beta1/openstacknet_types.go
@@ -113,7 +113,7 @@ type OpenStackNetStatus struct {
 	ReservedIPCount int `json:"reservedIpCount"`
 
 	// CurrentState - the overall state of this network
-	CurrentState NetState `json:"currentState"`
+	CurrentState ProvisioningState `json:"currentState"`
 
 	// TODO: It would be simpler, perhaps, to just have Conditions and get rid of CurrentState,
 	// but we are using the same approach in other CRDs for now anyhow
@@ -121,8 +121,8 @@ type OpenStackNetStatus struct {
 	Conditions ConditionList `json:"conditions,omitempty" optional:"true"`
 }
 
-// NetState - the state of this openstack network
-type NetState string
+// NetReason - the reason of the condition for this openstack net
+type NetReason string
 
 const (
 	//
@@ -130,15 +130,22 @@ const (
 	//
 
 	// NetWaiting - the network configuration is blocked by prerequisite objects
-	NetWaiting NetState = "Waiting"
+	NetWaiting ProvisioningState = "Waiting"
 	// NetInitializing - we are waiting for underlying OCP network resource(s) to appear
-	NetInitializing NetState = "Initializing"
+	NetInitializing ProvisioningState = "Initializing"
 	// NetConfiguring - the underlying network resources are configuring the nodes
-	NetConfiguring NetState = "Configuring"
+	NetConfiguring ProvisioningState = "Configuring"
 	// NetConfigured - the nodes have been configured by the underlying network resources
-	NetConfigured NetState = "Configured"
+	NetConfigured ProvisioningState = "Configured"
 	// NetError - the network configuration hit a generic error
-	NetError NetState = "Error"
+	NetError ProvisioningState = "Error"
+
+	//
+	// condition reasones
+	//
+
+	// NetCondReasonCreated - osnet created
+	NetCondReasonCreated ConditionReason = "NetCreated"
 )
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/openstacknet_types.go
+++ b/api/v1beta1/openstacknet_types.go
@@ -121,9 +121,6 @@ type OpenStackNetStatus struct {
 	Conditions ConditionList `json:"conditions,omitempty" optional:"true"`
 }
 
-// NetReason - the reason of the condition for this openstack net
-type NetReason string
-
 const (
 	//
 	// condition types
@@ -145,7 +142,9 @@ const (
 	//
 
 	// NetCondReasonCreated - osnet created
-	NetCondReasonCreated ConditionReason = "NetCreated"
+	NetCondReasonCreated ConditionReason = "OpenStackNetCreated"
+	// NetCondReasonCreateError - error creating osnet object
+	NetCondReasonCreateError ConditionReason = "OpenStackNetCreateError"
 )
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/openstacknetattachment_types.go
+++ b/api/v1beta1/openstacknetattachment_types.go
@@ -76,7 +76,7 @@ type OpenStackNetAttachmentSpec struct {
 // OpenStackNetAttachmentStatus defines the observed state of OpenStackNetAttachment
 type OpenStackNetAttachmentStatus struct {
 	// CurrentState - the overall state of the network attachment
-	CurrentState NetAttachState `json:"currentState"`
+	CurrentState ProvisioningState `json:"currentState"`
 
 	// TODO: It would be simpler, perhaps, to just have Conditions and get rid of CurrentState,
 	// but we are using the same approach in other CRDs for now anyhow
@@ -94,16 +94,27 @@ type OpenStackNetAttachmentStatus struct {
 type NetAttachState string
 
 const (
+	//
+	// condition types
+	//
+
 	// NetAttachWaiting - the network configuration is blocked by prerequisite objects
-	NetAttachWaiting NetAttachState = "Waiting"
+	NetAttachWaiting ProvisioningState = "Waiting"
 	// NetAttachInitializing - we are waiting for underlying OCP network resource(s) to appear
-	NetAttachInitializing NetAttachState = "Initializing"
+	NetAttachInitializing ProvisioningState = "Initializing"
 	// NetAttachConfiguring - the underlying network resources are configuring the nodes
-	NetAttachConfiguring NetAttachState = "Configuring"
+	NetAttachConfiguring ProvisioningState = "Configuring"
 	// NetAttachConfigured - the nodes have been configured by the underlying network resources
-	NetAttachConfigured NetAttachState = "Configured"
+	NetAttachConfigured ProvisioningState = "Configured"
 	// NetAttachError - the network configuration hit a generic error
-	NetAttachError NetAttachState = "Error"
+	NetAttachError ProvisioningState = "Error"
+
+	//
+	// condition reasones
+	//
+
+	// NetAttachCondReasonCreated - osnetattachment created
+	NetAttachCondReasonCreated ConditionReason = "NetAttachCreated"
 )
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/openstacknetattachment_types.go
+++ b/api/v1beta1/openstacknetattachment_types.go
@@ -90,9 +90,6 @@ type OpenStackNetAttachmentStatus struct {
 	BridgeName string `json:"bridgeName"`
 }
 
-// NetAttachState - the state of this openstack network
-type NetAttachState string
-
 const (
 	//
 	// condition types
@@ -115,6 +112,8 @@ const (
 
 	// NetAttachCondReasonCreated - osnetattachment created
 	NetAttachCondReasonCreated ConditionReason = "NetAttachCreated"
+	// NetAttachCondReasonCreateError - error creating osnetatt object
+	NetAttachCondReasonCreateError ConditionReason = "OpenStackNetAttachtCreateError"
 )
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/openstacknetconfig_types.go
+++ b/api/v1beta1/openstacknetconfig_types.go
@@ -129,6 +129,14 @@ type OpenStackNetConfigSpec struct {
 	// +kubebuilder:validation:Required
 	// Networks, list of all tripleo networks of the deployment
 	Networks []Network `json:"networks"`
+
+	// +kubebuilder:validation:Optional
+	// PhysNetworks - physical networks list with optional MAC address prefix, used to create static OVN Bridge MAC address mappings.
+	// Unique OVN bridge mac address is dynamically allocated by creating OpenStackMACAddress resource and create a MAC per physnet per OpenStack node.
+	// This information is used to create the OVNStaticBridgeMacMappings.
+	// If PhysNetworks is not provided, the tripleo default physnet datacentre gets created
+	// If the macPrefix is not specified for a physnet, the default macPrefix "fa:16:3a" is used.
+	PhysNetworks []Physnet `json:"physNetworks"`
 }
 
 // OpenStackNetConfigStatus defines the observed state of OpenStackNetConfig
@@ -141,12 +149,14 @@ type OpenStackNetConfigStatus struct {
 // OpenStackNetConfigProvisioningStatus represents the overall provisioning state of
 // the OpenStackNetConfig (with an optional explanatory message)
 type OpenStackNetConfigProvisioningStatus struct {
-	State              ProvisioningState `json:"state,omitempty"`
-	Reason             string            `json:"reason,omitempty"`
-	AttachDesiredCount int               `json:"attachDesiredCount,omitempty"`
-	AttachReadyCount   int               `json:"attachReadyCount,omitempty"`
-	NetDesiredCount    int               `json:"netDesiredCount,omitempty"`
-	NetReadyCount      int               `json:"netReadyCount,omitempty"`
+	State               ProvisioningState `json:"state,omitempty"`
+	Reason              string            `json:"reason,omitempty"`
+	AttachDesiredCount  int               `json:"attachDesiredCount,omitempty"`
+	AttachReadyCount    int               `json:"attachReadyCount,omitempty"`
+	NetDesiredCount     int               `json:"netDesiredCount,omitempty"`
+	NetReadyCount       int               `json:"netReadyCount,omitempty"`
+	PhysNetDesiredCount int               `json:"physNetDesiredCount,omitempty"`
+	PhysNetReadyCount   int               `json:"physNetReadyCount,omitempty"`
 }
 
 const (
@@ -170,6 +180,8 @@ const (
 //+kubebuilder:printcolumn:name="AttachConfig Ready",type="integer",JSONPath=".status.provisioningStatus.attachReadyCount",description="AttachConfig Ready"
 //+kubebuilder:printcolumn:name="Networks Desired",type="integer",JSONPath=".status.provisioningStatus.netDesiredCount",description="Networks Desired"
 //+kubebuilder:printcolumn:name="Networks Ready",type="integer",JSONPath=".status.provisioningStatus.netReadyCount",description="Networks Ready"
+//+kubebuilder:printcolumn:name="PhysNetworks Desired",type="integer",JSONPath=".status.provisioningStatus.physNetDesiredCount",description="PhysNetworks Desired"
+//+kubebuilder:printcolumn:name="PhysNetworks Ready",type="integer",JSONPath=".status.provisioningStatus.physNetReadyCount",description="PhysNetworks Ready"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.provisioningStatus.state",description="Status"
 //+kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.provisioningStatus.reason",description="Reason"
 

--- a/api/v1beta1/openstacknetconfig_webhook.go
+++ b/api/v1beta1/openstacknetconfig_webhook.go
@@ -67,6 +67,18 @@ func (r *OpenStackNetConfig) Default() {
 	}
 
 	//
+	// set default PhysNetworks name/prefix if non speficied
+	//
+	if len(r.Spec.PhysNetworks) == 0 {
+		r.Spec.PhysNetworks = []Physnet{
+			{
+				Name:      DefaultOVNChassisPhysNetName,
+				MACPrefix: DefaultOVNChassisPhysNetMACPrefix,
+			},
+		}
+	}
+
+	//
 	// The default domain name if non specified
 	//
 	if r.Spec.DomainName == "" {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1203,11 +1203,6 @@ func (in *OpenStackControlPlaneSpec) DeepCopyInto(out *OpenStackControlPlaneSpec
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.PhysNetworks != nil {
-		in, out := &in.PhysNetworks, &out.PhysNetworks
-		*out = make([]Physnet, len(*in))
-		copy(*out, *in)
-	}
 	if in.DNSServers != nil {
 		in, out := &in.DNSServers, &out.DNSServers
 		*out = make([]string, len(*in))
@@ -1862,6 +1857,11 @@ func (in *OpenStackNetConfigSpec) DeepCopyInto(out *OpenStackNetConfigSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.PhysNetworks != nil {
+		in, out := &in.PhysNetworks, &out.PhysNetworks
+		*out = make([]Physnet, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -867,39 +867,6 @@ spec:
                                   description: PasswordSecret used to e.g specify
                                     root pwd
                                   type: string
-                                physNetworks:
-                                  description: PhysNetworks - physical networks list
-                                    with optional MAC address prefix, used to create
-                                    static OVN Bridge MAC address mappings. Unique
-                                    OVN bridge mac address is dynamically allocated
-                                    by creating OpenStackMACAddress resource and create
-                                    a MAC per physnet per OpenStack node. This information
-                                    is used to create the OVNStaticBridgeMacMappings.
-                                    If PhysNetworks is not provided, the tripleo default
-                                    physnet datacentre gets created If the macPrefix
-                                    is not specified for a physnet, the default macPrefix
-                                    "fa:16:3a" is used.
-                                  items:
-                                    description: Physnet - name and prefix to be used
-                                      for the physnet
-                                    properties:
-                                      macPrefix:
-                                        default: fa:16:3a
-                                        description: MACPrefix - the MAC address prefix
-                                          to use Locally administered addresses are
-                                          distinguished from universally administered
-                                          addresses by setting (assigning the value
-                                          of 1 to) the second-least-significant bit
-                                          of the first octet of the address. https://en.wikipedia.org/wiki/MAC_address#Universal_vs._local_(U/L_bit)
-                                        type: string
-                                      name:
-                                        default: datacentre
-                                        description: Name - the name of the physnet
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                  type: array
                                 virtualMachineRoles:
                                   additionalProperties:
                                     description: OpenStackVirtualMachineRoleSpec -
@@ -2080,6 +2047,39 @@ spec:
                                     - subnets
                                     type: object
                                   type: array
+                                physNetworks:
+                                  description: PhysNetworks - physical networks list
+                                    with optional MAC address prefix, used to create
+                                    static OVN Bridge MAC address mappings. Unique
+                                    OVN bridge mac address is dynamically allocated
+                                    by creating OpenStackMACAddress resource and create
+                                    a MAC per physnet per OpenStack node. This information
+                                    is used to create the OVNStaticBridgeMacMappings.
+                                    If PhysNetworks is not provided, the tripleo default
+                                    physnet datacentre gets created If the macPrefix
+                                    is not specified for a physnet, the default macPrefix
+                                    "fa:16:3a" is used.
+                                  items:
+                                    description: Physnet - name and prefix to be used
+                                      for the physnet
+                                    properties:
+                                      macPrefix:
+                                        default: fa:16:3a
+                                        description: MACPrefix - the MAC address prefix
+                                          to use Locally administered addresses are
+                                          distinguished from universally administered
+                                          addresses by setting (assigning the value
+                                          of 1 to) the second-least-significant bit
+                                          of the first octet of the address. https://en.wikipedia.org/wiki/MAC_address#Universal_vs._local_(U/L_bit)
+                                        type: string
+                                      name:
+                                        default: datacentre
+                                        description: Name - the name of the physnet
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
                               required:
                               - attachConfigurations
                               - networks
@@ -2131,6 +2131,10 @@ spec:
                                     netDesiredCount:
                                       type: integer
                                     netReadyCount:
+                                      type: integer
+                                    physNetDesiredCount:
+                                      type: integer
+                                    physNetReadyCount:
                                       type: integer
                                     reason:
                                       type: string

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -119,34 +119,6 @@ spec:
               passwordSecret:
                 description: PasswordSecret used to e.g specify root pwd
                 type: string
-              physNetworks:
-                description: PhysNetworks - physical networks list with optional MAC
-                  address prefix, used to create static OVN Bridge MAC address mappings.
-                  Unique OVN bridge mac address is dynamically allocated by creating
-                  OpenStackMACAddress resource and create a MAC per physnet per OpenStack
-                  node. This information is used to create the OVNStaticBridgeMacMappings.
-                  If PhysNetworks is not provided, the tripleo default physnet datacentre
-                  gets created If the macPrefix is not specified for a physnet, the
-                  default macPrefix "fa:16:3a" is used.
-                items:
-                  description: Physnet - name and prefix to be used for the physnet
-                  properties:
-                    macPrefix:
-                      default: fa:16:3a
-                      description: MACPrefix - the MAC address prefix to use Locally
-                        administered addresses are distinguished from universally
-                        administered addresses by setting (assigning the value of
-                        1 to) the second-least-significant bit of the first octet
-                        of the address. https://en.wikipedia.org/wiki/MAC_address#Universal_vs._local_(U/L_bit)
-                      type: string
-                    name:
-                      default: datacentre
-                      description: Name - the name of the physnet
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
               virtualMachineRoles:
                 additionalProperties:
                   description: OpenStackVirtualMachineRoleSpec - defines the desired

--- a/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
@@ -38,6 +38,14 @@ spec:
       jsonPath: .status.provisioningStatus.netReadyCount
       name: Networks Ready
       type: integer
+    - description: PhysNetworks Desired
+      jsonPath: .status.provisioningStatus.physNetDesiredCount
+      name: PhysNetworks Desired
+      type: integer
+    - description: PhysNetworks Ready
+      jsonPath: .status.provisioningStatus.physNetReadyCount
+      name: PhysNetworks Ready
+      type: integer
     - description: Status
       jsonPath: .status.provisioningStatus.state
       name: Status
@@ -281,6 +289,34 @@ spec:
                   - subnets
                   type: object
                 type: array
+              physNetworks:
+                description: PhysNetworks - physical networks list with optional MAC
+                  address prefix, used to create static OVN Bridge MAC address mappings.
+                  Unique OVN bridge mac address is dynamically allocated by creating
+                  OpenStackMACAddress resource and create a MAC per physnet per OpenStack
+                  node. This information is used to create the OVNStaticBridgeMacMappings.
+                  If PhysNetworks is not provided, the tripleo default physnet datacentre
+                  gets created If the macPrefix is not specified for a physnet, the
+                  default macPrefix "fa:16:3a" is used.
+                items:
+                  description: Physnet - name and prefix to be used for the physnet
+                  properties:
+                    macPrefix:
+                      default: fa:16:3a
+                      description: MACPrefix - the MAC address prefix to use Locally
+                        administered addresses are distinguished from universally
+                        administered addresses by setting (assigning the value of
+                        1 to) the second-least-significant bit of the first octet
+                        of the address. https://en.wikipedia.org/wiki/MAC_address#Universal_vs._local_(U/L_bit)
+                      type: string
+                    name:
+                      default: datacentre
+                      description: Name - the name of the physnet
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
             required:
             - attachConfigurations
             - networks
@@ -330,6 +366,10 @@ spec:
                   netDesiredCount:
                     type: integer
                   netReadyCount:
+                    type: integer
+                  physNetDesiredCount:
+                    type: integer
+                  physNetReadyCount:
                     type: integer
                   reason:
                     type: string

--- a/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
+++ b/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
@@ -7,7 +7,7 @@ spec:
   # How many nodes to provision
   count: 1
   # The image to install on the provisioned nodes
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys
   # Networks to associate with this host

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -15,11 +15,6 @@ spec:
   openStackClientStorageClass: host-nfs-storageclass
   openStackRelease: "16.2"
   passwordSecret: userpassword
-  physNetworks:
-    - name: datacentre
-      macPrefix: fa:16:3a
-    - name: datacentre2
-      macPrefix: fa:16:3b
   virtualMachineRoles:
     controller:
       baseImageVolumeName: controller-base-img

--- a/config/samples/osp-director_v1beta1_openstacknetconfig.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknetconfig.yaml
@@ -104,3 +104,8 @@ spec:
         cidr: 172.20.0.0/24
       vlan: 50
       attachConfiguration: br-osp
+  physNetworks:
+    - name: datacentre
+      macPrefix: fa:16:3a
+    - name: datacentre2
+      macPrefix: fa:16:3b

--- a/config/samples/osp-director_v1beta1_openstacknetconfig_multi_subnet.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknetconfig_multi_subnet.yaml
@@ -232,3 +232,8 @@ spec:
           nexthop: 172.20.2.1
       vlan: 52
       attachConfiguration: br-osp
+  physNetworks:
+    - name: datacentre
+      macPrefix: fa:16:3a
+    - name: datacentre2
+      macPrefix: fa:16:3b

--- a/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
+++ b/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: openstack
 spec:
   port: 8080
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2

--- a/controllers/openstacknet_controller.go
+++ b/controllers/openstacknet_controller.go
@@ -120,7 +120,7 @@ func (r *OpenStackNetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		//
 		// Update object conditions
 		//
-		instance.Status.CurrentState = ospdirectorv1beta1.NetState(cond.Type)
+		instance.Status.CurrentState = ospdirectorv1beta1.ProvisioningState(cond.Type)
 		instance.Status.Conditions.UpdateCurrentCondition(
 			cond.Type,
 			ospdirectorv1beta1.ConditionReason(cond.Message),
@@ -191,8 +191,11 @@ func (r *OpenStackNetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// If we determine that a backup is overriding this reconcile, requeue after a longer delay
-	overrideReconcile, err := ospdirectorv1beta1.OpenStackBackupOverridesReconcile(r.Client, instance.Namespace, instance.Status.CurrentState == ospdirectorv1beta1.NetConfigured)
-
+	overrideReconcile, err := ospdirectorv1beta1.OpenStackBackupOverridesReconcile(
+		r.Client,
+		instance.Namespace,
+		instance.Status.CurrentState == ospdirectorv1beta1.NetConfigured,
+	)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/openstacknetattachment_controller.go
+++ b/controllers/openstacknetattachment_controller.go
@@ -121,7 +121,7 @@ func (r *OpenStackNetAttachmentReconciler) Reconcile(ctx context.Context, req ct
 		//
 		// Update object conditions
 		//
-		instance.Status.CurrentState = ospdirectorv1beta1.NetAttachState(cond.Type)
+		instance.Status.CurrentState = ospdirectorv1beta1.ProvisioningState(cond.Type)
 
 		// TODO, we should set some proper cond.Reason type
 		instance.Status.Conditions.UpdateCurrentCondition(

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -215,7 +215,9 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		}
 
-		// 5. as last step remove the finalizer on the operator CR to finish delete
+		// TODO: osmacaddr cleanup
+
+		// X. as last step remove the finalizer on the operator CR to finish delete
 		controllerutil.RemoveFinalizer(instance, openstacknetconfig.FinalizerName)
 		err = r.Client.Update(context.TODO(), instance)
 		if err != nil {
@@ -245,7 +247,20 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	//
-	// 1) create all OpenStackNetworkAttachments
+	// 1) Create or update the MACAddress CR object
+	//
+	instance.Status.ProvisioningStatus.PhysNetDesiredCount = len(instance.Spec.PhysNetworks)
+	instance.Status.ProvisioningStatus.PhysNetReadyCount = 0
+	err = r.createOrUpdateOpenStackMACAddress(
+		instance,
+		cond,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	//
+	// 2) create all OpenStackNetworkAttachments
 	//
 	instance.Status.ProvisioningStatus.AttachDesiredCount = len(instance.Spec.AttachConfigurations)
 	instance.Status.ProvisioningStatus.AttachReadyCount = 0
@@ -281,7 +296,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	//
-	// 2) create all OpenStackNetworks
+	// 3) create all OpenStackNetworks
 	//
 	instance.Status.ProvisioningStatus.NetDesiredCount = len(instance.Spec.Networks)
 	instance.Status.ProvisioningStatus.NetReadyCount = 0
@@ -388,16 +403,26 @@ func (r *OpenStackNetConfigReconciler) applyNetAttachmentConfig(
 
 	op, err := controllerutil.CreateOrUpdate(context.Background(), r.Client, attachConfig, apply)
 	if err != nil {
-		err = common.WrapErrorForObject(fmt.Sprintf("Updating %s OpenStackNetworkAttach", attachConfig.Name), attachConfig, err)
+		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", attachConfig.Kind, attachConfig.Name)
+		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.OpenStackProvisionServerCondReasonCreateError)
+		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+		err = common.WrapErrorForObject(cond.Message, attachConfig, err)
+
 		return attachConfig, err
 	}
 
-	if op != controllerutil.OperationResultNone {
-		cond.Message = fmt.Sprintf("OpenStackNetworkAttachment %s is %s", attachConfig.Name, string(op))
-		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigConfiguring)
+	cond.Message = fmt.Sprintf("%s %s %s %s CR successfully reconciled",
+		instance.Kind,
+		instance.Name,
+		attachConfig.Kind,
+		attachConfig.Name,
+	)
 
-		common.LogForObject(r, cond.Message, attachConfig)
+	if op != controllerutil.OperationResultNone {
+		cond.Message = fmt.Sprintf("%s - operation: %s", cond.Message, string(op))
 	}
+	cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetAttachCondReasonCreated)
+	cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeProvisioned)
 
 	return attachConfig, nil
 }
@@ -529,17 +554,26 @@ func (r *OpenStackNetConfigReconciler) applyNetConfig(
 
 	op, err := controllerutil.CreateOrUpdate(context.Background(), r.Client, osNet, apply)
 	if err != nil {
-		err = common.WrapErrorForObject(fmt.Sprintf("Updating %s OpenStackNetwork", osNet.Name), osNet, err)
+		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", osNet.Kind, osNet.Name)
+		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.OpenStackProvisionServerCondReasonCreateError)
+		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+		err = common.WrapErrorForObject(cond.Message, osNet, err)
+
 		return nil, err
 	}
 
+	cond.Message = fmt.Sprintf("%s %s %s %s CR successfully reconciled",
+		instance.Kind,
+		instance.Name,
+		osNet.Kind,
+		osNet.Name,
+	)
+
 	if op != controllerutil.OperationResultNone {
-		cond.Message = fmt.Sprintf("OpenStackNetwork %s is %s", osNet.Name, string(op))
-		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigConfiguring)
-	} else {
-		cond.Message = fmt.Sprintf("OpenStackNetwork %s configured", osNet.Name)
-		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigConfigured)
+		cond.Message = fmt.Sprintf("%s - operation: %s", cond.Message, string(op))
 	}
+	cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetCondReasonCreated)
+	cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeProvisioned)
 
 	return osNet, nil
 }
@@ -605,6 +639,81 @@ func (r *OpenStackNetConfigReconciler) osnetCleanup(
 	}
 
 	common.LogForObject(r, cond.Message, instance)
+
+	return nil
+}
+
+//
+// create or update the OpenStackMACAddress object
+//
+func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
+	instance *ospdirectorv1beta1.OpenStackNetConfig,
+	cond *ospdirectorv1beta1.Condition,
+) error {
+
+	mac := &ospdirectorv1beta1.OpenStackMACAddress{
+		ObjectMeta: metav1.ObjectMeta{
+			// use the role name as the VM CR name
+			Name:      strings.ToLower(instance.Name),
+			Namespace: instance.Namespace,
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, mac, func() error {
+		if len(instance.Spec.PhysNetworks) == 0 {
+			mac.Spec.PhysNetworks = []ospdirectorv1beta1.Physnet{
+				{
+					Name:      ospdirectorv1beta1.DefaultOVNChassisPhysNetName,
+					MACPrefix: ospdirectorv1beta1.DefaultOVNChassisPhysNetMACPrefix,
+				},
+			}
+		} else {
+			macPhysnets := []ospdirectorv1beta1.Physnet{}
+			for _, physnet := range instance.Spec.PhysNetworks {
+				macPrefix := physnet.MACPrefix
+				// make sure if MACPrefix was not speficied to set the default prefix
+				if macPrefix == "" {
+					macPrefix = ospdirectorv1beta1.DefaultOVNChassisPhysNetMACPrefix
+				}
+				macPhysnets = append(macPhysnets, ospdirectorv1beta1.Physnet{
+					Name:      physnet.Name,
+					MACPrefix: macPrefix,
+				})
+			}
+
+			mac.Spec.PhysNetworks = macPhysnets
+		}
+
+		err := controllerutil.SetControllerReference(instance, mac, r.Scheme)
+		if err != nil {
+			cond.Message = fmt.Sprintf("Error set controller reference for %s", mac.Name)
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonControllerReferenceError)
+			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		cond.Message = fmt.Sprintf("Failed to create or update OpenStackMACAddress %s ", instance.Name)
+		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.MACCondReasonCreateMACError)
+		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+		err = common.WrapErrorForObject(cond.Message, instance, err)
+
+		return err
+	}
+
+	cond.Message = "OpenStackMACAddress CR successfully reconciled"
+
+	if op != controllerutil.OperationResultNone {
+		cond.Message = fmt.Sprintf("%s - operation: %s", cond.Message, string(op))
+	}
+	cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.MACCondReasonAllMACAddressesCreated)
+	cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeProvisioned)
+
+	instance.Status.ProvisioningStatus.PhysNetReadyCount = len(mac.Spec.PhysNetworks)
 
 	return nil
 }

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -404,7 +404,7 @@ func (r *OpenStackNetConfigReconciler) applyNetAttachmentConfig(
 	op, err := controllerutil.CreateOrUpdate(context.Background(), r.Client, attachConfig, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", attachConfig.Kind, attachConfig.Name)
-		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.OpenStackProvisionServerCondReasonCreateError)
+		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetAttachCondReasonCreateError)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
 		err = common.WrapErrorForObject(cond.Message, attachConfig, err)
 
@@ -555,7 +555,7 @@ func (r *OpenStackNetConfigReconciler) applyNetConfig(
 	op, err := controllerutil.CreateOrUpdate(context.Background(), r.Client, osNet, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", osNet.Kind, osNet.Name)
-		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.OpenStackProvisionServerCondReasonCreateError)
+		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetCondReasonCreateError)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
 		err = common.WrapErrorForObject(cond.Message, osNet, err)
 

--- a/pkg/controlplane/const.go
+++ b/pkg/controlplane/const.go
@@ -31,10 +31,4 @@ const (
 
 	// TripleoPasswordSecret - name of the generated tripleo password secret
 	TripleoPasswordSecret = "tripleo-passwords"
-
-	// DefaultOVNChassisPhysNetName - default physnet netname used for OVNStaticBridgeMacMappings
-	DefaultOVNChassisPhysNetName = "datacentre"
-
-	// DefaultOVNChassisPhysNetMACPrefix - default prefix used to create MAC addresses for OVNStaticBridgeMacMappings
-	DefaultOVNChassisPhysNetMACPrefix = "fa:16:3a"
 )

--- a/tests/kuttl/tests/openstackbaremetalset_scale/01-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/01-assert.yaml
@@ -176,6 +176,11 @@ spec:
       name: tenant
       vlan: 50
     vip: false
+  physNetworks:
+  - name: datacentre
+    macPrefix: fa:16:3a
+  - name: datacentre2
+    macPrefix: fa:16:3b
 status:
   provisioningStatus:
     attachDesiredCount: 2
@@ -541,3 +546,30 @@ status:
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackMACAddress
+metadata:
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
+  namespace: openstack
+spec:
+  physNetworks:
+  - macPrefix: fa:16:3a
+    name: datacentre
+  - macPrefix: fa:16:3b
+    name: datacentre2
+status:
+  conditions:
+  - message: Waiting for ctlplane network to be created
+    reason: NetNotFound
+    status: "False"
+    type: Waiting
+  - message: All MAC addresses created
+    reason: MACAddressesCreated
+    status: "True"
+    type: Created
+  currentState: Created
+  macReservations: {}
+  reservedMACCount: 0

--- a/tests/kuttl/tests/openstackbaremetalset_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/02-assert.yaml
@@ -26,11 +26,6 @@ spec:
   openStackClientStorageClass: host-nfs-storageclass
   openStackRelease: "16.2"
   passwordSecret: userpassword
-  physNetworks:
-  - name: datacentre
-    macPrefix: fa:16:3a
-  - name: datacentre2
-    macPrefix: fa:16:3b
   virtualMachineRoles:
     controller:
       baseImageVolumeName: controller-base-img
@@ -49,6 +44,26 @@ spec:
       roleCount: 0
       roleName: Controller
       storageClass: host-nfs-storageclass
+status:
+  ospVersion: "16.2"
+  provisioningStatus:
+    clientReady: true
+    desiredCount: 1
+    readyCount: 1
+    reason: All requested OSVMSets have been provisioned
+    state: Provisioned
+  vipStatus:
+    controlplane:
+      annotatedForDeletion: false
+      hostRef: controlplane
+      hostname: controlplane
+      ipaddresses:
+        ctlplane: 192.168.25.100/24
+        external: 10.0.0.10/24
+        internal_api: 172.17.0.10/24
+        storage: 172.18.0.10/24
+        storage_mgmt: 172.19.0.10/24
+      provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -79,11 +94,6 @@ spec:
   vmCount: 0
 status:
   baseImageDVReady: true
-  conditions:
-  - message: No VirtualMachines have been requested
-    reason: No VirtualMachines have been requested
-    status: "True"
-    type: Empty
   provisioningStatus:
     reason: No VirtualMachines have been requested
     state: Empty
@@ -109,12 +119,14 @@ spec:
 status:
   netStatus:
     openstackclient-0:
-      hostRef: openstackclient
+      annotatedForDeletion: false
+      hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
         ctlplane: 192.168.25.101/24
         external: 10.0.0.11/24
         internal_api: 172.17.0.11/24
+      provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -122,6 +134,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "true"
     ooo-netname: Control
     ooo-netname-lower: ctlplane
     ooo-subnetname: ctlplane
@@ -135,20 +148,11 @@ spec:
   allocationStart: 192.168.25.100
   attachConfiguration: br-osp
   cidr: 192.168.25.0/24
+  domainName: ctlplane.localdomain
   gateway: 192.168.25.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
-  vip: true
-  vlan: 0
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -164,6 +168,13 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+  routes: []
+  vip: true
+  vlan: 0
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -171,6 +182,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: External
     ooo-netname-lower: external
     ooo-subnetname: external
@@ -184,20 +196,11 @@ spec:
   allocationStart: 10.0.0.10
   attachConfiguration: br-ex
   cidr: 10.0.0.0/24
+  domainName: external.localdomain
   gateway: 10.0.0.1
   mtu: 1500
   name: External
   nameLower: external
-  vip: true
-  vlan: 0
-status:
-  conditions:
-  - message: OpenStackNet external has been successfully configured on targeted node(s)
-    reason: OpenStackNet external has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -213,6 +216,13 @@ status:
         hostname: openstackclient-0
         ip: 10.0.0.11
         vip: false
+  routes: []
+  vip: true
+  vlan: 0
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -220,6 +230,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: InternalApi
     ooo-netname-lower: internal_api
     ooo-subnetname: internal_api
@@ -233,20 +244,11 @@ spec:
   allocationStart: 172.17.0.10
   attachConfiguration: br-osp
   cidr: 172.17.0.0/24
+  domainName: internalapi.localdomain
   gateway: ""
   mtu: 1350
   name: InternalApi
   nameLower: internal_api
-  vip: true
-  vlan: 20
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -262,6 +264,13 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+  routes: []
+  vip: true
+  vlan: 20
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -269,6 +278,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: Storage
     ooo-netname-lower: storage
     ooo-subnetname: storage
@@ -282,20 +292,11 @@ spec:
   allocationStart: 172.18.0.10
   attachConfiguration: br-osp
   cidr: 172.18.0.0/24
+  domainName: storage.localdomain
   gateway: ""
   mtu: 1350
   name: Storage
   nameLower: storage
-  vip: true
-  vlan: 30
-status:
-  conditions:
-  - message: OpenStackNet storage has been successfully configured on targeted node(s)
-    reason: OpenStackNet storage has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 1
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -304,6 +305,13 @@ status:
         hostname: controlplane
         ip: 172.18.0.10
         vip: true
+  routes: []
+  vip: true
+  vlan: 30
+status:
+  currentState: Configured
+  reservedIpCount: 1
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -311,6 +319,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: StorageMgmt
     ooo-netname-lower: storage_mgmt
     ooo-subnetname: storage_mgmt
@@ -324,20 +333,11 @@ spec:
   allocationStart: 172.19.0.10
   attachConfiguration: br-osp
   cidr: 172.19.0.0/24
+  domainName: storagemgmt.localdomain
   gateway: ""
   mtu: 1350
   name: StorageMgmt
   nameLower: storage_mgmt
-  vip: true
-  vlan: 40
-status:
-  conditions:
-  - message: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    reason: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 1
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -346,6 +346,13 @@ status:
         hostname: controlplane
         ip: 172.19.0.10
         vip: true
+  routes: []
+  vip: true
+  vlan: 40
+status:
+  currentState: Configured
+  reservedIpCount: 1
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -353,6 +360,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: Tenant
     ooo-netname-lower: tenant
     ooo-subnetname: tenant
@@ -366,18 +374,16 @@ spec:
   allocationStart: 172.20.0.10
   attachConfiguration: br-osp
   cidr: 172.20.0.0/24
+  domainName: tenant.localdomain
   gateway: ""
   mtu: 1350
   name: Tenant
   nameLower: tenant
+  roleReservations: {}
+  routes: []
   vip: false
   vlan: 50
 status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -395,7 +401,7 @@ spec:
   addToPredictableIPs: true
   hostCount: 1
   hostNameRefs:
-    controlplane: overcloud
+    controlplane: controlplane
   networks:
   - ctlplane
   - external
@@ -467,6 +473,9 @@ spec:
   - tenant
   roleName: Controller
   vip: false
+status:
+  hosts: {}
+  networks: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -481,7 +490,7 @@ spec:
   addToPredictableIPs: false
   hostCount: 1
   hostNameRefs:
-    openstackclient-0: openstackclient
+    openstackclient-0: openstackclient-0
   networks:
   - ctlplane
   - external
@@ -529,7 +538,7 @@ type: Opaque
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackMACAddress
 metadata:
-  name: overcloud
+  name: openstacknetconfig
   namespace: openstack
 spec:
   physNetworks:
@@ -538,11 +547,6 @@ spec:
   - macPrefix: fa:16:3b
     name: datacentre2
 status:
-  conditions:
-  - message: All MAC addresses created
-    reason: All MAC addresses created
-    status: "True"
-    type: Created
   currentState: Created
   macReservations: {}
   reservedMACCount: 0

--- a/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
@@ -14,7 +14,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   count: 0
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
@@ -26,12 +26,16 @@ spec:
   roleName: Compute
 status:
   conditions:
-  - message: No BaremetalHosts have been requested
-    reason: No BaremetalHosts have been requested
+  - message: OpenStackBaremetalSet compute OpenStackProvisionServer local image URL not yet available, requeuing and waiting 30 seconds                                                                                                                    
+    reason: Waiting
+    status: "False"
+    type: OpenStackProvisionServerNotReady
+  - message: No BaremetalHost have been requested
+    reason: BaremetalHostCountZero
     status: "True"
     type: Empty
   provisioningStatus:
-    reason: No BaremetalHosts have been requested
+    reason: No BaremetalHost have been requested
     state: Empty
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -40,11 +44,11 @@ metadata:
   name: compute-provisionserver
   namespace: openstack
 spec:
-  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:162cc35b2edb9054d29293ed3f0f98f195cf16647e89c3b8c7a4e911606ef4fd                                              
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2                                                                                       
-  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader@sha256:1a1caa9c2841f6aa66e385c3a21b9d084fd039c02b85e0a78722ededbed0bc22                            
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:d63a22b930f0309a8bb160b452147e81ceb1d3fd3df2d78f0a30e763e1d6f0c4
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
+  downloaderImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader@sha256:dadca151e8712eef8b206b69722c558b2aac035a4a3c52e705bf69c26d649567
   port: 6190
-  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent@sha256:22db35fb3fb4bb2d67a29f6db46ca8cbd8a903cc4f3437cfaec11f2b6b6d3b6b 
+  provisioningAgentImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-provisioner@sha256:77eab3a61ef569236a17575d5e4f1318d2ac13f164af8a2c94b732a4c50af579
 status:
   conditions:
   - message: ProvisionServer compute-provisionserver has been provisioned

--- a/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
@@ -19,7 +19,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   count: 2
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
@@ -41,11 +41,6 @@ status:
       ctlplaneIP: 192.168.25.103/24
       hostname: compute-1
       provisioningState: provisioned
-  conditions:
-  - message: All requested BaremetalHosts have been provisioned
-    reason: All requested BaremetalHosts have been provisioned
-    status: "True"
-    type: Provisioned
   provisioningStatus:
     readyCount: 2
     reason: All requested BaremetalHosts have been provisioned
@@ -132,14 +127,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -166,6 +154,15 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -174,14 +171,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -208,6 +198,15 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -216,14 +215,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -236,6 +228,15 @@ status:
         hostname: compute-1
         ip: 172.20.0.11
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
+    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet

--- a/tests/kuttl/tests/openstackbaremetalset_scale/05-check_openstackbaremetalset_connectivity.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/05-check_openstackbaremetalset_connectivity.yaml
@@ -10,7 +10,7 @@ commands:
       RETRIES="${RETRIES:-20}"
       for i in $(seq 1 $RETRIES); do
           SUCCESS="0"
-          for k in 101 102; do
+          for k in 102 103; do
             oc rsh -n openstack openstackclient ssh cloud-admin@192.168.25.$k hostname && SUCCESS=$((SUCCESS+1));
           done
           if [ "$SUCCESS" -eq "2" ]; then

--- a/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
@@ -15,7 +15,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   count: 1
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
@@ -32,39 +32,26 @@ status:
       ctlplaneIP: 192.168.25.103/24
       hostname: compute-1
       provisioningState: provisioned
-  conditions:
-  - message: All requested BaremetalHosts have been provisioned
-    reason: All requested BaremetalHosts have been provisioned
-    status: "True"
-    type: Provisioned
   provisioningStatus:
     readyCount: 1
     reason: All requested BaremetalHosts have been provisioned
     state: Provisioned
 ---
 # We don't know which BMH was chosen as compute-0 originally, so we just look
-# for one that is currently deprovisioning
-apiVersion: metal3.io/v1alpha1
-kind: BareMetalHost
-metadata:
-  finalizers:
-  - baremetalhost.metal3.io
-  namespace: openshift-machine-api
-spec:
-  bootMode: legacy
-  hardwareProfile: unknown
-  rootDeviceHints:
-    deviceName: /dev/sda
-status:
-  errorCount: 0
-  errorMessage: ""
-  hardwareProfile: unknown
-  operationalStatus: OK
-  provisioning:
-    bootMode: legacy
-    rootDeviceHints:
-      deviceName: /dev/sda
-    state: deprovisioning
+# for number of bmh hosts in deprovisioning state
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+timeout: 20
+commands:
+  - script: |
+      set -x
+      deprState=$(oc get bmh -n openshift-machine-api -o json | jq -r '.items[] | select(.status.provisioning.state=="deprovisioning") | .status.provisioning.state' | wc -l)
+      if [ $deprState -eq 1 ]; then
+          exit 0
+      else
+          exit 1
+      fi
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -110,14 +97,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 3
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -144,6 +124,15 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -152,14 +141,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -186,6 +168,15 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -194,14 +185,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -214,6 +198,15 @@ status:
         hostname: compute-1
         ip: 172.20.0.11
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
+    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -237,7 +230,7 @@ status:
   hosts:
     compute-1:
       ipaddresses:
-        ctlplane: 192.168.25.102/24
+        ctlplane: 192.168.25.103/24
         internal_api: 172.17.0.13/24
         tenant: 172.20.0.11/24
   networks:
@@ -254,8 +247,8 @@ status:
       gateway: ""
       vlan: 20
     tenant:
-      allocationEnd: 172.16.0.250
-      allocationStart: 172.16.0.4
-      cidr: 172.16.0.0/24
+      allocationEnd: 172.20.0.250
+      allocationStart: 172.20.0.10
+      cidr: 172.20.0.0/24
       gateway: ""
       vlan: 50

--- a/tests/kuttl/tests/openstackbaremetalset_scale/07-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/07-assert.yaml
@@ -42,25 +42,17 @@ status:
     state: provisioned
 ---
 # We don't know which BMH was chosen as compute-0 originally, so we just look
-# for one that is currently deprovisioning
-apiVersion: metal3.io/v1alpha1
-kind: BareMetalHost
-metadata:
-  finalizers:
-  - baremetalhost.metal3.io
-  namespace: openshift-machine-api
-spec:
-  bootMode: legacy
-  hardwareProfile: unknown
-  rootDeviceHints:
-    deviceName: /dev/sda
-status:
-  errorCount: 0
-  errorMessage: ""
-  hardwareProfile: unknown
-  operationalStatus: OK
-  provisioning:
-    bootMode: legacy
-    image:
-      url: ""
-    state: ready
+# for number of bmh hosts in ready state
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+timeout: 180
+commands:
+  - script: |
+      set -x
+      readyState=$(oc get bmh -n openshift-machine-api -o json | jq -r '.items[] | select(.status.provisioning.state=="ready") | .status.provisioning.state' | wc -l)
+      if [ $readyState -eq 1 ]; then
+          exit 0
+      else
+          exit 1
+      fi

--- a/tests/kuttl/tests/openstackbaremetalset_scale/08-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/08-assert.yaml
@@ -19,7 +19,7 @@ metadata:
   name: compute
   namespace: openstack
 spec:
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   count: 2
   ctlplaneInterface: enp7s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
@@ -41,11 +41,6 @@ status:
       ctlplaneIP: 192.168.25.103/24
       hostname: compute-1
       provisioningState: provisioned
-  conditions:
-  - message: All requested BaremetalHosts have been provisioned
-    reason: All requested BaremetalHosts have been provisioned
-    status: "True"
-    type: Provisioned
   provisioningStatus:
     readyCount: 2
     reason: All requested BaremetalHosts have been provisioned
@@ -132,14 +127,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 3
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -166,6 +154,15 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -174,14 +171,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -208,6 +198,15 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -216,14 +215,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
+spec:
   roleReservations:
     Compute:
       addToPredictableIPs: true
@@ -236,6 +228,15 @@ status:
         hostname: compute-1
         ip: 172.20.0.11
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
+    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -251,6 +252,7 @@ spec:
   hostCount: 2
   networks:
   - ctlplane
+  - internal_api
   - tenant
   roleName: Compute
   vip: false

--- a/tests/kuttl/tests/openstackbaremetalset_scale/09-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/09-assert.yaml
@@ -11,14 +11,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -34,6 +27,15 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -42,14 +44,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 0
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -65,6 +60,15 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+status:
+  conditions:
+  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
+    status: "True"
+    type: Configured
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -73,6 +77,8 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
+spec:
+  roleReservations: {}
 status:
   conditions:
   - message: OpenStackNet tenant has been successfully configured on targeted node(s)

--- a/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
@@ -176,6 +176,11 @@ spec:
       name: tenant
       vlan: 50
     vip: false
+  physNetworks:
+  - name: datacentre
+    macPrefix: fa:16:3a
+  - name: datacentre2
+    macPrefix: fa:16:3b
 status:
   provisioningStatus:
     attachDesiredCount: 2

--- a/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/01-assert.yaml
@@ -546,3 +546,30 @@ status:
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackMACAddress
+metadata:
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
+  namespace: openstack
+spec:
+  physNetworks:
+  - macPrefix: fa:16:3a
+    name: datacentre
+  - macPrefix: fa:16:3b
+    name: datacentre2
+status:
+  conditions:
+  - message: Waiting for ctlplane network to be created
+    reason: NetNotFound
+    status: "False"
+    type: Waiting
+  - message: All MAC addresses created
+    reason: MACAddressesCreated
+    status: "True"
+    type: Created
+  currentState: Created
+  macReservations: {}
+  reservedMACCount: 0

--- a/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/02-assert.yaml
@@ -26,11 +26,6 @@ spec:
   openStackClientStorageClass: host-nfs-storageclass
   openStackRelease: "16.2"
   passwordSecret: userpassword
-  physNetworks:
-  - name: datacentre
-    macPrefix: fa:16:3a
-  - name: datacentre2
-    macPrefix: fa:16:3b
   virtualMachineRoles:
     controller:
       baseImageVolumeName: controller-base-img
@@ -49,6 +44,26 @@ spec:
       roleCount: 0
       roleName: Controller
       storageClass: host-nfs-storageclass
+status:
+  ospVersion: "16.2"
+  provisioningStatus:
+    clientReady: true
+    desiredCount: 1
+    readyCount: 1
+    reason: All requested OSVMSets have been provisioned
+    state: Provisioned
+  vipStatus:
+    controlplane:
+      annotatedForDeletion: false
+      hostRef: controlplane
+      hostname: controlplane
+      ipaddresses:
+        ctlplane: 192.168.25.100/24
+        external: 10.0.0.10/24
+        internal_api: 172.17.0.10/24
+        storage: 172.18.0.10/24
+        storage_mgmt: 172.19.0.10/24
+      provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -79,11 +94,6 @@ spec:
   vmCount: 0
 status:
   baseImageDVReady: true
-  conditions:
-  - message: No VirtualMachines have been requested
-    reason: No VirtualMachines have been requested
-    status: "True"
-    type: Empty
   provisioningStatus:
     reason: No VirtualMachines have been requested
     state: Empty
@@ -109,12 +119,14 @@ spec:
 status:
   netStatus:
     openstackclient-0:
-      hostRef: openstackclient
+      annotatedForDeletion: false
+      hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
         ctlplane: 192.168.25.101/24
         external: 10.0.0.11/24
         internal_api: 172.17.0.11/24
+      provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -122,6 +134,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "true"
     ooo-netname: Control
     ooo-netname-lower: ctlplane
     ooo-subnetname: ctlplane
@@ -135,20 +148,11 @@ spec:
   allocationStart: 192.168.25.100
   attachConfiguration: br-osp
   cidr: 192.168.25.0/24
+  domainName: ctlplane.localdomain
   gateway: 192.168.25.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
-  vip: true
-  vlan: 0
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -164,6 +168,13 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+  routes: []
+  vip: true
+  vlan: 0
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -171,6 +182,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: External
     ooo-netname-lower: external
     ooo-subnetname: external
@@ -184,20 +196,11 @@ spec:
   allocationStart: 10.0.0.10
   attachConfiguration: br-ex
   cidr: 10.0.0.0/24
+  domainName: external.localdomain
   gateway: 10.0.0.1
   mtu: 1500
   name: External
   nameLower: external
-  vip: true
-  vlan: 0
-status:
-  conditions:
-  - message: OpenStackNet external has been successfully configured on targeted node(s)
-    reason: OpenStackNet external has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -213,6 +216,13 @@ status:
         hostname: openstackclient-0
         ip: 10.0.0.11
         vip: false
+  routes: []
+  vip: true
+  vlan: 0
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -220,6 +230,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: InternalApi
     ooo-netname-lower: internal_api
     ooo-subnetname: internal_api
@@ -233,20 +244,11 @@ spec:
   allocationStart: 172.17.0.10
   attachConfiguration: br-osp
   cidr: 172.17.0.0/24
+  domainName: internalapi.localdomain
   gateway: ""
   mtu: 1350
   name: InternalApi
   nameLower: internal_api
-  vip: true
-  vlan: 20
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -262,6 +264,13 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+  routes: []
+  vip: true
+  vlan: 20
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -269,6 +278,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: Storage
     ooo-netname-lower: storage
     ooo-subnetname: storage
@@ -282,20 +292,11 @@ spec:
   allocationStart: 172.18.0.10
   attachConfiguration: br-osp
   cidr: 172.18.0.0/24
+  domainName: storage.localdomain
   gateway: ""
   mtu: 1350
   name: Storage
   nameLower: storage
-  vip: true
-  vlan: 30
-status:
-  conditions:
-  - message: OpenStackNet storage has been successfully configured on targeted node(s)
-    reason: OpenStackNet storage has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 1
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -304,6 +305,13 @@ status:
         hostname: controlplane
         ip: 172.18.0.10
         vip: true
+  routes: []
+  vip: true
+  vlan: 30
+status:
+  currentState: Configured
+  reservedIpCount: 1
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -311,6 +319,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: StorageMgmt
     ooo-netname-lower: storage_mgmt
     ooo-subnetname: storage_mgmt
@@ -324,20 +333,11 @@ spec:
   allocationStart: 172.19.0.10
   attachConfiguration: br-osp
   cidr: 172.19.0.0/24
+  domainName: storagemgmt.localdomain
   gateway: ""
   mtu: 1350
   name: StorageMgmt
   nameLower: storage_mgmt
-  vip: true
-  vlan: 40
-status:
-  conditions:
-  - message: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    reason: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 1
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -346,6 +346,13 @@ status:
         hostname: controlplane
         ip: 172.19.0.10
         vip: true
+  routes: []
+  vip: true
+  vlan: 40
+status:
+  currentState: Configured
+  reservedIpCount: 1
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -353,6 +360,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: Tenant
     ooo-netname-lower: tenant
     ooo-subnetname: tenant
@@ -366,18 +374,16 @@ spec:
   allocationStart: 172.20.0.10
   attachConfiguration: br-osp
   cidr: 172.20.0.0/24
+  domainName: tenant.localdomain
   gateway: ""
   mtu: 1350
   name: Tenant
   nameLower: tenant
+  roleReservations: {}
+  routes: []
   vip: false
   vlan: 50
 status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -395,7 +401,7 @@ spec:
   addToPredictableIPs: true
   hostCount: 1
   hostNameRefs:
-    controlplane: overcloud
+    controlplane: controlplane
   networks:
   - ctlplane
   - external
@@ -467,6 +473,9 @@ spec:
   - tenant
   roleName: Controller
   vip: false
+status:
+  hosts: {}
+  networks: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -481,7 +490,7 @@ spec:
   addToPredictableIPs: false
   hostCount: 1
   hostNameRefs:
-    openstackclient-0: openstackclient
+    openstackclient-0: openstackclient-0
   networks:
   - ctlplane
   - external
@@ -529,7 +538,7 @@ type: Opaque
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackMACAddress
 metadata:
-  name: overcloud
+  name: openstacknetconfig
   namespace: openstack
 spec:
   physNetworks:
@@ -538,11 +547,6 @@ spec:
   - macPrefix: fa:16:3b
     name: datacentre2
 status:
-  conditions:
-  - message: All MAC addresses created
-    reason: All MAC addresses created
-    status: "True"
-    type: Created
   currentState: Created
   macReservations: {}
   reservedMACCount: 0

--- a/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/03-assert.yaml
@@ -47,11 +47,6 @@ spec:
   vmCount: 3
 status:
   baseImageDVReady: true
-  conditions:
-  - message: All requested VirtualMachines have been provisioned
-    reason: All requested VirtualMachines have been provisioned
-    status: "True"
-    type: Provisioned
   provisioningStatus:
     readyCount: 3
     reason: All requested VirtualMachines have been provisioned
@@ -137,14 +132,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -175,6 +163,10 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -183,14 +175,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: external
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet external has been successfully configured on targeted node(s)
-    reason: OpenStackNet external has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -221,6 +206,10 @@ status:
         hostname: openstackclient-0
         ip: 10.0.0.11
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -229,14 +218,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -267,6 +249,10 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -275,14 +261,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storage
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet storage has been successfully configured on targeted node(s)
-    reason: OpenStackNet storage has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -306,6 +285,10 @@ status:
         hostname: controller-2
         ip: 172.18.0.13
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -314,14 +297,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storagemgmt
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    reason: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -345,6 +321,10 @@ status:
         hostname: controller-2
         ip: 172.19.0.13
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -353,14 +333,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 3
+spec:
   roleReservations:
     Controller:
       addToPredictableIPs: true
@@ -377,6 +350,10 @@ status:
         hostname: controller-2
         ip: 172.20.0.12
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 3
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -470,7 +447,9 @@ status:
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackMACAddress
 metadata:
-  name: overcloud
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
   namespace: openstack
 spec:
   physNetworks:

--- a/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/05-assert.yaml
@@ -21,7 +21,7 @@ status:
   vipStatus:
     controlplane:
       annotatedForDeletion: false
-      hostRef: overcloud
+      hostRef: controlplane
       hostname: controlplane
       ipaddresses:
         ctlplane: 192.168.25.100/24
@@ -58,11 +58,6 @@ spec:
   vmCount: 1
 status:
   baseImageDVReady: true
-  conditions:
-  - message: All requested VirtualMachines have been provisioned
-    reason: All requested VirtualMachines have been provisioned
-    status: "True"
-    type: Provisioned
   provisioningStatus:
     readyCount: 1
     reason: All requested VirtualMachines have been provisioned
@@ -100,14 +95,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -138,6 +126,10 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -146,14 +138,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: external
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet external has been successfully configured on targeted node(s)
-    reason: OpenStackNet external has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -184,6 +169,10 @@ status:
         hostname: openstackclient-0
         ip: 10.0.0.11
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -192,14 +181,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -230,6 +212,10 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -238,14 +224,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storage
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet storage has been successfully configured on targeted node(s)
-    reason: OpenStackNet storage has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -269,6 +248,10 @@ status:
         hostname: controller-2
         ip: 172.18.0.13
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -277,14 +260,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storagemgmt
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    reason: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -308,6 +284,10 @@ status:
         hostname: controller-2
         ip: 172.19.0.13
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -316,14 +296,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 3
+spec:
   roleReservations:
     Controller:
       addToPredictableIPs: true
@@ -340,6 +313,10 @@ status:
         hostname: controller-2
         ip: 172.20.0.12
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 3
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -415,7 +392,9 @@ status:
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackMACAddress
 metadata:
-  name: overcloud
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
   namespace: openstack
 spec:
   physNetworks:
@@ -434,7 +413,7 @@ commands:
 # verify scaled down controller nodes MAC entries are marked as deleted
   - script: |
       set -x
-      deletedFlaggedMAC=$(oc get -n openstack osmacaddr overcloud -o json | jq -r '.status.macReservations[] | select(.deleted==true) | .deleted' | wc -l)
+      deletedFlaggedMAC=$(oc get -n openstack osmacaddr openstacknetconfig -o json | jq -r '.status.macReservations[] | select(.deleted==true) | .deleted' | wc -l)
       if [ $deletedFlaggedMAC -eq 2 ]; then
           exit 0
       else

--- a/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/06-assert.yaml
@@ -47,11 +47,6 @@ spec:
   vmCount: 3
 status:
   baseImageDVReady: true
-  conditions:
-  - message: All requested VirtualMachines have been provisioned
-    reason: All requested VirtualMachines have been provisioned
-    status: "True"
-    type: Provisioned
   provisioningStatus:
     readyCount: 3
     reason: All requested VirtualMachines have been provisioned
@@ -137,14 +132,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -175,6 +163,10 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -183,14 +175,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: external
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet external has been successfully configured on targeted node(s)
-    reason: OpenStackNet external has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -221,6 +206,10 @@ status:
         hostname: openstackclient-0
         ip: 10.0.0.11
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -229,14 +218,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 5
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -267,6 +249,10 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 5
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -275,14 +261,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storage
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet storage has been successfully configured on targeted node(s)
-    reason: OpenStackNet storage has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -306,6 +285,10 @@ status:
         hostname: controller-2
         ip: 172.18.0.13
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -314,14 +297,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storagemgmt
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    reason: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 4
+spec:
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -345,6 +321,10 @@ status:
         hostname: controller-2
         ip: 172.19.0.13
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 4
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -353,14 +333,7 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
-status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 3
+spec:
   roleReservations:
     Controller:
       addToPredictableIPs: true
@@ -377,6 +350,10 @@ status:
         hostname: controller-2
         ip: 172.20.0.12
         vip: false
+status:
+  currentState: Configured
+  reservedIpCount: 3
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -470,7 +447,9 @@ status:
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackMACAddress
 metadata:
-  name: overcloud
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
   namespace: openstack
 spec:
   physNetworks:

--- a/tests/kuttl/tests/openstackcontrolplane_scale/07-assert.yaml
+++ b/tests/kuttl/tests/openstackcontrolplane_scale/07-assert.yaml
@@ -11,12 +11,9 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: ctlplane
   namespace: openstack
+spec:
+  roleReservations: {}
 status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -28,12 +25,9 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: external
   namespace: openstack
+spec:
+  roleReservations: {}
 status:
-  conditions:
-  - message: OpenStackNet external has been successfully configured on targeted node(s)
-    reason: OpenStackNet external has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -45,12 +39,9 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: internalapi
   namespace: openstack
+spec:
+  roleReservations: {}
 status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -62,12 +53,9 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storage
   namespace: openstack
+spec:
+  roleReservations: {}
 status:
-  conditions:
-  - message: OpenStackNet storage has been successfully configured on targeted node(s)
-    reason: OpenStackNet storage has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -79,12 +67,9 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: storagemgmt
   namespace: openstack
+spec:
+  roleReservations: {}
 status:
-  conditions:
-  - message: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    reason: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -96,12 +81,9 @@ metadata:
   - openstacknet.osp-director.openstack.org
   name: tenant
   namespace: openstack
+spec:
+  roleReservations: {}
 status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}

--- a/tests/kuttl/tests/openstacknetconfig_cleanup_nncp/01-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_cleanup_nncp/01-assert.yaml
@@ -176,6 +176,11 @@ spec:
       name: tenant
       vlan: 50
     vip: false
+  physNetworks:
+  - name: datacentre
+    macPrefix: fa:16:3a
+  - name: datacentre2
+    macPrefix: fa:16:3b
 status:
   provisioningStatus:
     attachDesiredCount: 2
@@ -541,3 +546,30 @@ status:
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackMACAddress
+metadata:
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
+  namespace: openstack
+spec:
+  physNetworks:
+  - macPrefix: fa:16:3a
+    name: datacentre
+  - macPrefix: fa:16:3b
+    name: datacentre2
+status:
+  conditions:
+  - message: Waiting for ctlplane network to be created
+    reason: NetNotFound
+    status: "False"
+    type: Waiting
+  - message: All MAC addresses created
+    reason: MACAddressesCreated
+    status: "True"
+    type: Created
+  currentState: Created
+  macReservations: {}
+  reservedMACCount: 0

--- a/tests/kuttl/tests/openstacknetconfig_immutable_bridge_name/01-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_immutable_bridge_name/01-assert.yaml
@@ -176,6 +176,11 @@ spec:
       name: tenant
       vlan: 50
     vip: false
+  physNetworks:
+  - name: datacentre
+    macPrefix: fa:16:3a
+  - name: datacentre2
+    macPrefix: fa:16:3b
 status:
   provisioningStatus:
     attachDesiredCount: 2
@@ -541,3 +546,30 @@ status:
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackMACAddress
+metadata:
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
+  namespace: openstack
+spec:
+  physNetworks:
+  - macPrefix: fa:16:3a
+    name: datacentre
+  - macPrefix: fa:16:3b
+    name: datacentre2
+status:
+  conditions:
+  - message: Waiting for ctlplane network to be created
+    reason: NetNotFound
+    status: "False"
+    type: Waiting
+  - message: All MAC addresses created
+    reason: MACAddressesCreated
+    status: "True"
+    type: Created
+  currentState: Created
+  macReservations: {}
+  reservedMACCount: 0

--- a/tests/kuttl/tests/openstacknetconfig_immutable_bridge_name/02-change_openstacknet_bridge_name.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_immutable_bridge_name/02-change_openstacknet_bridge_name.yaml
@@ -7,3 +7,5 @@ kind: TestStep
 commands:
   - script: |
       oc patch osnetconfig -n openstack openstacknetconfig --type='json' -p='[{"op": "replace", "path": "/spec/attachConfigurations/br-osp/nodeNetworkConfigurationPolicy/desiredState", "value": {"interfaces":[{"name":"blah"}]}}]'
+    # ignore failure as the webhook will prevent the patch
+    ignoreFailure: true

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/01-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/01-assert.yaml
@@ -10,11 +10,11 @@ metadata:
   name: openstack
   namespace: openstack
 spec:
-  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:162cc35b2edb9054d29293ed3f0f98f195cf16647e89c3b8c7a4e911606ef4fd
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
-  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader@sha256:1a1caa9c2841f6aa66e385c3a21b9d084fd039c02b85e0a78722ededbed0bc22
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:d63a22b930f0309a8bb160b452147e81ceb1d3fd3df2d78f0a30e763e1d6f0c4
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
+  downloaderImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader@sha256:dadca151e8712eef8b206b69722c558b2aac035a4a3c52e705bf69c26d649567
   port: 8080
-  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent@sha256:22db35fb3fb4bb2d67a29f6db46ca8cbd8a903cc4f3437cfaec11f2b6b6d3b6b
+  provisioningAgentImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-provisioner@sha256:77eab3a61ef569236a17575d5e4f1318d2ac13f164af8a2c94b732a4c50af579
 status:
   conditions:
   - message: ProvisionServer openstack has been provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
@@ -10,11 +10,11 @@ metadata:
   name: goodprov
   namespace: openstack
 spec:
-  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:162cc35b2edb9054d29293ed3f0f98f195cf16647e89c3b8c7a4e911606ef4fd
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
-  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader@sha256:1a1caa9c2841f6aa66e385c3a21b9d084fd039c02b85e0a78722ededbed0bc22
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:d63a22b930f0309a8bb160b452147e81ceb1d3fd3df2d78f0a30e763e1d6f0c4
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
+  downloaderImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader@sha256:dadca151e8712eef8b206b69722c558b2aac035a4a3c52e705bf69c26d649567
   port: 8081
-  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent@sha256:22db35fb3fb4bb2d67a29f6db46ca8cbd8a903cc4f3437cfaec11f2b6b6d3b6b
+  provisioningAgentImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-provisioner@sha256:77eab3a61ef569236a17575d5e4f1318d2ac13f164af8a2c94b732a4c50af579
 status:
   conditions:
   - message: ProvisionServer goodprov has been provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/04-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/04-assert.yaml
@@ -176,6 +176,11 @@ spec:
       name: tenant
       vlan: 50
     vip: false
+  physNetworks:
+  - name: datacentre
+    macPrefix: fa:16:3a
+  - name: datacentre2
+    macPrefix: fa:16:3b
 status:
   provisioningStatus:
     attachDesiredCount: 2
@@ -541,3 +546,30 @@ status:
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackMACAddress
+metadata:
+  finalizers:
+  - openstackmacaddress.osp-director.openstack.org
+  name: openstacknetconfig
+  namespace: openstack
+spec:
+  physNetworks:
+  - macPrefix: fa:16:3a
+    name: datacentre
+  - macPrefix: fa:16:3b
+    name: datacentre2
+status:
+  conditions:
+  - message: Waiting for ctlplane network to be created
+    reason: NetNotFound
+    status: "False"
+    type: Waiting
+  - message: All MAC addresses created
+    reason: MACAddressesCreated
+    status: "True"
+    type: Created
+  currentState: Created
+  macReservations: {}
+  reservedMACCount: 0

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/05-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/05-assert.yaml
@@ -26,11 +26,6 @@ spec:
   openStackClientStorageClass: host-nfs-storageclass
   openStackRelease: "16.2"
   passwordSecret: userpassword
-  physNetworks:
-  - name: datacentre
-    macPrefix: fa:16:3a
-  - name: datacentre2
-    macPrefix: fa:16:3b
   virtualMachineRoles:
     controller:
       baseImageVolumeName: controller-base-img
@@ -49,6 +44,26 @@ spec:
       roleCount: 0
       roleName: Controller
       storageClass: host-nfs-storageclass
+status:
+  ospVersion: "16.2"
+  provisioningStatus:
+    clientReady: true
+    desiredCount: 1
+    readyCount: 1
+    reason: All requested OSVMSets have been provisioned
+    state: Provisioned
+  vipStatus:
+    controlplane:
+      annotatedForDeletion: false
+      hostRef: controlplane
+      hostname: controlplane
+      ipaddresses:
+        ctlplane: 192.168.25.100/24
+        external: 10.0.0.10/24
+        internal_api: 172.17.0.10/24
+        storage: 172.18.0.10/24
+        storage_mgmt: 172.19.0.10/24
+      provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -79,11 +94,6 @@ spec:
   vmCount: 0
 status:
   baseImageDVReady: true
-  conditions:
-  - message: No VirtualMachines have been requested
-    reason: No VirtualMachines have been requested
-    status: "True"
-    type: Empty
   provisioningStatus:
     reason: No VirtualMachines have been requested
     state: Empty
@@ -109,12 +119,14 @@ spec:
 status:
   netStatus:
     openstackclient-0:
-      hostRef: openstackclient
+      annotatedForDeletion: false
+      hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
         ctlplane: 192.168.25.101/24
         external: 10.0.0.11/24
         internal_api: 172.17.0.11/24
+      provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -122,6 +134,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "true"
     ooo-netname: Control
     ooo-netname-lower: ctlplane
     ooo-subnetname: ctlplane
@@ -135,20 +148,11 @@ spec:
   allocationStart: 192.168.25.100
   attachConfiguration: br-osp
   cidr: 192.168.25.0/24
+  domainName: ctlplane.localdomain
   gateway: 192.168.25.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
-  vip: true
-  vlan: 0
-status:
-  conditions:
-  - message: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    reason: OpenStackNet ctlplane has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -164,6 +168,13 @@ status:
         hostname: openstackclient-0
         ip: 192.168.25.101
         vip: false
+  routes: []
+  vip: true
+  vlan: 0
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -171,6 +182,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: External
     ooo-netname-lower: external
     ooo-subnetname: external
@@ -184,20 +196,11 @@ spec:
   allocationStart: 10.0.0.10
   attachConfiguration: br-ex
   cidr: 10.0.0.0/24
+  domainName: external.localdomain
   gateway: 10.0.0.1
   mtu: 1500
   name: External
   nameLower: external
-  vip: true
-  vlan: 0
-status:
-  conditions:
-  - message: OpenStackNet external has been successfully configured on targeted node(s)
-    reason: OpenStackNet external has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -213,6 +216,13 @@ status:
         hostname: openstackclient-0
         ip: 10.0.0.11
         vip: false
+  routes: []
+  vip: true
+  vlan: 0
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -220,6 +230,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: InternalApi
     ooo-netname-lower: internal_api
     ooo-subnetname: internal_api
@@ -233,20 +244,11 @@ spec:
   allocationStart: 172.17.0.10
   attachConfiguration: br-osp
   cidr: 172.17.0.0/24
+  domainName: internalapi.localdomain
   gateway: ""
   mtu: 1350
   name: InternalApi
   nameLower: internal_api
-  vip: true
-  vlan: 20
-status:
-  conditions:
-  - message: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    reason: OpenStackNet internalapi has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 2
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -262,6 +264,13 @@ status:
         hostname: openstackclient-0
         ip: 172.17.0.11
         vip: false
+  routes: []
+  vip: true
+  vlan: 20
+status:
+  currentState: Configured
+  reservedIpCount: 2
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -269,6 +278,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: Storage
     ooo-netname-lower: storage
     ooo-subnetname: storage
@@ -282,20 +292,11 @@ spec:
   allocationStart: 172.18.0.10
   attachConfiguration: br-osp
   cidr: 172.18.0.0/24
+  domainName: storage.localdomain
   gateway: ""
   mtu: 1350
   name: Storage
   nameLower: storage
-  vip: true
-  vlan: 30
-status:
-  conditions:
-  - message: OpenStackNet storage has been successfully configured on targeted node(s)
-    reason: OpenStackNet storage has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 1
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -304,6 +305,13 @@ status:
         hostname: controlplane
         ip: 172.18.0.10
         vip: true
+  routes: []
+  vip: true
+  vlan: 30
+status:
+  currentState: Configured
+  reservedIpCount: 1
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -311,6 +319,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: StorageMgmt
     ooo-netname-lower: storage_mgmt
     ooo-subnetname: storage_mgmt
@@ -324,20 +333,11 @@ spec:
   allocationStart: 172.19.0.10
   attachConfiguration: br-osp
   cidr: 172.19.0.0/24
+  domainName: storagemgmt.localdomain
   gateway: ""
   mtu: 1350
   name: StorageMgmt
   nameLower: storage_mgmt
-  vip: true
-  vlan: 40
-status:
-  conditions:
-  - message: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    reason: OpenStackNet storagemgmt has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
-  currentState: Configured
-  reservedIpCount: 1
   roleReservations:
     ControlPlane:
       addToPredictableIPs: true
@@ -346,6 +346,13 @@ status:
         hostname: controlplane
         ip: 172.19.0.10
         vip: true
+  routes: []
+  vip: true
+  vlan: 40
+status:
+  currentState: Configured
+  reservedIpCount: 1
+  roleReservations: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNet
@@ -353,6 +360,7 @@ metadata:
   finalizers:
   - openstacknet.osp-director.openstack.org
   labels:
+    ooo-ctlplane-network: "false"
     ooo-netname: Tenant
     ooo-netname-lower: tenant
     ooo-subnetname: tenant
@@ -366,18 +374,16 @@ spec:
   allocationStart: 172.20.0.10
   attachConfiguration: br-osp
   cidr: 172.20.0.0/24
+  domainName: tenant.localdomain
   gateway: ""
   mtu: 1350
   name: Tenant
   nameLower: tenant
+  roleReservations: {}
+  routes: []
   vip: false
   vlan: 50
 status:
-  conditions:
-  - message: OpenStackNet tenant has been successfully configured on targeted node(s)
-    reason: OpenStackNet tenant has been successfully configured on targeted node(s)
-    status: "True"
-    type: Configured
   currentState: Configured
   reservedIpCount: 0
   roleReservations: {}
@@ -395,7 +401,7 @@ spec:
   addToPredictableIPs: true
   hostCount: 1
   hostNameRefs:
-    controlplane: overcloud
+    controlplane: controlplane
   networks:
   - ctlplane
   - external
@@ -467,6 +473,9 @@ spec:
   - tenant
   roleName: Controller
   vip: false
+status:
+  hosts: {}
+  networks: {}
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackIPSet
@@ -481,7 +490,7 @@ spec:
   addToPredictableIPs: false
   hostCount: 1
   hostNameRefs:
-    openstackclient-0: openstackclient
+    openstackclient-0: openstackclient-0
   networks:
   - ctlplane
   - external
@@ -529,7 +538,7 @@ type: Opaque
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackMACAddress
 metadata:
-  name: overcloud
+  name: openstacknetconfig
   namespace: openstack
 spec:
   physNetworks:
@@ -538,11 +547,6 @@ spec:
   - macPrefix: fa:16:3b
     name: datacentre2
 status:
-  conditions:
-  - message: All MAC addresses created
-    reason: All MAC addresses created
-    status: "True"
-    type: Created
   currentState: Created
   macReservations: {}
   reservedMACCount: 0

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/06-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/06-assert.yaml
@@ -10,11 +10,11 @@ metadata:
   name: compute-provisionserver
   namespace: openstack
 spec:
-  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:162cc35b2edb9054d29293ed3f0f98f195cf16647e89c3b8c7a4e911606ef4fd
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
-  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader@sha256:1a1caa9c2841f6aa66e385c3a21b9d084fd039c02b85e0a78722ededbed0bc22
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:d63a22b930f0309a8bb160b452147e81ceb1d3fd3df2d78f0a30e763e1d6f0c4
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
+  downloaderImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader@sha256:dadca151e8712eef8b206b69722c558b2aac035a4a3c52e705bf69c26d649567
   port: 6190
-  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent@sha256:22db35fb3fb4bb2d67a29f6db46ca8cbd8a903cc4f3437cfaec11f2b6b6d3b6b
+  provisioningAgentImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-provisioner@sha256:77eab3a61ef569236a17575d5e4f1318d2ac13f164af8a2c94b732a4c50af579
 status:
   conditions:
   - message: ProvisionServer compute-provisionserver has been provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/07-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/07-assert.yaml
@@ -10,11 +10,11 @@ metadata:
   name: compute2-provisionserver
   namespace: openstack
 spec:
-  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:162cc35b2edb9054d29293ed3f0f98f195cf16647e89c3b8c7a4e911606ef4fd
-  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
-  downloaderImageUrl: quay.io/openstack-k8s-operators/rhel-downloader@sha256:1a1caa9c2841f6aa66e385c3a21b9d084fd039c02b85e0a78722ededbed0bc22
+  apacheImageUrl: registry.redhat.io/rhel8/httpd-24@sha256:d63a22b930f0309a8bb160b452147e81ceb1d3fd3df2d78f0a30e763e1d6f0c4
+  baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
+  downloaderImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader@sha256:dadca151e8712eef8b206b69722c558b2aac035a4a3c52e705bf69c26d649567
   port: 6191
-  provisioningAgentImageUrl: quay.io/openstack-k8s-operators/provision-ip-discovery-agent@sha256:22db35fb3fb4bb2d67a29f6db46ca8cbd8a903cc4f3437cfaec11f2b6b6d3b6b
+  provisioningAgentImageUrl: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-provisioner@sha256:77eab3a61ef569236a17575d5e4f1318d2ac13f164af8a2c94b732a4c50af579
 status:
   conditions:
   - message: ProvisionServer compute2-provisionserver has been provisioned


### PR DESCRIPTION
This is a first step and moves the osmacaddr CR handling from the ctlplane to the osnetcfg CRD/controller.

Also fixes the kuttl tests after the changes we did in the last couple of weeks.