### PR TITLE
[OSPK8-433] Allow to set StorageAccessMode and StorageVolumeMode for VMset

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,14 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
           memory: 12
           diskSize: 50
           baseImageVolumeName: openstack-base-img
+          # storageClass must support RWX to be able to live migrate VMs
           storageClass: host-nfs-storageclass
+          storageAccessMode: ReadWriteMany
+          # When using OpenShift Virtualization with OpenShift Container Platform Container Storage,
+          # specify RBD block mode persistent volume claims (PVCs) when creating virtual machine disks. With virtual machine disks,
+          # RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
+          # To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and VolumeMode: Block.
+          storageVolumeMode: Filesystem
     ```
 
     If you write the above YAML into a file called openstackcontrolplane.yaml you can create the OpenStackControlPlane via this command:

--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -94,6 +94,20 @@ type OpenStackVirtualMachineRoleSpec struct {
 	DiskSize uint32 `json:"diskSize"`
 	// StorageClass to be used for the controller disks
 	StorageClass string `json:"storageClass,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=ReadWriteMany
+	// +kubebuilder:validation:Enum=ReadWriteOnce;ReadWriteMany
+	// StorageAccessMode - Virtual machines must have a persistent volume claim (PVC)
+	// with a shared ReadWriteMany (RWX) access mode to be live migrated.
+	StorageAccessMode string `json:"storageAccessMode,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=Filesystem
+	// +kubebuilder:validation:Enum=Block;Filesystem
+	// StorageVolumeMode - When using OpenShift Virtualization with OpenShift Container Platform Container Storage,
+	// specify RBD block mode persistent volume claims (PVCs) when creating virtual machine disks. With virtual machine disks,
+	// RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
+	// To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and VolumeMode: Block.
+	StorageVolumeMode string `json:"storageVolumeMode"`
 	// BaseImageVolumeName used as the base volume for the VM
 	BaseImageVolumeName string `json:"baseImageVolumeName"`
 

--- a/api/v1beta1/openstackvmset_types.go
+++ b/api/v1beta1/openstackvmset_types.go
@@ -33,6 +33,20 @@ type OpenStackVMSetSpec struct {
 	DiskSize uint32 `json:"diskSize"`
 	// StorageClass to be used for the disks
 	StorageClass string `json:"storageClass,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=ReadWriteMany
