### PR TITLE
Fix duplicate ip assignmnent

### DIFF
--- a/pkg/openstacknet/funcs.go
+++ b/pkg/openstacknet/funcs.go
@@ -254,6 +254,31 @@ func GetAllIPReservations(
 	}
 
 	//
+	// add new reservations from osnet.Spec.Reservations which are not yet synced to osnet.Status.Reservations
+	//
+	for _, role := range osNet.Spec.RoleReservations {
+		for _, res := range role.Reservations {
+			found := false
+			for _, resList := range reservationList {
+				if res.IP == resList.IP {
+					found = true
+					break
+				}
+			}
+			if !found {
+				reservationList = append(
+					reservationList,
+					ospdirectorv1beta1.IPReservation{
+						IP:       res.IP,
+						Hostname: res.Hostname,
+						Deleted:  res.Deleted,
+					},
+				)
+			}
+		}
+	}
+
+	//
 	// add new staticReservations provided by the osnetcfg CR
 	//
 	for _, staticRes := range staticReservations {


### PR DESCRIPTION
Already assigned IPs right now are only considered as reserved when
they got added to the osnet status. If IPs for multiple roles get
created in the same run, new reservations are only added to the
osnet spec and not yet synced to the osnet status. Because of that
it might happen that IPs assigned/created for different get assigned
to nodes from another role.

This fix make sure that also new IP reservations added to the osnet
spec and not yet synced to the osnet status are considered as
reserved and therefore are not a candidate for new ip assignments.