### PR TITLE
[OSPK8-432] Prevent NNCP updates while configuration is in progress - v1.2.x backport

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -98,6 +98,8 @@ const (
 	CommonCondReasonNewHostnameError ConditionReason = "NewHostnameError"
 	// CommonCondReasonCRStatusUpdateError - error updating CR status
 	CommonCondReasonCRStatusUpdateError ConditionReason = "CRStatusUpdateError"
+	// CommonCondReasonNNCPError - NNCP error
+	CommonCondReasonNNCPError ConditionReason = "NNCPError"
 	// CommonCondReasonOSNetNotFound - openstack network not found
 	CommonCondReasonOSNetNotFound ConditionReason = "OSNetNotFound"
 	// CommonCondReasonOSNetError - openstack network error

--- a/api/v1beta1/openstacknetattachment_types.go
+++ b/api/v1beta1/openstacknetattachment_types.go
@@ -111,9 +111,9 @@ const (
 	//
 
 	// NetAttachCondReasonCreated - osnetattachment created
-	NetAttachCondReasonCreated ConditionReason = "NetAttachCreated"
+	NetAttachCondReasonCreated ConditionReason = "OpenStackNetAttachCreated"
 	// NetAttachCondReasonCreateError - error creating osnetatt object
-	NetAttachCondReasonCreateError ConditionReason = "OpenStackNetAttachtCreateError"
+	NetAttachCondReasonCreateError ConditionReason = "OpenStackNetAttachCreateError"
 )
 
 // IsReady - Is this resource in its fully-configured (quiesced) state?

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/tidwall/gjson v1.9.3
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
-	golang.org/x/tools v0.1.8 // indirect
+	golang.org/x/tools v0.1.9 // indirect
 	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1877,8 +1877,8 @@ golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
-golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
+golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Randomly the following error was seen:

{"level":"info","ts":1643296206.0834217,"logger":"enactmentstatus","msg":"status: {DesiredState:interfaces:\n- bridge:\n    options:\n      stp:\n        enabled: false\n    port:\n    - name: enp6s0\n  description: Linux bridge with enp6s0 as a port\n  mtu: 1500\n  name: br-ex\n  state: up\n  type: linux-bridge\n
...
ERROR: State editing already in progress.\nCommit, roll back or wait before retrying.\n' LastHeartbeatTime:2022-01-27 15:10:06.083365961 +0000 UTC m=+5.790948854 LastTransitionTime:2022-01-27 15:10:06.083365961 +0000 UTC m=+5.790948854}

We suspect that it is could be a result of applying an nncp update
while nmstate is sill applying the config. This patch prevents
the osnetattach controller to update the NNCP CR when the NNCP CR
is not in SuccessfullyConfigured ConditionReason.

(cherry picked from commit dbb44542cf4917195ab1212dc068244291e4c640)