### PR TITLE
Fix github actions for agent container

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -39,7 +39,7 @@ sed -z -e 's!\(AGENT_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${AGENT_IMG_WITH_DI
 
 echo "Bundle file images:"
 cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-grep -A1 "${CLUSTER_BUNDLE_FILE}" IMAGE_URL_DEFAULT
+grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
 
 # We do not want to exit here. Some images are in different registries, so
 # error will be reported to the console.
@@ -77,4 +77,4 @@ done
 
 echo "Resulting bundle file images:"
 cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-grep -A1 "${CLUSTER_BUNDLE_FILE}" IMAGE_URL_DEFAULT
+grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"

--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -27,27 +27,37 @@ echo "Release Version: $RELEASE_VERSION"
 echo "Creating bundle image..."
 VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
 
-echo "Applying work-arounds..."
-sed -i '/^    webhookPath:.*/a #added\n    containerPort: 4343\n    targetPort: 4343' "${CLUSTER_BUNDLE_FILE}"
-sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controller-manager/g' "${CLUSTER_BUNDLE_FILE}"
+echo "Bundle file images:"
+cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
+grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
 
 # Replace AGENT_IMAGE_URL_DEFAULT in CSV
 
 AGENT_IMG_BASE="${REGISTRY}/${AGENT_IMAGE}"
 AGENT_IMG="${AGENT_IMG_BASE}:${GITHUB_SHA}"
