### PR TITLE
Replicate 16.2 parameter merge behaviour

### DIFF
--- a/pkg/openstackconfiggenerator/volumes.go
+++ b/pkg/openstackconfiggenerator/volumes.go
@@ -47,6 +47,12 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []co
 			ReadOnly:  true,
 		},
 		{
+			Name:      "openstackconfig-scripts",
+			MountPath: "/home/cloud-admin/process-heat-environment.py",
+			SubPath:   "process-heat-environment.py",
+			ReadOnly:  true,
+		},
+		{
 			Name:      "git-ssh-config",
 			MountPath: "/mnt/ssh-config/git_id_rsa",
 			SubPath:   "git_id_rsa",
@@ -116,6 +122,10 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []corev1.
 						{
 							Key:  "create-playbooks.sh",
 							Path: "create-playbooks.sh",
+						},
+						{
+							Key:  "process-heat-environment.py",
+							Path: "process-heat-environment.py",
 						},
 					},
 				},

--- a/templates/openstackconfiggenerator/bin/process-heat-environment.py
+++ b/templates/openstackconfiggenerator/bin/process-heat-environment.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python3
+
+import argparse
+import collections
+import yaml
+
+
+def process_environment_file(filename):
+    with open(filename, 'r', encoding='utf-8') as orig:
+        original_data = orig.read()
+        original_env = yaml.safe_load(original_data)
+
+    if not isinstance(original_env, collections.abc.Mapping) or \
+            'parameter_defaults' not in original_env:
+        # Empty environment file or no parameter defaults? Do nothing
+        return
+
+    new_env = dict(original_env)
+    for key, val in new_env.get('parameter_defaults', {}).items():
+        if isinstance(val, collections.abc.Mapping):
+            new_env.setdefault(
+                'parameter_merge_strategies', {}
+            ).setdefault(key, 'merge')
+
+    if (new_env.get('parameter_merge_strategies') !=
+            original_env.get('parameter_merge_strategies')):
+        with open(filename, 'w', encoding='utf-8') as new:
+            new.write(yaml.dump(new_env, default_flow_style=False))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Process heat environment files to set merge strategy for '
+                    'all mapping parameters'
+    )
+    parser.add_argument(
+        '-e', '--environment',
+        metavar='<environment>',
+        action='append',
+        required=True,
+        help='Path to the environment. Can be specified multiple times'
+    )
+    args = parser.parse_args()
+    for f in args.environment:
+        process_environment_file(f)


### PR DESCRIPTION
In a regular OSP16 deployment, parameters are merged by heat-client if
they are a map type.
This does not happen automatically in OSP17 regular deployments and
Director operator (for both 16.x and 17.x) which use ephemeral heat.
The merge strategy must be set explicitly in each environment file.

To workaround this, and remain compatible with existing 16.x
environment files and 3rd party integrations, automatically inject the
merge strategy for all map type parameters if not explicitly set.