### PR TITLE
Harvest overcloud.json after deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1545,6 +1545,25 @@ openstackbackuprestore   restore    openstackbackupsave-1641928378   Restored   
 
 At this point, all resources contained with the chosen `OpenStackBackup` should be restored and fully provisioned.
 
+Exported stack data config map
+--------------------------------------------------------
+
+The OSP Director Operator automatically creates a ConfigMap after each OSDeploy resource finishes executing. This ConfigMap is named after the OSDeploy resource name and prefixed with tripleo-exports-. For example tripleo-exports-default would be the name of the ConfigMap for the 'default' OSDeploy resource. Each ConfigMap contains 2 YAML files:
+
+| Filename    | Description | TripleO Command Equivalent |
+| ----------- | ----------- | -------------------------- |
+| ctlplane-export.yaml | Used with multiple stacks for DCN | overcloud export |
+| ctlplane-export-filtered.yaml | Used for multiple stacks with Cell "Controller" stacks | overcloud cell export |
+
+Use the command below to extract the YAML files from the ConfigMap. Once extracted the YAML files can be
+added into custom Heat parameters on OSConfigGenerator resources.
+
+```bash
+oc extract cm/tripleo-exports-default
+```
+
+NOTE: The OSP Director Operator does not yet generate exports for Ceph stacks.
+
 # Day2 Operations
 
 ## Change resources on virtual machines

--- a/api/v1beta1/openstackconfigversion_types.go
+++ b/api/v1beta1/openstackconfigversion_types.go
@@ -36,7 +36,7 @@ type OpenStackConfigVersionStatus struct {
 //+kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=osconfigversion;osconfigversions
 // +operator-sdk:csv:customresourcedefinitions:displayName="OpenStack Config Version"
-// +kubebuilder:printcolumn:name="Generator",type="string",JSONPath=".spec.ConfigGeneratorName",description="Config Generator Name"
+// +kubebuilder:printcolumn:name="Generator",type="string",JSONPath=".spec.configGeneratorName",description="Config Generator Name"
 
 // OpenStackConfigVersion represents a set of executable Ansible playbooks
 type OpenStackConfigVersion struct {

--- a/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
@@ -21,7 +21,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Config Generator Name
-      jsonPath: .spec.ConfigGeneratorName
+      jsonPath: .spec.configGeneratorName
       name: Generator
       type: string
     name: v1beta1

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -132,6 +132,24 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - osp-director.openstack.org
+  resources:
+  - openstackconfigversions
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/containers/agent/deploy.go
+++ b/containers/agent/deploy.go
@@ -2,23 +2,30 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
+	"reflect"
 	"strings"
 	"syscall"
 
 	"github.com/golang/glog"
+	"github.com/openstack-k8s-operators/osp-director-operator/pkg/openstackdeploy"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -33,6 +40,7 @@ var (
 		kubeconfig     string
 		namespace      string
 		pod            string
+		deployName     string
 		configVersion  string
 		gitURL         string
 		gitSSHIdentity string
@@ -41,6 +49,21 @@ var (
 		tags           string
 		skipTags       string
 	}
+
+	openstackConfigVersionGVR = schema.GroupVersionResource{
+		Group:    "osp-director.openstack.org",
+		Version:  "v1beta1",
+		Resource: "openstackconfigversions",
+	}
+
+	filteredAllNodesConfig = []string{
+		"oslo_messaging_notify_short_bootstrap_node_name",
+		"oslo_messaging_notify_node_names",
+		"oslo_messaging_rpc_node_names",
+		"memcached_node_ips",
+		"ovn_dbs_vip",
+		"redis_vip",
+	}
 )
 
 func init() {
@@ -48,12 +71,87 @@ func init() {
 	deployCmd.PersistentFlags().StringVar(&deployOpts.namespace, "namespace", "openstack", "Namespace to use for openstackclient pod.")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.pod, "pod", "", "Pod to use for executing the deployment.")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.configVersion, "configVersion", "", "Config version to use when executing the deployment.")
+	deployCmd.PersistentFlags().StringVar(&deployOpts.deployName, "deployName", "", "The name of the deployment being executed. Controls the name of the generated exports ConfigMap.")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.gitURL, "gitURL", "", "Git URL to use when downloading playbooks.")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.gitSSHIdentity, "gitSSHIdentity", "", "Git SSH Identity to use when downloading playbooks.")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.playbook, "playbook", "", "Playbook to deploy")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.playbook, "limit", "", "Playbook inventory limit")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.playbook, "tags", "", "Playbook include tags")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.playbook, "skipTags", "", "Playbook exclude tags")
+}
+
+// GetConfigMap for our exports Heat environment
+func GetConfigMap(namespace string, exports string, exportsFiltered string, deployName string) *corev1.ConfigMap {
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      openstackdeploy.ConfigMapBasename + deployName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"ctlplane-export.yaml":          exports,
+			"ctlplane-export-filtered.yaml": exportsFiltered,
+		},
+	}
+
+	return cm
+}
+
+// CopyFromPod -
+func CopyFromPod(kclient kubernetes.Clientset, pod corev1.Pod, containerName string, filename string) (string, error) {
+	req := kclient.CoreV1().RESTClient().Post().
+		Namespace(pod.Namespace).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("exec").
+		Param("container", containerName).
+		Param("stdin", "true").
+		Param("stdout", "true").
+		Param("stderr", "true").
+		Param("tty", "false").
+		Param("command", "sh")
+
+	cfg, err := config.GetConfig()
+
+	if err != nil {
+		return "", err
+	}
+
+	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
+	if err != nil {
+		return "", err
+	}
+
+	argString := fmt.Sprintf("%s\n", "/usr/bin/cat "+filename)
+	argReader := strings.NewReader(argString)
+
+	reader, writer := io.Pipe()
+
+	go func() {
+		defer writer.Close()
+		err := exec.Stream(remotecommand.StreamOptions{
+			Stdin:  argReader,
+			Stdout: writer,
+			Stderr: os.Stderr,
+			Tty:    false,
+		})
+		if err != nil {
+			panic(err)
+		}
+	}()
+	buf := new(strings.Builder)
+	num, err := io.Copy(buf, reader)
+	if err != nil {
+		return "", err
+	}
+	if num <= 0 {
+		return "", nil
+	}
+	return buf.String(), nil
 }
 
 // ExecPodCommand -
