### PR TITLE
Add generator name to ConfigVersion

### DIFF
--- a/api/v1beta1/openstackconfigversion_types.go
+++ b/api/v1beta1/openstackconfigversion_types.go
@@ -22,9 +22,10 @@ import (
 
 // OpenStackConfigVersionSpec defines the desired state of OpenStackConfigVersion
 type OpenStackConfigVersionSpec struct {
-	Hash            string `json:"hash"`
-	Diff            string `json:"diff"`
-	CtlplaneExports string `json:"ctlplaneExports"`
+	Hash                string `json:"hash"`
+	Diff                string `json:"diff"`
+	CtlplaneExports     string `json:"ctlplaneExports"`
+	ConfigGeneratorName string `json:"configGeneratorName"`
 }
 
 // OpenStackConfigVersionStatus defines the observed state of OpenStackConfigVersion
@@ -35,6 +36,7 @@ type OpenStackConfigVersionStatus struct {
 //+kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=osconfigversion;osconfigversions
 // +operator-sdk:csv:customresourcedefinitions:displayName="OpenStack Config Version"
+// +kubebuilder:printcolumn:name="Generator",type="string",JSONPath=".spec.ConfigGeneratorName",description="Config Generator Name"
 
 // OpenStackConfigVersion is the Schema for the openstackconfigversions API
 type OpenStackConfigVersion struct {

--- a/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
@@ -19,7 +19,12 @@ spec:
     singular: openstackconfigversion
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Config Generator Name
+      jsonPath: .spec.ConfigGeneratorName
+      name: Generator
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: OpenStackConfigVersion is the Schema for the openstackconfigversions
@@ -40,6 +45,8 @@ spec:
           spec:
             description: OpenStackConfigVersionSpec defines the desired state of OpenStackConfigVersion
             properties:
+              configGeneratorName:
+                type: string
               ctlplaneExports:
                 type: string
               diff:
@@ -47,6 +54,7 @@ spec:
               hash:
                 type: string
             required:
+            - configGeneratorName
             - ctlplaneExports
             - diff
             - hash

--- a/pkg/openstackconfigversion/git_util.go
+++ b/pkg/openstackconfigversion/git_util.go
@@ -202,14 +202,14 @@ func SyncGit(inst *ospdirectorv1beta1.OpenStackConfigGenerator, client client.Cl
 							Name:      m1.Split(ref.Name().String(), -1)[2],
 							Namespace: inst.Namespace,
 						},
-						Spec: ospdirectorv1beta1.OpenStackConfigVersionSpec{Hash: m1.Split(ref.Name().String(), -1)[2], Diff: buffer.String()}}
+						Spec: ospdirectorv1beta1.OpenStackConfigVersionSpec{Hash: m1.Split(ref.Name().String(), -1)[2], Diff: buffer.String(), ConfigGeneratorName: inst.Name}}
 				} else {
 					configVersion = ospdirectorv1beta1.OpenStackConfigVersion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      m1.Split(ref.Name().String(), -1)[2],
 							Namespace: inst.Namespace,
 						},
-						Spec: ospdirectorv1beta1.OpenStackConfigVersionSpec{Hash: m1.Split(ref.Name().String(), -1)[2], Diff: ""}}
+						Spec: ospdirectorv1beta1.OpenStackConfigVersionSpec{Hash: m1.Split(ref.Name().String(), -1)[2], Diff: "", ConfigGeneratorName: inst.Name}}
 				}
 				configVersions[ref.Hash().String()] = configVersion
 			}


### PR DESCRIPTION
This adds the name of the ConfigGenerator to ConfigVersion
resources so that we can display them when listing.