### PR TITLE
Ensure correct images are used for provision server

### DIFF
--- a/api/v1beta1/openstackprovisionserver_types.go
+++ b/api/v1beta1/openstackprovisionserver_types.go
@@ -31,12 +31,6 @@ type OpenStackProvisionServerSpec struct {
 	Interface string `json:"interface,omitempty"`
 	// URL for RHEL qcow2 image (compressed as gz, or uncompressed)
 	BaseImageURL string `json:"baseImageUrl"`
-	// Container image URL for init container that downloads the RHEL qcow2 image (baseImageUrl)
-	DownloaderImageURL string `json:"downloaderImageUrl,omitempty"`
-	// Container image URL for the main container that serves the downloaded RHEL qcow2 image (baseImageUrl)
-	ApacheImageURL string `json:"apacheImageUrl,omitempty"`
-	// Container image URL for the sidecar container that discovers provisioning network IPs
-	AgentImageURL string `json:"agentImageUrl,omitempty"`
 }
 
 // OpenStackProvisionServerStatus defines the observed state of OpenStackProvisionServer
@@ -56,6 +50,13 @@ type OpenStackProvisionServerStatus struct {
 type OpenStackProvisionServerProvisioningStatus struct {
 	State  ProvisioningState `json:"state,omitempty"`
 	Reason string            `json:"reason,omitempty"`
+}
+
+// OpenStackProvisionServerDefaults -
+type OpenStackProvisionServerDefaults struct {
+	DownloaderImageURL string
+	AgentImageURL      string
+	ApacheImageURL     string
 }
 
 const (

--- a/api/v1beta1/openstackprovisionserver_webhook.go
+++ b/api/v1beta1/openstackprovisionserver_webhook.go
@@ -30,22 +30,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// OpenStackProvisionServerDefaults -
-type OpenStackProvisionServerDefaults struct {
-	DownloaderImageURL string
-	AgentImageURL      string
-	ApacheImageURL     string
-}
-
-var openstackProvisionServerDefaults OpenStackProvisionServerDefaults
-
 // log is for logging in this package.
 var openstackprovisionserverlog = logf.Log.WithName("openstackprovisionserver-resource")
 
 // SetupWebhookWithManager - register this webhook with the controller manager
 func (r *OpenStackProvisionServer) SetupWebhookWithManager(mgr ctrl.Manager, defaults OpenStackProvisionServerDefaults) error {
-
-	openstackProvisionServerDefaults = defaults
 
 	if webhookClient == nil {
 		webhookClient = mgr.GetClient()
@@ -105,15 +94,4 @@ func (r *OpenStackProvisionServer) ValidateDelete() error {
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *OpenStackProvisionServer) Default() {
 	openstackephemeralheatlog.Info("default", "name", r.Name)
-
-	if r.Spec.DownloaderImageURL == "" {
-		r.Spec.DownloaderImageURL = openstackProvisionServerDefaults.DownloaderImageURL
-	}
-	if r.Spec.AgentImageURL == "" {
-		r.Spec.AgentImageURL = openstackProvisionServerDefaults.AgentImageURL
-	}
-	if r.Spec.ApacheImageURL == "" {
-		r.Spec.ApacheImageURL = openstackProvisionServerDefaults.ApacheImageURL
-	}
-
 }

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -2468,22 +2468,9 @@ spec:
                               description: OpenStackProvisionServerSpec defines the
                                 desired state of OpenStackProvisionServer
                               properties:
-                                agentImageUrl:
-                                  description: Container image URL for the sidecar
-                                    container that discovers provisioning network
-                                    IPs
-                                  type: string
-                                apacheImageUrl:
-                                  description: Container image URL for the main container
-                                    that serves the downloaded RHEL qcow2 image (baseImageUrl)
-                                  type: string
                                 baseImageUrl:
                                   description: URL for RHEL qcow2 image (compressed
                                     as gz, or uncompressed)
-                                  type: string
-                                downloaderImageUrl:
-                                  description: Container image URL for init container
-                                    that downloads the RHEL qcow2 image (baseImageUrl)
                                   type: string
                                 interface:
                                   description: An optional interface to use instead

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -50,20 +50,8 @@ spec:
             description: OpenStackProvisionServerSpec defines the desired state of
               OpenStackProvisionServer
             properties:
-              agentImageUrl:
-                description: Container image URL for the sidecar container that discovers
-                  provisioning network IPs
-                type: string
-              apacheImageUrl:
-                description: Container image URL for the main container that serves
-                  the downloaded RHEL qcow2 image (baseImageUrl)
-                type: string
               baseImageUrl:
                 description: URL for RHEL qcow2 image (compressed as gz, or uncompressed)
-                type: string
-              downloaderImageUrl:
-                description: Container image URL for init container that downloads
-                  the RHEL qcow2 image (baseImageUrl)
                 type: string
               interface:
                 description: An optional interface to use instead of the cluster's

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -55,9 +55,10 @@ var (
 // OpenStackProvisionServerReconciler reconciles a ProvisionServer object
 type OpenStackProvisionServerReconciler struct {
 	client.Client
-	Kclient kubernetes.Interface
-	Log     logr.Logger
-	Scheme  *runtime.Scheme
+	Kclient  kubernetes.Interface
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Defaults ospdirectorv1beta1.OpenStackProvisionServerDefaults
 }
 
 // GetClient -
@@ -402,7 +403,7 @@ func (r *OpenStackProvisionServerReconciler) deploymentCreateOrUpdate(
 			Containers: []corev1.Container{
 				{
 					Name:            "osp-httpd",
-					Image:           instance.Spec.ApacheImageURL,
+					Image:           r.Defaults.ApacheImageURL,
 					ImagePullPolicy: corev1.PullAlways,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &trueValue,
@@ -420,7 +421,7 @@ func (r *OpenStackProvisionServerReconciler) deploymentCreateOrUpdate(
 				{
 					Name:            "osp-provision-ip-discovery-agent",
 					Command:         []string{"/osp-director-agent", "provision-ip-discovery"},
-					Image:           instance.Spec.AgentImageURL,
+					Image:           r.Defaults.AgentImageURL,
 					ImagePullPolicy: corev1.PullAlways,
 					Env: []corev1.EnvVar{
 						{
@@ -442,7 +443,7 @@ func (r *OpenStackProvisionServerReconciler) deploymentCreateOrUpdate(
 
 		initContainerDetails := []provisionserver.InitContainer{
 			{
-				ContainerImage: instance.Spec.DownloaderImageURL,
+				ContainerImage: r.Defaults.DownloaderImageURL,
 				Env: []corev1.EnvVar{
 					{
 						Name:  "RHEL_IMAGE_URL",

--- a/main.go
+++ b/main.go
@@ -146,6 +146,38 @@ func main() {
 		srv.Port = WebhookPort
 	}
 
+	//
+	// DEFAULTS
+	//
+	openstackControlPlaneDefaults := ospdirectorv1beta1.OpenStackControlPlaneDefaults{
+		OpenStackRelease: os.Getenv("OPENSTACK_RELEASE_DEFAULT"),
+	}
+
+	openstackClientDefaults := ospdirectorv1beta1.OpenStackClientDefaults{
+		ImageURL: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
+	}
+
+	ephemeralHeatDefaults := ospdirectorv1beta1.OpenStackEphemeralHeatDefaults{
+		HeatAPIImageURL:    os.Getenv("HEAT_API_IMAGE_URL_DEFAULT"),
+		HeatEngineImageURL: os.Getenv("HEAT_ENGINE_IMAGE_URL_DEFAULT"),
+		MariaDBImageURL:    os.Getenv("MARIADB_IMAGE_URL_DEFAULT"),
+		RabbitImageURL:     os.Getenv("RABBITMQ_IMAGE_URL_DEFAULT"),
+	}
+
+	provisionServerDefaults := ospdirectorv1beta1.OpenStackProvisionServerDefaults{
+		DownloaderImageURL: os.Getenv("DOWNLOADER_IMAGE_URL_DEFAULT"),
+		AgentImageURL:      os.Getenv("AGENT_IMAGE_URL_DEFAULT"),
+		ApacheImageURL:     os.Getenv("APACHE_IMAGE_URL_DEFAULT"),
+	}
+
+	openstackDeployDefaults := ospdirectorv1beta1.OpenStackDeployDefaults{
+		AgentImageURL: os.Getenv("AGENT_IMAGE_URL_DEFAULT"),
+	}
+
+	openstackConfigGeneratorDefaults := ospdirectorv1beta1.OpenStackConfigGeneratorDefaults{
+		ImageURL: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
+	}
+
 	if err = (&controllers.OpenStackControlPlaneReconciler{
 		Client:  mgr.GetClient(),
 		Kclient: kclient,
@@ -165,10 +197,11 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.OpenStackProvisionServerReconciler{
-		Client:  mgr.GetClient(),
-		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackProvisionServer"),
-		Scheme:  mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Kclient:  kclient,
+		Log:      ctrl.Log.WithName("controllers").WithName("OpenStackProvisionServer"),
+		Scheme:   mgr.GetScheme(),
+		Defaults: provisionServerDefaults,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackProvisionServer")
 		os.Exit(1)
@@ -300,38 +333,6 @@ func main() {
 	}
 
 	if enableWebhooks {
-		//
-		// DEFAULTS
-		//
-		openstackControlPlaneDefaults := ospdirectorv1beta1.OpenStackControlPlaneDefaults{
-			OpenStackRelease: os.Getenv("OPENSTACK_RELEASE_DEFAULT"),
-		}
-
-		openstackClientDefaults := ospdirectorv1beta1.OpenStackClientDefaults{
-			ImageURL: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
-		}
-
-		ephemeralHeatDefaults := ospdirectorv1beta1.OpenStackEphemeralHeatDefaults{
-			HeatAPIImageURL:    os.Getenv("HEAT_API_IMAGE_URL_DEFAULT"),
-			HeatEngineImageURL: os.Getenv("HEAT_ENGINE_IMAGE_URL_DEFAULT"),
-			MariaDBImageURL:    os.Getenv("MARIADB_IMAGE_URL_DEFAULT"),
-			RabbitImageURL:     os.Getenv("RABBITMQ_IMAGE_URL_DEFAULT"),
-		}
-
-		provisionServerDefaults := ospdirectorv1beta1.OpenStackProvisionServerDefaults{
-			DownloaderImageURL: os.Getenv("DOWNLOADER_IMAGE_URL_DEFAULT"),
-			AgentImageURL:      os.Getenv("AGENT_IMAGE_URL_DEFAULT"),
-			ApacheImageURL:     os.Getenv("APACHE_IMAGE_URL_DEFAULT"),
-		}
-
-		openstackDeployDefaults := ospdirectorv1beta1.OpenStackDeployDefaults{
-			AgentImageURL: os.Getenv("AGENT_IMAGE_URL_DEFAULT"),
-		}
-
-		openstackConfigGeneratorDefaults := ospdirectorv1beta1.OpenStackConfigGeneratorDefaults{
-			ImageURL: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
-		}
-
 		//
 		// Register webhooks
 		//


### PR DESCRIPTION
The provision server should always use the images specified in the
bundle CSV.
With the current approach of setting images in the spec and defaulting
in the webhook, users are likely to overlook updating the CRs after
updating the operator.
This could lead to mis-matched operator and agent images being used
together, or missing out on critial security fixes in the apache image.

This removes the images from the provision server spec completely and
ensures the correct images are always used in the Reconcile function.