### PR TITLE
[OSPK8-434] Harvest Ctlplane exports from heat

### DIFF
--- a/api/v1beta1/openstackconfiggenerator_types.go
+++ b/api/v1beta1/openstackconfiggenerator_types.go
@@ -104,6 +104,8 @@ const (
 	ConfigGeneratorCondReasonEphemeralHeatLaunch ConfigGeneratorReason = "EphemeralHeatLaunch"
 	// ConfigGeneratorCondReasonEphemeralHeatDelete - Ephemeral heat delete
 	ConfigGeneratorCondReasonEphemeralHeatDelete ConfigGeneratorReason = "EphemeralHeatDelete"
+	// ConfigGeneratorCondReasonExportFailed - Export of Ctlplane Heat Parameters Failed
+	ConfigGeneratorCondReasonExportFailed ConfigGeneratorReason = "CtlplaneExportFailed"
 	// ConfigGeneratorCondReasonJobCreated - created job
 	ConfigGeneratorCondReasonJobCreated ConfigGeneratorReason = "JobCreated"
 	// ConfigGeneratorCondReasonJobDelete - delete job

--- a/api/v1beta1/openstackconfigversion_types.go
+++ b/api/v1beta1/openstackconfigversion_types.go
@@ -22,8 +22,9 @@ import (
 
 // OpenStackConfigVersionSpec defines the desired state of OpenStackConfigVersion
 type OpenStackConfigVersionSpec struct {
-	Hash string `json:"hash"`
-	Diff string `json:"diff"`
+	Hash            string `json:"hash"`
+	Diff            string `json:"diff"`
+	CtlplaneExports string `json:"ctlplaneExports"`
 }
 
 // OpenStackConfigVersionStatus defines the observed state of OpenStackConfigVersion

--- a/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
@@ -40,11 +40,14 @@ spec:
           spec:
             description: OpenStackConfigVersionSpec defines the desired state of OpenStackConfigVersion
             properties:
+              ctlplaneExports:
+                type: string
               diff:
                 type: string
               hash:
                 type: string
             required:
+            - ctlplaneExports
             - diff
             - hash
             type: object

--- a/controllers/openstackconfiggenerator_controller.go
+++ b/controllers/openstackconfiggenerator_controller.go
@@ -367,6 +367,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	// Define a new Job object
 	job := openstackconfiggenerator.ConfigJob(instance, configMapHash, OSPVersion)
 
+	var exports string
 	if instance.Status.ConfigHash != configMapHash {
 		op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, heat, func() error {
 			err := controllerutil.SetControllerReference(instance, heat, r.Scheme)
@@ -507,6 +508,17 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
+		// obtain the cltplaneExports from Heat
+		exports, err = openstackconfiggenerator.CtlplaneExports("heat-"+instance.Name, r.Log)
+		if err != nil && !k8s_errors.IsNotFound(err) {
+			cond.Message = err.Error()
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatDelete)
+			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorCondTypeError)
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
+			return ctrl.Result{}, err
+		}
+
 	}
 
 	r.setConfigHash(instance, configMapHash)
@@ -525,7 +537,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	err = r.Client.Delete(context.TODO(), heat)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		cond.Message = err.Error()
-		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatDelete)
+		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonExportFailed)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorCondTypeError)
 		err = common.WrapErrorForObject(cond.Message, instance, err)
 
@@ -539,7 +551,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, gerr
 	}
 
