### PR TITLE
Ensure ansible playbooks symlink is correct

### DIFF
--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -162,6 +162,7 @@ EOF_PYTHON
 
 # with OSP17 the rendered templates get into overcloud directory, create link to have the same dst
 output_dir=$(ls -dtr $HOME/ansible/tripleo-ansible-* | tail -1)
+rm -f $HOME/ansible/overcloud
 ln -sf ${output_dir} $HOME/ansible/overcloud
 
 {{- else }}


### PR DESCRIPTION
If the symlink target already exists then a symlink is created within it
instead of updating the symlink source. This could result in the wrong
playbooks being used.