-AGENT_IMG_WITH_DIGEST="${AGENT_IMG_BASE}@"$(skopeo inspect docker://${AGENT_IMG} | jq '.Digest' -r)
+AGENT_DIGEST=$(skopeo inspect docker://${AGENT_IMG} | jq '.Digest' -r)
+if [[ -z "$AGENT_DIGEST" ]]; then
+  echo "ERROR: skopeo inspect failed for ${AGENT_IMG}"
+  exit 1
+fi
+AGENT_IMG_WITH_DIGEST="${AGENT_IMG_BASE}@${AGENT_DIGEST}"
 sed -z -e 's!\(AGENT_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${AGENT_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
 
 # Replace DOWNLOADER_IMAGE_URL_DEFAULT in CSV
 
 DOWNLOADER_IMG_BASE="${REGISTRY}/${DOWNLOADER_IMAGE}"
 DOWNLOADER_IMG="${DOWNLOADER_IMG_BASE}:${GITHUB_SHA}"
-DOWNLOADER_IMG_WITH_DIGEST="${DOWNLOADER_IMG_BASE}@"$(skopeo inspect docker://${DOWNLOADER_IMG} | jq '.Digest' -r)
+DOWNLOADER_DIGEST=$(skopeo inspect docker://${DOWNLOADER_IMG} | jq '.Digest' -r)
+if [[ -z "$DOWNLOADER_DIGEST" ]]; then
+  echo "ERROR: skopeo inspect failed for ${DOWNLOADER_IMG}"
+  exit 1
+fi
+DOWNLOADER_IMG_WITH_DIGEST="${DOWNLOADER_IMG_BASE}@${DOWNLOADER_DIGEST}"
 sed -z -e 's!\(DOWNLOADER_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${DOWNLOADER_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
 
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+echo "Applying work-arounds..."
+sed -i '/^    webhookPath:.*/a #added\n    containerPort: 4343\n    targetPort: 4343' "${CLUSTER_BUNDLE_FILE}"
+sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controller-manager/g' "${CLUSTER_BUNDLE_FILE}"
 
 # We do not want to exit here. Some images are in different registries, so
 # error will be reported to the console.
@@ -77,11 +87,12 @@ for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*im
     sed -e "s|$base_image:$tag_image|$DOWNLOADER_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
   else
     digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-
-    if [ ! -z "$digest_image" ]; then
-      echo "Base image: $base_image"
+    echo "Base image: $base_image"
+    if [ -n "$digest_image" ]; then
       echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
       sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
+    else
+      echo "$base_image${delimeter}$tag_image not changed"
     fi
   fi
 done

--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -25,9 +25,22 @@ env:
   latesttag: latest
 
 jobs:
+
+  check-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secrets are set
+        id: have-secrets
+        if: "${{ env.imagenamespace != '' }}"
+        run: echo "::set-output name=ok::true"
+    outputs:
+      have-secrets: ${{ steps.have-secrets.outputs.ok }}
+
   build-osp-director-operator:
     name: Build osp-director-operator image using buildah
     runs-on: ubuntu-latest
+    needs: [check-secrets]
+    if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
     - uses: actions/checkout@v2
@@ -62,6 +75,8 @@ jobs:
   build-osp-director-downloader:
     name: Build osp-director-downloader image using buildah
     runs-on: ubuntu-latest
+    needs: [check-secrets]
+    if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
     - uses: actions/checkout@v2
@@ -98,6 +113,8 @@ jobs:
   build-osp-director-agent:
     name: Build agent image using buildah
     runs-on: ubuntu-latest
+    needs: [check-secrets]
+    if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
     - uses: actions/checkout@v2
@@ -130,9 +147,10 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
   build-osp-director-operator-bundle:
-    needs: [ build-osp-director-operator, build-osp-director-downloader, build-osp-director-agent ]
+    needs: [ check-secrets, build-osp-director-operator, build-osp-director-downloader, build-osp-director-agent ]
     name: osp-director-operator-bundle
     runs-on: ubuntu-latest
+    if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
     - name: Checkout osp-director-operator repository
@@ -199,9 +217,10 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
   build-osp-director-operator-index:
-    needs: [ build-osp-director-operator-bundle ]
+    needs: [ check-secrets, build-osp-director-operator-bundle ]
     name: osp-director-operator-index
     runs-on: ubuntu-latest
+    if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
     - name: Checkout osp-director-operator repository

--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -169,6 +169,7 @@ jobs:
         GITHUB_SHA: ${{ github.sha }}
         BASE_IMAGE: osp-director-operator
         AGENT_IMAGE: osp-director-operator-agent
+        DOWNLOADER_IMAGE: osp-director-downloader
 
     - name: Get branch name
       id: branch-name

--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -21,7 +21,7 @@ on:
 
 env:
   imageregistry: 'quay.io'
-  imagenamespace: 'openstack-k8s-operators'
+  imagenamespace: ${{ secrets.IMAGENAMESPACE || secrets.QUAY_USERNAME }}
   latesttag: latest
 
 jobs:

--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -95,8 +95,8 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
-  build-osp-director-provisioner:
-    name: Build provision-ip-discovery-agent image using buildah
+  build-osp-director-agent:
+    name: Build agent image using buildah
     runs-on: ubuntu-latest
 
     steps:
@@ -112,25 +112,25 @@ jobs:
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
     - name: Buildah Action
-      id: build-osp-director-provisioner
+      id: build-osp-director-agent
       uses: redhat-actions/buildah-build@v2
       with:
-        image: provision-ip-discovery-agent
+        image: osp-director-operator-agent
         tags: ${{ env.latesttag }} ${{ github.sha }}
         containerfiles: |
-          ./Dockerfile.provision-ip-discovery-agent
+          ./Dockerfile.agent
 
-    - name: Push provision-ip-discovery-agent To ${{ env.imageregistry }}
+    - name: Push agent To ${{ env.imageregistry }}
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ steps.build-osp-director-provisioner.outputs.image }}
-        tags: ${{ steps.build-osp-director-provisioner.outputs.tags }}
+        image: ${{ steps.build-osp-director-agent.outputs.image }}
+        tags: ${{ steps.build-osp-director-agent.outputs.tags }}
         registry:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
   build-osp-director-operator-bundle:
-    needs: [ build-osp-director-operator, build-osp-director-downloader, build-osp-director-provisioner ]
+    needs: [ build-osp-director-operator, build-osp-director-downloader, build-osp-director-agent ]
     name: osp-director-operator-bundle
     runs-on: ubuntu-latest
 
@@ -168,6 +168,7 @@ jobs:
         REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         GITHUB_SHA: ${{ github.sha }}
         BASE_IMAGE: osp-director-operator
+        AGENT_IMAGE: osp-director-operator-agent
 
     - name: Get branch name
       id: branch-name

--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -60,7 +60,7 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
   build-osp-director-downloader:
-    name: Build rhel-downloader image using buildah
+    name: Build osp-director-downloader image using buildah
     runs-on: ubuntu-latest
 
     steps:
@@ -79,14 +79,14 @@ jobs:
       id: build-osp-director-downloader
       uses: redhat-actions/buildah-build@v2
       with:
-        image: rhel-downloader
+        image: osp-director-downloader
         tags: ${{ env.latesttag }} ${{ github.sha }}
         containerfiles: |
           ./containers/image_downloader/Dockerfile
         build-args: |
           REMOTE_SOURCE=containers/image_downloader
 
-    - name: Push rhel-downloader To ${{ env.imageregistry }}
+    - name: Push osp-director-downloader To ${{ env.imageregistry }}
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-osp-director-downloader.outputs.image }}