@@ -93,6 +191,111 @@ func ExecPodCommand(kclient kubernetes.Clientset, pod corev1.Pod, containerName 
 	})
 }
 
+func allNodesToYaml(allNodesData string, filter bool) (string, error) {
+
+	allNodesUnstructured := make(map[string]interface{})
+	err := json.Unmarshal([]byte(allNodesData), &allNodesUnstructured)
+	if err != nil {
+		return "", err
+	}
+
+	if filter {
+		for _, val := range filteredAllNodesConfig {
+			delete(allNodesUnstructured, val)
+		}
+	}
+
+	// convert to string
+	yamlStr, err := yaml.Marshal(allNodesUnstructured)
+
+	return string(yamlStr), err
+}
+
+func getCtlplaneExports(dClient dynamic.Interface) (string, error) {
+
+	configVersion := dClient.Resource(openstackConfigVersionGVR)
+
+	unstructuredConfigVersion, err := configVersion.Namespace(deployOpts.namespace).Get(context.Background(), os.Getenv("CONFIG_VERSION"), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", unstructuredConfigVersion.Object["spec"].(map[string]interface{})["ctlplaneExports"]), nil
+
+}
+
+func processOvercloudJSON(kclient kubernetes.Clientset, config *rest.Config) error {
+	var err error
+	glog.V(0).Info("Running process Overcloud JSON.")
+
+	// lookup the deployment pod (openstackclient)
+	pod, err := kclient.CoreV1().Pods(deployOpts.namespace).Get(
+		context.TODO(),
+		deployOpts.pod,
+		metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// obtain the allNodesData from the overcloud.json from the deployment pod
+	// this is written by TripleO's Ansible after successful deployment
+	allNodesDataString, err := CopyFromPod(kclient, *pod, "openstackclient", "/home/cloud-admin/work/"+deployOpts.configVersion+"/playbooks/tripleo-ansible/group_vars/overcloud.json")
+	if err != nil {
+		return err
+	}
+
+	// get the existing CtlplaneExports from the ConfigVersion CR
+	dClient := dynamic.NewForConfigOrDie(config)
+	ctlplaneExport, err := getCtlplaneExports(dClient)
+	if err != nil {
+		return err
+	}
+
+	// we now have 2 YAML strings. Combine them into a buffer
+	// noting to tab in the new data accordingly.
+	var filterBuffer, buffer strings.Builder
+
+	// filtered
+	allNodesDataFiltered, err := allNodesToYaml(allNodesDataString, true)
+	if err != nil {
+		return err
+	}
+	filterBuffer.WriteString(ctlplaneExport)
+	filterBuffer.WriteString("  AllNodesExtraMapData:\n")
+	for _, line := range strings.Split(allNodesDataFiltered, "\n") {
+		filterBuffer.WriteString(fmt.Sprintf("    %s\n", line))
+	}
+
+	// unfiltered
+	allNodesData, err := allNodesToYaml(allNodesDataString, false)
+	if err != nil {
+		return err
+	}
+	buffer.WriteString(ctlplaneExport)
+	buffer.WriteString("  AllNodesExtraMapData:\n")
+	for _, line := range strings.Split(allNodesData, "\n") {
+		buffer.WriteString(fmt.Sprintf("    %s\n", line))
+	}
+
+	// Create or Update the ConfigMap
+	configMap := GetConfigMap(deployOpts.namespace, buffer.String(), filterBuffer.String(), deployOpts.deployName)
+	foundConfigMap, err := kclient.CoreV1().ConfigMaps(deployOpts.namespace).Get(context.TODO(), openstackdeploy.ConfigMapBasename+deployOpts.deployName, metav1.GetOptions{})
+	if err != nil && k8s_errors.IsNotFound(err) {
+		_, err := kclient.CoreV1().ConfigMaps(deployOpts.namespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	} else if !reflect.DeepEqual(configMap.Data, foundConfigMap.Data) {
+		foundConfigMap.Data = configMap.Data
+		_, err := kclient.CoreV1().ConfigMaps(deployOpts.namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
 func runDeployCmd(cmd *cobra.Command, args []string) {
 	var err error
 	err = flag.Set("logtostderr", "true")
@@ -124,6 +327,13 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 			glog.Fatalf("configVersion is required")
 		}
 		deployOpts.configVersion = configVersion
+	}
+	if deployOpts.deployName == "" {
+		deployName, ok := os.LookupEnv("DEPLOY_NAME")
+		if !ok || deployName == "" {
+			glog.Fatalf("deployName is required")
+		}
+		deployOpts.deployName = deployName
 	}
 
 	if deployOpts.gitURL == "" {
@@ -229,5 +439,11 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 		panic(execErr.Error())
 	}
 
+	err = processOvercloudJSON(*kclient, config)
+	if err != nil {
+		panic(err.Error())
+	}
+
 	glog.V(0).Info("Shutting down deploy agent")
+
 }

--- a/pkg/openstackdeploy/configmap.go
+++ b/pkg/openstackdeploy/configmap.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstackdeploy
+
+import (
+	"context"
+
+	ospdirectorv1beta1 "github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1"
+	common "github.com/openstack-k8s-operators/osp-director-operator/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// SetConfigMapOwner -
+func SetConfigMapOwner(r common.ReconcilerCommon, cr *ospdirectorv1beta1.OpenStackDeploy) error {
+
+	// set ownership on the ConfigMap created by our Deployment container
+	configMap := &corev1.ConfigMap{}
+	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: ConfigMapBasename + cr.Name, Namespace: cr.Namespace}, configMap)
+	if err != nil {
+		return err
+	}
+	ownerErr := controllerutil.SetOwnerReference(cr, configMap, r.GetScheme())
+	if ownerErr != nil {
+		return ownerErr
+	}
+	err = r.GetClient().Update(context.TODO(), configMap)
+	if err != nil {
+		return err
+	}
+	return nil
+
+}

--- a/pkg/openstackdeploy/const.go
+++ b/pkg/openstackdeploy/const.go
@@ -19,4 +19,7 @@ package openstackdeploy
 const (
 	// ServiceAccount -
 	ServiceAccount = "osp-director-operator-openstackdeploy"
+
+	// ConfigMapBasename The basename prefix for exports data ConfigMaps
+	ConfigMapBasename = "tripleo-exports-"
 )

--- a/pkg/openstackdeploy/job.go
+++ b/pkg/openstackdeploy/job.go
@@ -68,9 +68,14 @@ func DeployJob(
 				ImagePullPolicy: corev1.PullAlways,
 				Command:         cmd,
 				Env: []corev1.EnvVar{
+					// NOTE: CONFIG_VERSION must be the first ENV due to logic in openstackdeploy_controller
 					{
 						Name:  "CONFIG_VERSION",
 						Value: configVersion,
+					},
+					{
+						Name:  "DEPLOY_NAME",
+						Value: cr.Name,
 					},
 					{
 						Name:  "OSP_DIRECTOR_OPERATOR_NAMESPACE",


### PR DESCRIPTION
This patch harvests overcloud.json (generated by TripleO Ansible)
after a successful deployment finishes. The results are merged
into other "exported" data from the Heat stack and then written
to the 'tripleo-ctlplane-exports' ConfigMap.

Then intent is to optionally use this ConfigMap alongside
a new ConfigGenerator to implement a multi-stack workflows
like DCN.