-	if err := r.syncConfigVersions(instance, configVersions); err != nil {
+	if err := r.syncConfigVersions(instance, configVersions, exports); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -572,7 +584,7 @@ func (r *OpenStackConfigGeneratorReconciler) getNormalizedStatus(status *ospdire
 	return s
 }
 
-func (r *OpenStackConfigGeneratorReconciler) syncConfigVersions(instance *ospdirectorv1beta1.OpenStackConfigGenerator, configVersions map[string]ospdirectorv1beta1.OpenStackConfigVersion) error {
+func (r *OpenStackConfigGeneratorReconciler) syncConfigVersions(instance *ospdirectorv1beta1.OpenStackConfigGenerator, configVersions map[string]ospdirectorv1beta1.OpenStackConfigVersion, exports string) error {
 
 	for _, version := range configVersions {
 
@@ -582,6 +594,8 @@ func (r *OpenStackConfigGeneratorReconciler) syncConfigVersions(instance *ospdir
 		if err == nil {
 			//FIXME(dprince): update existing?
 		} else if err != nil && k8s_errors.IsNotFound(err) {
+			// we only add the most recent export to new ConfigVersions (just created...)
+			version.Spec.CtlplaneExports = exports
 			r.Log.Info("Creating a ConfigVersion", "ConfigVersion.Namespace", instance.Namespace, "ConfigVersion.Name", version.Name)
 			err = r.Client.Create(context.TODO(), &version)
 			if err != nil {
@@ -841,7 +855,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 	//
 	cm := []common.Template{
 		{
-			Name:               "tripleo-deploy-config",
+			Name:               "tripleo-deploy-config-" + instance.Name,
 			Namespace:          instance.Namespace,
 			Type:               common.TemplateTypeConfig,
 			InstanceType:       instance.Kind,
@@ -869,7 +883,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 	//
 	// Read the tripleo-deploy-config CM
 	//
-	tripleoDeployCM, _, err := common.GetConfigMapAndHashWithName(r, "tripleo-deploy-config", instance.Namespace)
+	tripleoDeployCM, _, err := common.GetConfigMapAndHashWithName(r, "tripleo-deploy-config-"+instance.Name, instance.Namespace)
 	if err != nil {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMCreateError)

--- a/controllers/openstackconfiggenerator_controller.go
+++ b/controllers/openstackconfiggenerator_controller.go
@@ -512,7 +512,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 		exports, err = openstackconfiggenerator.CtlplaneExports("heat-"+instance.Name, r.Log)
 		if err != nil && !k8s_errors.IsNotFound(err) {
 			cond.Message = err.Error()
-			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatDelete)
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonExportFailed)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorCondTypeError)
 			err = common.WrapErrorForObject(cond.Message, instance, err)
 
@@ -537,7 +537,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	err = r.Client.Delete(context.TODO(), heat)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		cond.Message = err.Error()
-		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonExportFailed)
+		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatDelete)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorCondTypeError)
 		err = common.WrapErrorForObject(cond.Message, instance, err)
 

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ exclude k8s.io/cluster-bootstrap v0.0.0
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-git/go-git/v5 v5.3.0
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/uuid v1.2.0
+	github.com/gophercloud/gophercloud v0.12.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
 	github.com/metal3-io/baremetal-operator v0.0.0-20201116105209-c72e2e0d8803
 	github.com/nmstate/kubernetes-nmstate v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -705,6 +705,7 @@ github.com/gophercloud/gophercloud v0.2.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gophercloud/gophercloud v0.10.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
+github.com/gophercloud/gophercloud v0.12.0 h1:mZrie07npp6ODiwHZolTicr5jV8Ogn43AvAsSMm6Ork=
 github.com/gophercloud/gophercloud v0.12.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/utils v0.0.0-20191020172814-bd86af96d544/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/pkg/openstackconfiggenerator/export.go
+++ b/pkg/openstackconfiggenerator/export.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstackconfiggenerator
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
+)
+
+func exportNames() map[string]string {
+	return map[string]string{
+		"EndpointMap":  "EndpointMapOverride",
+		"HostsEntry":   "ExtraHostFileEntries",
+		"GlobalConfig": "GlobalConfigExtraMapData",
+	}
+}
+
+// CtlplaneExports -
+func CtlplaneExports(heatServiceName string, log logr.Logger) (string, error) {
+
+	provider, err := openstack.NewClient("http://" + heatServiceName + ":8004/")
+	if err != nil {
+		log.Error(err, "Failed to create new HeatClient provider.")
+		return "", err
+	}
+	// override the EndpointLocator as we are using noauth without a real Catalog
+	provider.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
+		return "http://" + heatServiceName + ":8004/v1/admin/", nil
+	}
+	client, err := openstack.NewOrchestrationV1(provider, gophercloud.EndpointOpts{Region: "regionOne"})
+	if err != nil {
+		log.Error(err, "Failed to create new HeatClient.")
+		return "", err
+	}
+
+	overcloudStack, err := stacks.Find(client, "overcloud").Extract()
+	if err != nil {
+		log.Error(err, "Failed to find overcloud stack.")
+		return "", err
+	}
+
+	parameters := make(map[string]interface{})
+	// array of {output_key, output_value, description}
+	for _, m := range overcloudStack.Outputs {
+		outputKey := m["output_key"].(string)
+		if val, ok := exportNames()[outputKey]; ok {
+			parameters[val] = m["output_value"]
+		}
+	}
+
+	parameterDefaults := make(map[string]interface{})
+	parameterDefaults["parameter_defaults"] = parameters
+	outputValueData, err := yaml.Marshal(parameterDefaults)
+	if err != nil {
+		log.Error(err, "Failed to marshal stack outputs to yaml.")
+		return "", err
+	}
+	return string(outputValueData), nil
+
+}

--- a/pkg/openstackconfiggenerator/export.go
+++ b/pkg/openstackconfiggenerator/export.go
@@ -24,12 +24,10 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
 )
 
-func exportNames() map[string]string {
-	return map[string]string{
-		"EndpointMap":  "EndpointMapOverride",
-		"HostsEntry":   "ExtraHostFileEntries",
-		"GlobalConfig": "GlobalConfigExtraMapData",
-	}
+var exportNames = map[string]string{
+	"EndpointMap":  "EndpointMapOverride",
+	"HostsEntry":   "ExtraHostFileEntries",
+	"GlobalConfig": "GlobalConfigExtraMapData",
 }
 
 // CtlplaneExports -
@@ -60,7 +58,7 @@ func CtlplaneExports(heatServiceName string, log logr.Logger) (string, error) {
 	// array of {output_key, output_value, description}
 	for _, m := range overcloudStack.Outputs {
 		outputKey := m["output_key"].(string)
-		if val, ok := exportNames()[outputKey]; ok {
+		if val, ok := exportNames[outputKey]; ok {
 			parameters[val] = m["output_value"]
 		}
 	}

--- a/pkg/openstackconfiggenerator/volumes.go
+++ b/pkg/openstackconfiggenerator/volumes.go
@@ -26,7 +26,7 @@ import (
 func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []corev1.VolumeMount {
 	retVolMounts := []corev1.VolumeMount{
 		{
-			Name:      "tripleo-deploy-config",
+			Name:      "tripleo-deploy-config-" + instance.Name,
 			MountPath: "/home/cloud-admin/config",
 			ReadOnly:  true,
 		},
@@ -74,12 +74,12 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []corev1.
 
 	retVolumes := []corev1.Volume{
 		{
-			Name: "tripleo-deploy-config",
+			Name: "tripleo-deploy-config-" + instance.Name,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					DefaultMode: &config0644AccessMode,
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "tripleo-deploy-config",
+						Name: "tripleo-deploy-config-" + instance.Name,
 					},
 				},
 			},


### PR DESCRIPTION
A step towards DCN support

Updates the ConfigGeneratorController with logic to harvest
controlPlane Heat parameter exports from the Heat stack.
These are subsequently saved alongside of the ConfigVersion
and will be combined with the overcloud.json data (which
gets generated after deployment) to create the final
set of Ctlplane heat parameter exports.

Also fixes an issue with the ConfigGenerator so that we can create
multiple: previously the ConfigMap name was hard coded preventing
multiple ConfigGenerators from being created.