+	// +kubebuilder:validation:Enum=ReadWriteOnce;ReadWriteMany
+	// StorageAccessMode - Virtual machines must have a persistent volume claim (PVC)
+	// with a shared ReadWriteMany (RWX) access mode to be live migrated.
+	StorageAccessMode string `json:"storageAccessMode,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=Filesystem
+	// +kubebuilder:validation:Enum=Block;Filesystem
+	// StorageVolumeMode - When using OpenShift Virtualization with OpenShift Container Platform Container Storage,
+	// specify RBD block mode persistent volume claims (PVCs) when creating virtual machine disks. With virtual machine disks,
+	// RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
+	// To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and VolumeMode: Block.
+	StorageVolumeMode string `json:"storageVolumeMode"`
 	// BaseImageVolumeName used as the base volume for the VM
 	BaseImageVolumeName string `json:"baseImageVolumeName"`
 	// name of secret holding the stack-admin ssh keys

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -940,9 +940,36 @@ spec:
                                           role this VM Spec is associated with. If
                                           it is a TripleO role, the name must match.
                                         type: string
+                                      storageAccessMode:
+                                        default: ReadWriteMany
+                                        description: StorageAccessMode - Virtual machines
+                                          must have a persistent volume claim (PVC)
+                                          with a shared ReadWriteMany (RWX) access
+                                          mode to be live migrated.
+                                        enum:
+                                        - ReadWriteOnce
+                                        - ReadWriteMany
+                                        type: string
                                       storageClass:
                                         description: StorageClass to be used for the
                                           controller disks
+                                        type: string
+                                      storageVolumeMode:
+                                        default: Filesystem
+                                        description: 'StorageVolumeMode - When using
+                                          OpenShift Virtualization with OpenShift
+                                          Container Platform Container Storage, specify
+                                          RBD block mode persistent volume claims
+                                          (PVCs) when creating virtual machine disks.
+                                          With virtual machine disks, RBD block mode
+                                          volumes are more efficient and provide better
+                                          performance than Ceph FS or RBD filesystem-mode
+                                          PVCs. To specify RBD block mode PVCs, use
+                                          the ''ocs-storagecluster-ceph-rbd'' storage
+                                          class and VolumeMode: Block.'
+                                        enum:
+                                        - Block
+                                        - Filesystem
                                         type: string
                                     required:
                                     - baseImageVolumeName
@@ -2702,8 +2729,34 @@ spec:
                                     this VM Spec is associated with. If it is a TripleO
                                     role, the name must match.
                                   type: string
+                                storageAccessMode:
+                                  default: ReadWriteMany
+                                  description: StorageAccessMode - Virtual machines
+                                    must have a persistent volume claim (PVC) with
+                                    a shared ReadWriteMany (RWX) access mode to be
+                                    live migrated.
+                                  enum:
+                                  - ReadWriteOnce
+                                  - ReadWriteMany
+                                  type: string
                                 storageClass:
                                   description: StorageClass to be used for the disks
+                                  type: string
+                                storageVolumeMode:
+                                  default: Filesystem
+                                  description: 'StorageVolumeMode - When using OpenShift
+                                    Virtualization with OpenShift Container Platform
+                                    Container Storage, specify RBD block mode persistent
+                                    volume claims (PVCs) when creating virtual machine
+                                    disks. With virtual machine disks, RBD block mode
+                                    volumes are more efficient and provide better
+                                    performance than Ceph FS or RBD filesystem-mode
+                                    PVCs. To specify RBD block mode PVCs, use the
+                                    ''ocs-storagecluster-ceph-rbd'' storage class
+                                    and VolumeMode: Block.'
+                                  enum:
+                                  - Block
+                                  - Filesystem
                                   type: string
                                 vmCount:
                                   description: Number of VMs to configure, 1 or 3

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -171,8 +171,31 @@ spec:
                         is associated with. If it is a TripleO role, the name must
                         match.
                       type: string
+                    storageAccessMode:
+                      default: ReadWriteMany
+                      description: StorageAccessMode - Virtual machines must have
+                        a persistent volume claim (PVC) with a shared ReadWriteMany
+                        (RWX) access mode to be live migrated.
+                      enum:
+                      - ReadWriteOnce
+                      - ReadWriteMany
+                      type: string
                     storageClass:
                       description: StorageClass to be used for the controller disks
+                      type: string
+                    storageVolumeMode:
+                      default: Filesystem
+                      description: 'StorageVolumeMode - When using OpenShift Virtualization
+                        with OpenShift Container Platform Container Storage, specify
+                        RBD block mode persistent volume claims (PVCs) when creating
+                        virtual machine disks. With virtual machine disks, RBD block
+                        mode volumes are more efficient and provide better performance
+                        than Ceph FS or RBD filesystem-mode PVCs. To specify RBD block
+                        mode PVCs, use the ''ocs-storagecluster-ceph-rbd'' storage
+                        class and VolumeMode: Block.'
+                      enum:
+                      - Block
+                      - Filesystem
                       type: string
                   required:
                   - baseImageVolumeName

--- a/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
@@ -120,8 +120,30 @@ spec:
                 description: RoleName the name of the TripleO role this VM Spec is
                   associated with. If it is a TripleO role, the name must match.
                 type: string
+              storageAccessMode:
+                default: ReadWriteMany
+                description: StorageAccessMode - Virtual machines must have a persistent
+                  volume claim (PVC) with a shared ReadWriteMany (RWX) access mode
+                  to be live migrated.
+                enum:
+                - ReadWriteOnce
+                - ReadWriteMany
+                type: string
               storageClass:
                 description: StorageClass to be used for the disks
+                type: string
+              storageVolumeMode:
+                default: Filesystem
+                description: 'StorageVolumeMode - When using OpenShift Virtualization
+                  with OpenShift Container Platform Container Storage, specify RBD
+                  block mode persistent volume claims (PVCs) when creating virtual
+                  machine disks. With virtual machine disks, RBD block mode volumes
+                  are more efficient and provide better performance than Ceph FS or
+                  RBD filesystem-mode PVCs. To specify RBD block mode PVCs, use the
+                  ''ocs-storagecluster-ceph-rbd'' storage class and VolumeMode: Block.'
+                enum:
+                - Block
+                - Filesystem
                 type: string
               vmCount:
                 description: Number of VMs to configure, 1 or 3

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -33,3 +33,5 @@ spec:
       roleCount: 0
       roleName: Controller
       storageClass: host-nfs-storageclass
+      storageAccessMode:  ReadWriteMany
+      storageVolumeMode: Filesystem

--- a/config/samples/osp-director_v1beta1_openstackvmset.yaml
+++ b/config/samples/osp-director_v1beta1_openstackvmset.yaml
@@ -10,6 +10,8 @@ spec:
   diskSize: 50
   baseImageVolumeName: controller-base-img
   storageClass: host-nfs-storageclass
+  storageAccessMode:  ReadWriteMany
+  storageVolumeMode: Filesystem
   #imageImportStorageClass: local #optional
   deploymentSSHSecret: osp-controlplane-ssh-keys
   isTripleoRole: true

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -847,6 +847,8 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateVMSets(
 			if vmRole.StorageClass != "" {
 				vmSet.Spec.StorageClass = vmRole.StorageClass
 			}
+			vmSet.Spec.StorageAccessMode = vmRole.StorageAccessMode
+			vmSet.Spec.StorageVolumeMode = vmRole.StorageVolumeMode
 			vmSet.Spec.BaseImageVolumeName = vmRole.DeepCopy().BaseImageVolumeName
 			vmSet.Spec.DeploymentSSHSecret = deploymentSecret.Name
 			vmSet.Spec.CtlplaneInterface = vmRole.CtlplaneInterface

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -697,7 +697,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 ) error {
 
 	evictionStrategy := virtv1.EvictionStrategyLiveMigrate
-	fsMode := corev1.PersistentVolumeFilesystem
+	fsMode := corev1.PersistentVolumeMode(instance.Spec.StorageVolumeMode)
 	trueValue := true
 	terminationGracePeriodSeconds := int64(0)
 
@@ -726,7 +726,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 		Spec: cdiv1.DataVolumeSpec{
 			PVC: &corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{
-					"ReadWriteOnce",
+					corev1.PersistentVolumeAccessMode(instance.Spec.StorageAccessMode),
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/tidwall/gjson v1.9.3
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
-	golang.org/x/tools v0.1.8 // indirect
+	golang.org/x/tools v0.1.9 // indirect
 	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1877,8 +1877,8 @@ golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
-golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
+golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This patch allows to set the StorageAccessMode and/or StorageVolumeMode
for the VirtualMachineRole disk. StorageAccessMode defaults to
ReadWriteMany as this is required to be able to live migrate
an instance, but could be set to ReadWriteOnce if wanted.
StorageVolumeMode defaults to Filesystem, but when OpenShift
Virtualization with OpenShift Container Platform Container Storage
is used, Block should be used.