--- a/.github/workflows/release-osp-director-operator.yaml
+++ b/.github/workflows/release-osp-director-operator.yaml
@@ -37,10 +37,10 @@ jobs:
         registry_username: ${{ secrets.QUAY_USERNAME }}
         registry_password: ${{ secrets.QUAY_PASSWORD }}
 
-    - name: Tag provision-ip-discovery-agent image
+    - name: Tag agent image
       uses: tinact/docker.image-retag@1.0.2
       with:
-        image_name: ${{ env.imagenamespace }}/provision-ip-discovery-agent
+        image_name: ${{ env.imagenamespace }}/osp-director-operator-agent
         image_old_tag: ${{ github.sha }}
         image_new_tag: ${{ github.event.release.tag_name }}
         registry: ${{ env.imageregistry }}

--- a/.github/workflows/release-osp-director-operator.yaml
+++ b/.github/workflows/release-osp-director-operator.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   imageregistry: 'quay.io'
-  imagenamespace: 'openstack-k8s-operators'
+  imagenamespace: ${{ secrets.IMAGENAMESPACE || secrets.QUAY_USERNAME }}
 
 jobs:
   release:

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -29,7 +29,7 @@ ARG DEST_ROOT=/dest-root
 ARG WHAT=osp-director-operator-agent
 
 ARG IMAGE_COMPONENT="osp-director-operator-agent-container"
-ARG IMAGE_NAME="osp-director-agent-container-container"
+ARG IMAGE_NAME="osp-director-operator-agent"
 ARG IMAGE_VERSION="1.0.0"
 ARG IMAGE_SUMMARY="OSP-Director-Operator-agent"
 ARG IMAGE_DESC="This is agent that works with the OSP Director Operator"

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,9 @@ generate: controller-gen
 
 # Build the docker image
 DOCKERFILE := "Dockerfile"
+DOCKER_BUILD_DIR := .
 docker-build: test
-	podman build -t ${IMG} -f ${DOCKERFILE} .
+	podman build -t ${IMG} -f ${DOCKERFILE} ${DOCKER_BUILD_DIR}
 
 # Push the docker image
 docker-push:

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,9 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image
+DOCKERFILE := "Dockerfile"
 docker-build: test
-	podman build -t ${IMG} .
+	podman build -t ${IMG} -f ${DOCKERFILE} .
 
 # Push the docker image
 docker-push:

--- a/scripts/build_and_push_images.sh
+++ b/scripts/build_and_push_images.sh
@@ -41,7 +41,7 @@ make IMG=${IMG} docker-build docker-push
 make IMG=${AGENT_IMG} DOCKERFILE="Dockerfile.agent" docker-build docker-push
 
 # Downloader image
-make IMG=${DOWNLOADER_IMG} DOCKERFILE="containers/image_downloader/Dockerfile" docker-build docker-push
+make IMG=${DOWNLOADER_IMG} DOCKERFILE="containers/image_downloader/Dockerfile" DOCKER_BUILD_DIR="containers/image_downloader" docker-build docker-push
 
 rm -Rf bundle
 rm -Rf bundle.Dockerfile

