### PR TITLE
Update webhook/manifests.yaml for removed webhook

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -337,27 +337,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-osp-director-openstack-org-v1beta1-openstackprovisionserver
-  failurePolicy: Fail
-  name: vopenstackprovisionserver.kb.io
-  rules:
-  - apiGroups:
-    - osp-director.openstack.org
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - openstackprovisionservers
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /validate-osp-director-openstack-org-v1beta1-openstacknetconfig
   failurePolicy: Fail
   name: vopenstacknetconfig.kb.io


### PR DESCRIPTION
In eab3f6d203e79590bb95a4a406c15363865cc071 we removed a duplicate
webhook. This updates the config/webhook/manifests.yaml for
the associated change.