### PR TITLE
Drop GitSecret params from OpenStackClient CRD

### DIFF
--- a/api/v1beta1/openstackclient_types.go
+++ b/api/v1beta1/openstackclient_types.go
@@ -30,10 +30,6 @@ type OpenStackClientSpec struct {
 	DeploymentSSHSecret string `json:"deploymentSSHSecret"`
 
 	// +kubebuilder:validation:Optional
-	// GitSecret the name of the secret used to pull Ansible playbooks into the openstackclient pod. This secret should contain an entry for both 'git_url' and 'git_ssh_identity'
-	GitSecret string `json:"gitSecret"`
-
-	// +kubebuilder:validation:Optional
 	// cloudname passed in via OS_CLOUDNAME
 	CloudName string `json:"cloudName"`
 

--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -50,8 +50,6 @@ type OpenStackControlPlaneSpec struct {
 	OpenStackClientStorageClass string `json:"openStackClientStorageClass,omitempty"`
 	// PasswordSecret used to e.g specify root pwd
 	PasswordSecret string `json:"passwordSecret,omitempty"`
-	// GitSecret used to pull playbooks into the openstackclient pod
-	GitSecret string `json:"gitSecret"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={ctlplane,external}

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -597,12 +597,6 @@ spec:
                                 domainName:
                                   description: Domain name used to build fqdn
                                   type: string
-                                gitSecret:
-                                  description: GitSecret the name of the secret used
-                                    to pull Ansible playbooks into the openstackclient
-                                    pod. This secret should contain an entry for both
-                                    'git_url' and 'git_ssh_identity'
-                                  type: string
                                 idmSecret:
                                   description: Idm secret used to register openstack
                                     client in IPA
@@ -844,10 +838,6 @@ spec:
                                     FIXME: Defaulting to false until Kubevirt agent
                                     merged into RHEL overcloud image'
                                   type: boolean
-                                gitSecret:
-                                  description: GitSecret used to pull playbooks into
-                                    the openstackclient pod
-                                  type: string
                                 idmSecret:
                                   description: Idm secret used to register openstack
                                     client in IPA
@@ -985,7 +975,6 @@ spec:
                                   type: object
                               required:
                               - enableFencing
-                              - gitSecret
                               - virtualMachineRoles
                               type: object
                             status:

--- a/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
@@ -62,11 +62,6 @@ spec:
               domainName:
                 description: Domain name used to build fqdn
                 type: string
-              gitSecret:
-                description: GitSecret the name of the secret used to pull Ansible
-                  playbooks into the openstackclient pod. This secret should contain
-                  an entry for both 'git_url' and 'git_ssh_identity'
-                type: string
               idmSecret:
                 description: Idm secret used to register openstack client in IPA
                 type: string

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -83,10 +83,6 @@ spec:
                   to disable fencing if desired FIXME: Defaulting to false until Kubevirt
                   agent merged into RHEL overcloud image'
                 type: boolean
-              gitSecret:
-                description: GitSecret used to pull playbooks into the openstackclient
-                  pod
-                type: string
               idmSecret:
                 description: Idm secret used to register openstack client in IPA
                 type: string
@@ -211,7 +207,6 @@ spec:
                 type: object
             required:
             - enableFencing
-            - gitSecret
             - virtualMachineRoles
             type: object
           status:

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane_single_net.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane_single_net.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -465,22 +465,6 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 
 	env := common.MergeEnvs([]corev1.EnvVar{}, *envVars)
 
-	if instance.Spec.GitSecret != "" {
-		env = common.MergeEnvs([]corev1.EnvVar{
-			{
-				Name: "GIT_URL",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: instance.Spec.GitSecret,
-						},
-						Key: "git_url",
-					},
-				},
-			},
-		}, *envVars)
-	}
-
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -916,7 +916,6 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateOpenStackClient(
 		osc.Spec.DeploymentSSHSecret = deploymentSecret.Name
 		osc.Spec.CloudName = instance.Name
 		osc.Spec.StorageClass = instance.Spec.OpenStackClientStorageClass
-		osc.Spec.GitSecret = instance.Spec.GitSecret
 		osc.Spec.RunUID = openstackclient.CloudAdminUID
 		osc.Spec.RunGID = openstackclient.CloudAdminGID
 		if instance.Spec.DomainName != "" {

--- a/pkg/openstackbackup/funcs.go
+++ b/pkg/openstackbackup/funcs.go
@@ -276,21 +276,11 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 				return *secretList, err
 			}
 		}
-		if item.Spec.GitSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.GitSecret, secretList); err != nil {
-				return *secretList, err
-			}
-		}
 	}
 
 	for _, item := range desiredCrs.OpenStackClients.Items {
 		if item.Spec.DeploymentSSHSecret != "" {
 			if err := addSecretToList(r, request.Namespace, item.Spec.DeploymentSSHSecret, secretList); err != nil {
-				return *secretList, err
-			}
-		}
-		if item.Spec.GitSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.GitSecret, secretList); err != nil {
 				return *secretList, err
 			}
 		}

--- a/pkg/openstackclient/volumes.go
+++ b/pkg/openstackclient/volumes.go
@@ -138,15 +138,6 @@ func GetInitVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.
 		}...)
 	}
 
-	if instance.Spec.GitSecret != "" {
-		volumes = append(volumes, corev1.VolumeMount{
-			Name:      "git-ssh-config",
-			MountPath: "/mnt/ssh-config/git_id_rsa",
-			SubPath:   "git_id_rsa",
-			ReadOnly:  true})
-
-	}
-
 	if instance.Spec.CAConfigMap != "" {
 		volumes = append(volumes, corev1.VolumeMount{
 			Name:      "ca-certs",
@@ -276,25 +267,6 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 						{
 							Key:  "config",
 							Path: "config",
-						},
-					},
-				},
-			},
-		})
-	}
-
-	if instance.Spec.GitSecret != "" {
-		volumes = append(volumes, corev1.Volume{
-			Name: "git-ssh-config", //ssh key for git repo access
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: &config0644AccessMode,
-					SecretName:  instance.Spec.GitSecret,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "git_ssh_identity",
-							Path: "git_id_rsa",
-							Mode: &config0600AccessMode,
 						},
 					},
 				},

--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -44,23 +44,6 @@ if [ -d /mnt/ssh-config ]; then
   chown -R cloud-admin: /home/cloud-admin/.ssh
 fi
 
-if [ -v GIT_URL ]; then
-  GIT_HOST=$(echo $GIT_URL | sed -e 's|^git@\(.*\):.*|\1|g')
-  GIT_USER=$(echo $GIT_URL | sed -e 's|^git@.*:\(.*\)/.*|\1|g')
-
-  cat <<EOF >> /home/cloud-admin/.ssh/config
-
-
-Host $GIT_HOST
-    User $GIT_USER
-    IdentityFile /home/cloud-admin/.ssh/git_id_rsa
-    StrictHostKeyChecking no
-EOF
-
-  git config --global user.email "dev@null.io"
-  git config --global user.name "OSP Director Operator"
-fi
-
 if [ -d /mnt/ca-certs ]; then
   sudo touch /run/ca-certs-epoch
   sudo cp -v /mnt/ca-certs/* /etc/pki/ca-trust/source/anchors/

--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -40,7 +40,6 @@ if [ -d /mnt/ssh-config ]; then
   mkdir -p /home/cloud-admin/.ssh
   cp /mnt/ssh-config/* /home/cloud-admin/.ssh/
   chmod 600 /home/cloud-admin/.ssh/id_rsa
-  chmod 600 /home/cloud-admin/.ssh/git_id_rsa
   chown -R cloud-admin: /home/cloud-admin/.ssh
 fi
 


### PR DESCRIPTION
Now that we have the OpenStackDeploy CR workflow we no
longer need to specify GitSecret on the OpenStackClient
and OpenStackControlPlane CRs.

OSPK8-438 #close Closing issue.