--- a/scripts/build_and_push_images.sh
+++ b/scripts/build_and_push_images.sh
@@ -21,11 +21,21 @@ INDEX_IMG="$REPO/$OP_NAME-index:$VERSION"
 
 BUNDLE_IMG="$REPO/$OP_NAME-bundle:$VERSION"
 
+AGENT_IMAGE="$OP_NAME-agent"
+AGENT_IMG_BASE="$REPO/$AGENT_IMAGE"
+AGENT_IMG="$AGENT_IMG_BASE:$VERSION"
+
+CLUSTER_BUNDLE_FILE="bundle/manifests/osp-director-operator.clusterserviceversion.yaml"
+
 # Base operator image
 make manager
 make manifests
 make generate
-IMG=${IMG} make docker-build docker-push
+make IMG=${IMG} docker-build docker-push
+
+# Agent image
+make IMG=${AGENT_IMG} DOCKERFILE="Dockerfile.agent" docker-build docker-push
+
 
 rm -Rf bundle
 rm -Rf bundle.Dockerfile
@@ -33,22 +43,32 @@ rm -Rf bundle.Dockerfile
 # Generate bundle manifests
 VERSION=${VERSION} IMG=${IMG} make bundle
 
+# Replace AGENT_IMAGE_URL_DEFAULT in CSV
+AGENT_IMG_WITH_DIGEST="${AGENT_IMG_BASE}@"$(skopeo inspect docker://${AGENT_IMG} | jq '.Digest' -r)
+sed -z -e 's!\(AGENT_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${AGENT_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
+
 # HACKs for webhook deployment to work around: https://bugzilla.redhat.com/show_bug.cgi?id=1921000
 # TODO: Figure out how to do this via Kustomize so that it's automatically rolled into the make
 #       commands above
-sed -i '/^    webhookPath:.*/a #added\n    containerPort: 4343\n    targetPort: 4343' bundle/manifests/osp-director-operator.clusterserviceversion.yaml
-sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controller-manager/g' bundle/manifests/osp-director-operator.clusterserviceversion.yaml
+sed -i '/^    webhookPath:.*/a #added\n    containerPort: 4343\n    targetPort: 4343' ${CLUSTER_BUNDLE_FILE}
+sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controller-manager/g' ${CLUSTER_BUNDLE_FILE}
 
 # Convert any tags to digests within the CSV (for offline/air gapped environments)
-for csv_image in $(cat bundle/manifests/osp-director-operator.clusterserviceversion.yaml | grep "image:" | sed -e "s|.*image:||" | sort -u); do
+for csv_image in $(cat ${CLUSTER_BUNDLE_FILE} | grep "image:" | sed -e "s|.*image:||" | sort -u); do
   base_image=$(echo $csv_image | cut -f 1 -d':')
   tag_image=$(echo $csv_image | cut -f 2 -d':')
   if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-    sed -e "s|$base_image:$tag_image|$IMG|g" -i bundle/manifests/osp-director-operator.clusterserviceversion.yaml
+    sed -e "s|$base_image:$tag_image|$IMG|g" -i ${CLUSTER_BUNDLE_FILE}
+  elif [[ "$base_image" == */"${AGENT_IMAGE}" ]]; then
+    sed -e "s|$base_image:$tag_image|$AGENT_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
   else
     digest_image=$(skopeo inspect docker://$base_image:$tag_image | jq '.Digest' -r)
-    echo "$base_image:$tag_image becomes $base_image@$digest_image."
-    sed -e "s|$base_image:$tag_image|$base_image@$digest_image|g" -i bundle/manifests/osp-director-operator.clusterserviceversion.yaml
+    if [[ "$digest_image" == "" ]]; then
+	echo "Failed to get image digest for docker://$base_image:$tag_image"
+    else
+        echo "$base_image:$tag_image becomes $base_image@$digest_image."
+        sed -e "s|$base_image:$tag_image|$base_image@$digest_image|g" -i ${CLUSTER_BUNDLE_FILE}
+    fi
   fi
 done
 


### PR DESCRIPTION
The provision-ip-discovery-agent has been removed so drop from the
github actions. Add the operator-agent container instead. Also update
the agent container url in the CSV.