### PR TITLE
Fix adding osnetcfg and osnet labels on CR

### DIFF
--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -152,7 +152,13 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// controller to watch this resource and reconcile
 	//
 	var ctrlResult ctrl.Result
-	ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(r, instance, cond, instance.Spec.Networks[0])
+	currentLabels := instance.DeepCopy().Labels
+	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(
+		r,
+		instance,
+		cond,
+		instance.Spec.Networks[0],
+	)
 	if (err != nil) || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -160,9 +166,25 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	//
 	// add labels of all networks used by this CR
 	//
-	err = openstacknet.AddOSNetNameLowerLabels(r, instance, cond, instance.Spec.Networks)
-	if err != nil {
-		return ctrl.Result{}, err
+	instance.Labels = openstacknet.AddOSNetNameLowerLabels(r, instance, cond, instance.Spec.Networks)
+
+	//
+	// update instance to sync labels if changed
+	//
+	if !equality.Semantic.DeepEqual(
+		currentLabels,
+		instance.Labels,
+	) {
+		err = r.Client.Update(context.TODO(), instance)
+		if err != nil {
+			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonAddOSNetLabelError)
+			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
+			return ctrl.Result{}, err
+		}
 	}
 
 	envVars := make(map[string]common.EnvSetter)
@@ -741,10 +763,6 @@ func (r *OpenStackClientReconciler) createNewHostnames(
 			err = common.WrapErrorForObject(cond.Message, instance, err)
 
 			return newHostnames, err
-		}
-
-		if instance.Status.OpenStackClientNetStatus == nil {
-			instance.Status.OpenStackClientNetStatus = map[string]ospdirectorv1beta1.HostStatus{}
 		}
 
 		if hostnameDetails.Hostname != "" {

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -256,11 +256,17 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	currentLabels := instance.DeepCopy().Labels
 	//
 	// add osnetcfg CR label reference which is used in the in the osnetcfg
 	// controller to watch this resource and reconcile
 	//
-	ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(r, instance, cond, vipNetworksList[0])
+	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(
+		r,
+		instance,
+		cond,
+		vipNetworksList[0],
+	)
 	if (err != nil) || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -268,9 +274,25 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	//
 	// add labels of all networks used by this CR
 	//
-	err = openstacknet.AddOSNetNameLowerLabels(r, instance, cond, vipNetworksList)
-	if err != nil {
-		return ctrl.Result{}, err
+	instance.Labels = openstacknet.AddOSNetNameLowerLabels(r, instance, cond, vipNetworksList)
+
+	//
+	// update instance to sync labels if changed
+	//
+	if !equality.Semantic.DeepEqual(
+		currentLabels,
+		instance.Labels,
+	) {
+		err = r.Client.Update(context.TODO(), instance)
+		if err != nil {
+			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
+			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonAddOSNetLabelError)
+			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
+
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
+			return ctrl.Result{}, err
+		}
 	}
 
 	//
@@ -763,10 +785,6 @@ func (r *OpenStackControlPlaneReconciler) createNewHostnames(
 			err = common.WrapErrorForObject(cond.Message, instance, err)
 
 			return newVMs, err
-		}
-
-		if instance.Status.VIPStatus == nil {
-			instance.Status.VIPStatus = map[string]ospdirectorv1beta1.HostStatus{}
 		}
 
 		if hostnameDetails.Hostname != "" {

--- a/pkg/openstacknetconfig/funcs.go
+++ b/pkg/openstacknetconfig/funcs.go
@@ -1,7 +1,6 @@
 package openstacknetconfig
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -12,9 +11,7 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -27,7 +24,8 @@ func AddOSNetConfigRefLabel(
 	obj client.Object,
 	cond *ospdirectorv1beta1.Condition,
 	networkNameLower string,
-) (reconcile.Result, error) {
+) (map[string]string, reconcile.Result, error) {
+	labels := obj.GetLabels()
 
 	//
 	// only add label if it is not already there
@@ -50,14 +48,14 @@ func AddOSNetConfigRefLabel(
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeWaiting)
 			common.LogForObject(r, cond.Message, obj)
 
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			return labels, ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		} else if err != nil {
 			cond.Message = fmt.Sprintf("Failed to get OpenStackNet %s ", networkNameLower)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonOSNetError)
 			cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetError)
 			err = common.WrapErrorForObject(cond.Message, obj, err)
 
-			return ctrl.Result{}, err
+			return labels, ctrl.Result{}, err
 		}
 
 		//
@@ -66,44 +64,30 @@ func AddOSNetConfigRefLabel(
 		for _, ownerRef := range osnet.ObjectMeta.OwnerReferences {
 			if ownerRef.Kind == "OpenStackNetConfig" {
 				//
-				// update labels on obj
+				// merge with obj labels
 				//
-				op, err := controllerutil.CreateOrUpdate(context.TODO(), r.GetClient(), obj, func() error {
-					obj.SetLabels(
-						labels.Merge(
-							obj.GetLabels(),
-							map[string]string{
-								OpenStackNetConfigReconcileLabel: ownerRef.Name,
-							},
-						))
+				labels = common.MergeStringMaps(
+					labels,
+					map[string]string{
+						OpenStackNetConfigReconcileLabel: ownerRef.Name,
+					},
+				)
 
-					return nil
-				})
-				if err != nil {
-					cond.Message = fmt.Sprintf("Failed to update RefLabel label on %s %s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
-					cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonAddRefLabelError)
-					cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.ConfigGeneratorCondTypeError)
-					err = common.WrapErrorForObject(cond.Message, obj, err)
-
-					return ctrl.Result{}, err
-				}
 				common.LogForObject(
 					r,
-					fmt.Sprintf("%s updated with %s:%s label: %s",
+					fmt.Sprintf("%s updated with %s:%s label",
 						obj.GetName(),
 						OpenStackNetConfigReconcileLabel,
 						ownerRef.Name,
-						op,
 					),
 					obj,
 				)
-
-				return ctrl.Result{}, nil
+				break
 			}
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return labels, ctrl.Result{}, nil
 }
 
 //


### PR DESCRIPTION
Right now AddOSNetConfigRefLabel and AddOSNetNameLowerLabels
updated the object when added the required labels to the metadata.
Since the generic way of the functions only updated the object
labels at that point of the reconcilation other object information,
like status got lost.
This changes the two functions to merge the required labels into
the object labels and returns them so that they can be set on the
CR object instead of writing the object in the specific label
functions.