### PR TITLE
Support interrupting a deploy job

### DIFF
--- a/pkg/openstackclient/volumes.go
+++ b/pkg/openstackclient/volumes.go
@@ -52,6 +52,12 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volu
 		},
 		{
 			Name:      "openstackclient-scripts",
+			MountPath: "/usr/local/bin/tripleo-deploy-term.sh",
+			SubPath:   "tripleo-deploy-term.sh",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "openstackclient-scripts",
 			MountPath: "/home/cloud-admin/ctlplane-ansible-inventory",
 			SubPath:   "ansible-inventory",
 			ReadOnly:  true,
@@ -183,6 +189,10 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 						{
 							Key:  "tripleo-deploy.sh",
 							Path: "tripleo-deploy.sh",
+						},
+						{
+							Key:  "tripleo-deploy-term.sh",
+							Path: "tripleo-deploy-term.sh",
 						},
 						{
 							Key:  "init.sh",

--- a/pkg/openstackdeploy/job.go
+++ b/pkg/openstackdeploy/job.go
@@ -44,7 +44,7 @@ func DeployJob(
 		},
 	}
 
-	var terminationGracePeriodSeconds int64 = 0
+	var terminationGracePeriodSeconds int64 = 60
 	var backoffLimit int32 = 0
 
 	cmd := []string{"/osp-director-operator-agent", "deploy"}

--- a/templates/openstackclient/bin/tripleo-deploy-term.sh
+++ b/templates/openstackclient/bin/tripleo-deploy-term.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+umask 022
+
+CONFIG_VERSION=${CONFIG_VERSION:?"Please set CONFIG_VERSION."}
+RUNDIR="/var/run/tripleo-deploy/$CONFIG_VERSION"
+PGIDFILE=$RUNDIR/pgid
+
+if [[ ! -e $PGIDFILE ]]; then
+  exit 0
+fi
+
+PGID=$(cat $PGIDFILE)
+
+if kill -0 -$PGID; then
+  echo "Terminating tripleo-deploy($PGID)"
+  kill -- -$PGID
+  i=0
+  until [[ "$i" -gt 50 ]]; do
+    kill -0 -$PGID && exit 0
+    sleep 1
+  done
+  kill -9 -$PGID
+fi

--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -4,6 +4,18 @@ umask 022
 
 export PWD=/home/cloud-admin
 CONFIG_VERSION=${CONFIG_VERSION:?"Please set CONFIG_VERSION."}
+sudo bash -c 'mkdir -p /var/run/tripleo-deploy && chown '$(whoami)' /var/run/tripleo-deploy'
+RUNDIR="/var/run/tripleo-deploy/$CONFIG_VERSION"
+mkdir -p $RUNDIR
+PGIDFILE=$RUNDIR/pgid
+trap "rm -f $PGIDFILE" EXIT
+# Assume PGID==$PPID which is the case when run via oc exec
+# Alternatively could do something like:
+# PGID=$(python3 -c 'import os; print(os.getpgid(os.getpid()))')
+PGID=$PPID
+echo $PGID > $PGIDFILE
+
+
 WORKDIR="/home/cloud-admin/work/$CONFIG_VERSION"
 mkdir -p $WORKDIR
 


### PR DESCRIPTION
The tripleo-deploy.sh oc exec shell creates a new process group. Can use
this to terminate the deployment.

Set terminateGracePeriod to 60s for the deploy job container.
Add a signal handler goroutine to the deploy job that exec a new
tripleo-deploy-term.sh script on the openstackclient.
This script will send a SIGTERM to the process group and, if it has not
not terminated after ~30s~50s, send a SIGKILL.