### PR TITLE
Change from CreateOrUpdate to CreateOrPatch and introduce ctx parameters

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/controllers/openstackbackup_controller.go
+++ b/controllers/openstackbackup_controller.go
@@ -67,7 +67,7 @@ func (r *OpenStackBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Fetch the instance
 	instance := &ospdirectorv1beta1.OpenStackBackup{}
-	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile
 			// request.  Owned objects are automatically garbage collected.  For

--- a/controllers/openstackbackuprequest_controller.go
+++ b/controllers/openstackbackuprequest_controller.go
@@ -240,7 +240,7 @@ func (r *OpenStackBackupRequestReconciler) saveBackup(
 				},
 			}
 
-			op, err := controllerutil.CreateOrUpdate(ctx, r.Client, backup, func() error {
+			op, err := controllerutil.CreateOrPatch(ctx, r.Client, backup, func() error {
 				backup.Spec.Crs = crLists
 				backup.Spec.ConfigMaps = cmList
 				backup.Spec.Secrets = secretList
@@ -517,7 +517,7 @@ func (r *OpenStackBackupRequestReconciler) ensureLoadBackup(
 }
 
 func (r *OpenStackBackupRequestReconciler) ensureLoadBackupResource(ctx context.Context, item client.Object) error {
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, item, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, item, func() error {
 		return nil
 	})
 

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -500,7 +500,7 @@ func (r *OpenStackBaremetalSetReconciler) provisionServerCreateOrUpdate(
 			},
 		}
 
-		op, err := controllerutil.CreateOrUpdate(ctx, r.Client, provisionServer, func() error {
+		op, err := controllerutil.CreateOrPatch(ctx, r.Client, provisionServer, func() error {
 			// Assign the prov server its existing port if this is an update, otherwise pick a new one
 			// based on what is available
 			err := provisionServer.AssignProvisionServerPort(

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -529,7 +529,7 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, pod, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, pod, func() error {
 		// Note: initialize the pod structs above then only reconcile individual fields here
 		// Can not add/replace new structs in the pod here as that will drop the defaults that
 		// are set/added when the pod is created.

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -80,7 +80,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Fetch the OpenStackClient instance
 	instance := &ospdirectorv1beta1.OpenStackClient{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -123,7 +123,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		)
 
 		if statusChanged() {
-			if updateErr := r.Client.Status().Update(context.Background(), instance); updateErr != nil {
+			if updateErr := r.Status().Update(context.Background(), instance); updateErr != nil {
 				common.LogErrorForObject(r, updateErr, "Update status", instance)
 			}
 		}
@@ -151,6 +151,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	var ctrlResult ctrl.Result
 	currentLabels := instance.DeepCopy().Labels
 	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(
+		ctx,
 		r,
 		instance,
 		cond,
@@ -172,7 +173,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		currentLabels,
 		instance.Labels,
 	) {
-		err = r.Client.Update(context.TODO(), instance)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonAddOSNetLabelError)
@@ -192,6 +193,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	//
 	if instance.Spec.DeploymentSSHSecret != "" {
 		_, ctrlResult, err = common.GetDataFromSecret(
+			ctx,
 			r,
 			instance,
 			cond,
@@ -215,6 +217,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	//
 	if instance.Spec.CAConfigMap != "" {
 		_, ctrlResult, err = common.GetConfigMap(
+			ctx,
 			r,
 			instance,
 			cond,
@@ -237,6 +240,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	//
 	if instance.Spec.IdmSecret != "" {
 		_, ctrlResult, err = common.GetDataFromSecret(
+			ctx,
 			r,
 			instance,
 			cond,
@@ -259,6 +263,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// create openstackclient IPs for all networks
 	//
 	ipsetStatus, ctrlResult, err := openstackipset.EnsureIPs(
+		ctx,
 		r,
 		instance,
 		cond,
@@ -284,6 +289,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// NetworkAttachmentDefinition
 	//
 	ctrlResult, err = r.verifyNetworkAttachments(
+		ctx,
 		instance,
 		cond,
 	)
@@ -306,7 +312,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			Labels:             labels,
 		},
 	}
-	err = common.EnsureConfigMaps(r, instance, cms, &envVars)
+	err = common.EnsureConfigMaps(ctx, r, instance, cms, &envVars)
 	if err != nil && k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -315,6 +321,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// PVCs
 	//
 	err = r.createPVCs(
+		ctx,
 		instance,
 		cond,
 		labels,
@@ -328,6 +335,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// Create or update the pod object
 		//
 		err = r.podCreateOrUpdate(
+			ctx,
 			instance,
 			cond,
 			hostname,
@@ -371,6 +379,7 @@ func (r *OpenStackClientReconciler) getNormalizedStatus(status *ospdirectorv1bet
 }
 
 func (r *OpenStackClientReconciler) podCreateOrUpdate(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackClient,
 	cond *ospdirectorv1beta1.Condition,
 	hostname string,
@@ -462,6 +471,7 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 
 		// get network with name_lower label
 		network, err := openstacknet.GetOpenStackNetWithLabel(
+			ctx,
 			r,
 			instance.Namespace,
 			labelSelector,
@@ -519,7 +529,7 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, pod, func() error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, pod, func() error {
 		// Note: initialize the pod structs above then only reconcile individual fields here
 		// Can not add/replace new structs in the pod here as that will drop the defaults that
 		// are set/added when the pod is created.
@@ -597,7 +607,7 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 				fmt.Sprintf("OpenStackClient pod deleted due to spec change %v", err),
 				instance,
 			)
-			if err := r.Client.Delete(context.TODO(), pod); err != nil && !k8s_errors.IsNotFound(err) {
+			if err := r.Delete(ctx, pod); err != nil && !k8s_errors.IsNotFound(err) {
 
 				// Error deleting the object
 				cond.Message = fmt.Sprintf("Error deleting OpenStackClient pod %s", pod.Name)
@@ -640,11 +650,12 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 // NetworkAttachmentDefinition, SriovNetwork and SriovNetworkNodePolicy
 //
 func (r *OpenStackClientReconciler) verifyNetworkAttachments(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackClient,
 	cond *ospdirectorv1beta1.Condition,
 ) (ctrl.Result, error) {
 	// verify that NetworkAttachmentDefinition for each configured network exist
-	nadMap, err := common.GetAllNetworkAttachmentDefinitions(r, instance)
+	nadMap, err := common.GetAllNetworkAttachmentDefinitions(ctx, r, instance)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -654,6 +665,7 @@ func (r *OpenStackClientReconciler) verifyNetworkAttachments(
 
 		// get network with name_lower label
 		network, err := openstacknet.GetOpenStackNetWithLabel(
+			ctx,
 			r,
 			instance.Namespace,
 			map[string]string{
@@ -699,6 +711,7 @@ func (r *OpenStackClientReconciler) verifyNetworkAttachments(
 // PVCs
 //
 func (r *OpenStackClientReconciler) createPVCs(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackClient,
 	cond *ospdirectorv1beta1.Condition,
 	labels map[string]string,
@@ -715,7 +728,7 @@ func (r *OpenStackClientReconciler) createPVCs(
 		},
 	}
 
-	pvc, op, err := common.CreateOrUpdatePvc(r, instance, &pvcDetails)
+	pvc, op, err := common.CreateOrUpdatePvc(ctx, r, instance, &pvcDetails)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update pvc %s ", pvc.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.OsClientCondReasonPVCError)
@@ -743,7 +756,7 @@ func (r *OpenStackClientReconciler) createPVCs(
 		},
 	}
 
-	pvc, op, err = common.CreateOrUpdatePvc(r, instance, &pvcDetails)
+	pvc, op, err = common.CreateOrUpdatePvc(ctx, r, instance, &pvcDetails)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update pvc %s ", pvc.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.OsClientCondReasonPVCError)
@@ -771,7 +784,7 @@ func (r *OpenStackClientReconciler) createPVCs(
 		},
 	}
 
-	pvc, op, err = common.CreateOrUpdatePvc(r, instance, &pvcDetails)
+	pvc, op, err = common.CreateOrUpdatePvc(ctx, r, instance, &pvcDetails)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update pvc %s ", pvc.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.OsClientCondReasonPVCError)

--- a/controllers/openstackconfiggenerator_controller.go
+++ b/controllers/openstackconfiggenerator_controller.go
@@ -95,7 +95,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 	// Fetch the instance
 	instance := &ospdirectorv1beta1.OpenStackConfigGenerator{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -149,7 +149,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 		)
 
 		if statusChanged() {
-			if updateErr := r.Client.Status().Update(context.Background(), instance); updateErr != nil {
+			if updateErr := r.Status().Update(context.Background(), instance); updateErr != nil {
 				common.LogErrorForObject(r, updateErr, "Update status", instance)
 			}
 		}
@@ -167,7 +167,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	//
 	// unified OSPVersion from ControlPlane CR
 	// which means also get either 16.2 or 17.0 for upstream versions
-	controlPlane, ctrlResult, err := common.GetControlPlane(r, instance)
+	controlPlane, ctrlResult, err := common.GetControlPlane(ctx, r, instance)
 	if err != nil {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ControlPlaneReasonNetNotFound)
@@ -207,7 +207,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	//
 	// check if heat-env-config (customizations provided by administrator) exist if it does not exist, requeue
 	//
-	tripleoCustomDeployCM, _, err := common.GetConfigMapAndHashWithName(r, instance.Spec.HeatEnvConfigMap, instance.Namespace)
+	tripleoCustomDeployCM, _, err := common.GetConfigMapAndHashWithName(ctx, r, instance.Spec.HeatEnvConfigMap, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			cond.Message = fmt.Sprintf("The ConfigMap %s doesn't yet exist. Requeing...", instance.Spec.HeatEnvConfigMap)
@@ -222,7 +222,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// add ConfigGeneratorInputLabel if required
-	err = r.addConfigGeneratorInputLabel(instance, cond, tripleoCustomDeployCM)
+	err = r.addConfigGeneratorInputLabel(ctx, instance, cond, tripleoCustomDeployCM)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -235,7 +235,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	//
 	var tripleoTarballCM *corev1.ConfigMap
 	if instance.Spec.TarballConfigMap != "" {
-		tripleoTarballCM, _, err = common.GetConfigMapAndHashWithName(r, instance.Spec.TarballConfigMap, instance.Namespace)
+		tripleoTarballCM, _, err = common.GetConfigMapAndHashWithName(ctx, r, instance.Spec.TarballConfigMap, instance.Namespace)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				cond.Message = "Tarball config map not found, requeuing and waiting. Requeing..."
@@ -253,7 +253,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// add ConfigGeneratorInputLabel if required
-	err = r.addConfigGeneratorInputLabel(instance, cond, tripleoTarballCM)
+	err = r.addConfigGeneratorInputLabel(ctx, instance, cond, tripleoTarballCM)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -272,6 +272,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	// render OOO environment, create TripleoDeployCM and read the tripleo-deploy-config CM
 	//
 	tripleoDeployCM, err := r.createTripleoDeployCM(
+		ctx,
 		instance,
 		cond,
 		&envVars,
@@ -313,7 +314,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			Labels:             cmLabels,
 		},
 	}
-	err = common.EnsureConfigMaps(r, instance, cms, &envVars)
+	err = common.EnsureConfigMaps(ctx, r, instance, cms, &envVars)
 	if err != nil {
 		cond.Message = fmt.Sprintf("%s config map not found, requeuing and waiting. Requeing...", "openstackconfig-script-"+instance.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMNotFound)
@@ -369,7 +370,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 	var exports string
 	if instance.Status.ConfigHash != configMapHash {
-		op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, heat, func() error {
+		op, err := controllerutil.CreateOrUpdate(ctx, r.Client, heat, func() error {
 			err := controllerutil.SetControllerReference(instance, heat, r.Scheme)
 			if err != nil {
 				return err
@@ -401,7 +402,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 		// configMap Hash changed after Ephemeral Heat was created
 		if heat.Spec.ConfigHash != configMapHash {
-			err = r.Client.Delete(context.TODO(), heat)
+			err = r.Delete(ctx, heat)
 			if err != nil && !k8s_errors.IsNotFound(err) {
 				cond.Message = err.Error()
 				cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMHashChanged)
@@ -420,7 +421,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 		}
 
 		// check if osvmset and osbms is in status provisioned
-		msg, deployed, err := r.verifyNodeResourceStatus(instance)
+		msg, deployed, err := r.verifyNodeResourceStatus(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -433,7 +434,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			return ctrl.Result{RequeueAfter: time.Second * 20}, err
 		}
 
-		op, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, job, func() error {
+		op, err = controllerutil.CreateOrUpdate(ctx, r.Client, job, func() error {
 			err := controllerutil.SetControllerReference(instance, job, r.Scheme)
 			if err != nil {
 				return err
@@ -458,7 +459,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 		common.LogForObject(r, fmt.Sprintf("ConfigMap Hash : %s", configMapHash), instance)
 
 		if configMapHash != job.Spec.Template.Spec.Containers[0].Env[0].Value {
-			_, err = common.DeleteJob(job, r.Kclient, r.Log)
+			_, err = common.DeleteJob(ctx, job, r.Kclient, r.Log)
 			if err != nil {
 				cond.Message = err.Error()
 				cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonJobDelete)
@@ -470,7 +471,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 			// in this case delete heat too as the database may have been used
 			r.Log.Info("Deleting Ephemeral Heat...")
-			err = r.Client.Delete(context.TODO(), heat)
+			err = r.Delete(ctx, heat)
 			if err != nil && !k8s_errors.IsNotFound(err) {
 				cond.Message = err.Error()
 				cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatDelete)
@@ -489,7 +490,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 		}
 
-		requeue, err := common.WaitOnJob(job, r.Client, r.Log)
+		requeue, err := common.WaitOnJob(ctx, job, r.Client, r.Log)
 		common.LogForObject(r, "Generating Configs...", instance)
 
 		if err != nil {
@@ -523,7 +524,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 	r.setConfigHash(instance, configMapHash)
 
-	_, err = common.DeleteJob(job, r.Kclient, r.Log)
+	_, err = common.DeleteJob(ctx, job, r.Kclient, r.Log)
 	if err != nil {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonJobDelete)
@@ -534,7 +535,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// cleanup the ephemeral Heat
-	err = r.Client.Delete(context.TODO(), heat)
+	err = r.Delete(ctx, heat)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonEphemeralHeatDelete)
@@ -545,13 +546,13 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// update ConfigVersions with Git Commits
-	configVersions, gerr := openstackconfigversion.SyncGit(instance, r.Client, r.Log)
+	configVersions, gerr := openstackconfigversion.SyncGit(ctx, instance, r.Client, r.Log)
 	if gerr != nil {
 		r.Log.Error(gerr, "ConfigVersions")
 		return ctrl.Result{}, gerr
 	}
 
-	if err := r.syncConfigVersions(instance, configVersions, exports); err != nil {
+	if err := r.syncConfigVersions(ctx, instance, configVersions, exports); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -584,20 +585,25 @@ func (r *OpenStackConfigGeneratorReconciler) getNormalizedStatus(status *ospdire
 	return s
 }
 
-func (r *OpenStackConfigGeneratorReconciler) syncConfigVersions(instance *ospdirectorv1beta1.OpenStackConfigGenerator, configVersions map[string]ospdirectorv1beta1.OpenStackConfigVersion, exports string) error {
+func (r *OpenStackConfigGeneratorReconciler) syncConfigVersions(
+	ctx context.Context,
+	instance *ospdirectorv1beta1.OpenStackConfigGenerator,
+	configVersions map[string]ospdirectorv1beta1.OpenStackConfigVersion,
+	exports string,
+) error {
 
 	for _, version := range configVersions {
 
 		// Check if this ConfigVersion already exists
 		foundVersion := &ospdirectorv1beta1.OpenStackConfigVersion{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: version.Name, Namespace: instance.Namespace}, foundVersion)
+		err := r.Get(ctx, types.NamespacedName{Name: version.Name, Namespace: instance.Namespace}, foundVersion)
 		if err == nil {
 			//FIXME(dprince): update existing?
 		} else if err != nil && k8s_errors.IsNotFound(err) {
 			// we only add the most recent export to new ConfigVersions (just created...)
 			version.Spec.CtlplaneExports = exports
 			r.Log.Info("Creating a ConfigVersion", "ConfigVersion.Namespace", instance.Namespace, "ConfigVersion.Name", version.Name)
-			err = r.Client.Create(context.TODO(), &version)
+			err = r.Create(ctx, &version)
 			if err != nil {
 				return err
 			}
@@ -644,7 +650,10 @@ func (r *OpenStackConfigGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) 
 		Complete(r)
 }
 
-func (r *OpenStackConfigGeneratorReconciler) verifyNodeResourceStatus(instance *ospdirectorv1beta1.OpenStackConfigGenerator) (string, bool, error) {
+func (r *OpenStackConfigGeneratorReconciler) verifyNodeResourceStatus(
+	ctx context.Context,
+	instance *ospdirectorv1beta1.OpenStackConfigGenerator,
+) (string, bool, error) {
 
 	msg := ""
 
@@ -652,7 +661,7 @@ func (r *OpenStackConfigGeneratorReconciler) verifyNodeResourceStatus(instance *
 	vmsetList := &ospdirectorv1beta1.OpenStackVMSetList{}
 
 	listOpts := []client.ListOption{}
-	err := r.Client.List(context.TODO(), vmsetList, listOpts...)
+	err := r.List(ctx, vmsetList, listOpts...)
 	if err != nil {
 		return msg, false, err
 	}
@@ -668,7 +677,7 @@ func (r *OpenStackConfigGeneratorReconciler) verifyNodeResourceStatus(instance *
 	bmsetList := &ospdirectorv1beta1.OpenStackBaremetalSetList{}
 
 	listOpts = []client.ListOption{}
-	err = r.Client.List(context.TODO(), bmsetList, listOpts...)
+	err = r.List(ctx, bmsetList, listOpts...)
 	if err != nil {
 		return msg, false, err
 	}
@@ -691,6 +700,7 @@ func (r *OpenStackConfigGeneratorReconciler) verifyNodeResourceStatus(instance *
 // Fencing considerations
 //
 func (r *OpenStackConfigGeneratorReconciler) createFencingEnvironmentFiles(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackConfigGenerator,
 	cond *ospdirectorv1beta1.Condition,
 	controlPlane *ospdirectorv1beta1.OpenStackControlPlane,
@@ -729,7 +739,7 @@ func (r *OpenStackConfigGeneratorReconciler) createFencingEnvironmentFiles(
 		for roleName, roleParams := range controlPlane.Spec.VirtualMachineRoles {
 			if common.StringInSlice(roleParams.RoleName, fencingRoles) && roleParams.RoleCount == 3 {
 				// Get the associated VM instances
-				virtualMachineInstanceList, err := common.GetVirtualMachineInstances(r, instance.Namespace, map[string]string{
+				virtualMachineInstanceList, err := common.GetVirtualMachineInstances(ctx, r, instance.Namespace, map[string]string{
 					common.OwnerNameLabelSelector: strings.ToLower(roleName),
 				})
 				if err != nil {
@@ -786,6 +796,7 @@ func (r *OpenStackConfigGeneratorReconciler) createFencingEnvironmentFiles(
 // generate TripleoDeploy configmap with environment file containing predictible IPs
 //
 func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackConfigGenerator,
 	cond *ospdirectorv1beta1.Condition,
 	envVars *map[string]common.EnvSetter,
@@ -797,7 +808,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 	//
 	// generate OOO environment file with predictible IPs
 	//
-	templateParameters, rolesMap, err := openstackconfiggenerator.CreateConfigMapParams(r, instance, cond)
+	templateParameters, rolesMap, err := openstackconfiggenerator.CreateConfigMapParams(ctx, r, instance, cond)
 	if err != nil {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonRenderEnvFilesError)
@@ -811,6 +822,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 	// get clusterServiceIP for fencing routing in the nic templates
 	//
 	clusterServiceIP, err := r.getClusterServiceEndpoint(
+		ctx,
 		instance,
 		cond,
 		"default",
@@ -846,6 +858,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 	// Render fencing template
 	//
 	fencingTemplate, err := r.createFencingEnvironmentFiles(
+		ctx,
 		instance,
 		cond,
 		controlPlane,
@@ -876,7 +889,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 		},
 	}
 
-	err = common.EnsureConfigMaps(r, instance, cm, envVars)
+	err = common.EnsureConfigMaps(ctx, r, instance, cm, envVars)
 	if err != nil {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMCreateError)
@@ -889,7 +902,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 	//
 	// Read the tripleo-deploy-config CM
 	//
-	tripleoDeployCM, _, err := common.GetConfigMapAndHashWithName(r, "tripleo-deploy-config-"+instance.Name, instance.Namespace)
+	tripleoDeployCM, _, err := common.GetConfigMapAndHashWithName(ctx, r, "tripleo-deploy-config-"+instance.Name, instance.Namespace)
 	if err != nil {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ConfigGeneratorCondReasonCMCreateError)
@@ -903,13 +916,14 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 }
 
 func (r *OpenStackConfigGeneratorReconciler) getClusterServiceEndpoint(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackConfigGenerator,
 	cond *ospdirectorv1beta1.Condition,
 	namespace string,
 	labelSelector map[string]string,
 ) (string, error) {
 
-	serviceList, err := common.GetServicesListWithLabel(r, namespace, labelSelector)
+	serviceList, err := common.GetServicesListWithLabel(ctx, r, namespace, labelSelector)
 	if err != nil {
 		cond.Message = err.Error()
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonServiceNotFound)
@@ -994,6 +1008,7 @@ func (r *OpenStackConfigGeneratorReconciler) createVMRoleNicTemplates(
 // the CMs to watch
 //
 func (r *OpenStackConfigGeneratorReconciler) addConfigGeneratorInputLabel(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackConfigGenerator,
 	cond *ospdirectorv1beta1.Condition,
 	cm *corev1.ConfigMap,
@@ -1004,7 +1019,7 @@ func (r *OpenStackConfigGeneratorReconciler) addConfigGeneratorInputLabel(
 	}
 
 	if _, ok := cm.Labels[openstackconfiggenerator.ConfigGeneratorInputLabel]; !ok {
-		op, err := controllerutil.CreateOrUpdate(context.TODO(), r.GetClient(), cm, func() error {
+		op, err := controllerutil.CreateOrUpdate(ctx, r.GetClient(), cm, func() error {
 			cm.SetLabels(labels.Merge(cm.GetLabels(), labelSelector))
 
 			return nil

--- a/controllers/openstackconfiggenerator_controller.go
+++ b/controllers/openstackconfiggenerator_controller.go
@@ -370,7 +370,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 
 	var exports string
 	if instance.Status.ConfigHash != configMapHash {
-		op, err := controllerutil.CreateOrUpdate(ctx, r.Client, heat, func() error {
+		op, err := controllerutil.CreateOrPatch(ctx, r.Client, heat, func() error {
 			err := controllerutil.SetControllerReference(instance, heat, r.Scheme)
 			if err != nil {
 				return err
@@ -434,7 +434,7 @@ func (r *OpenStackConfigGeneratorReconciler) Reconcile(ctx context.Context, req 
 			return ctrl.Result{RequeueAfter: time.Second * 20}, err
 		}
 
-		op, err = controllerutil.CreateOrUpdate(ctx, r.Client, job, func() error {
+		op, err = controllerutil.CreateOrPatch(ctx, r.Client, job, func() error {
 			err := controllerutil.SetControllerReference(instance, job, r.Scheme)
 			if err != nil {
 				return err
@@ -1019,7 +1019,7 @@ func (r *OpenStackConfigGeneratorReconciler) addConfigGeneratorInputLabel(
 	}
 
 	if _, ok := cm.Labels[openstackconfiggenerator.ConfigGeneratorInputLabel]; !ok {
-		op, err := controllerutil.CreateOrUpdate(ctx, r.GetClient(), cm, func() error {
+		op, err := controllerutil.CreateOrPatch(ctx, r.GetClient(), cm, func() error {
 			cm.SetLabels(labels.Merge(cm.GetLabels(), labelSelector))
 
 			return nil

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -91,7 +91,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Fetch the controlplane instance
 	instance := &ospdirectorv1beta1.OpenStackControlPlane{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -154,7 +154,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 		instance.Status.ProvisioningStatus.State = ospdirectorv1beta1.ProvisioningState(cond.Type)
 
 		if statusChanged() {
-			if updateErr := r.Client.Status().Update(context.Background(), instance); updateErr != nil {
+			if updateErr := r.Status().Update(context.Background(), instance); updateErr != nil {
 				common.LogErrorForObject(r, updateErr, "Update status", instance)
 			}
 		}
@@ -188,7 +188,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	//
 	// create or get hash of "tripleo-passwords" controlplane.TripleoPasswordSecret secret
 	//
-	err = r.createOrGetTripleoPasswords(instance, cond, &envVars)
+	err = r.createOrGetTripleoPasswords(ctx, instance, cond, &envVars)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -197,7 +197,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	// Secret - used for deployment to ssh into the overcloud nodes,
 	//          gets added to the controller VMs cloud-admin user using cloud-init
 	//
-	deploymentSecret, err := r.createOrGetDeploymentSecret(instance, cond, &envVars)
+	deploymentSecret, err := r.createOrGetDeploymentSecret(ctx, instance, cond, &envVars)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -205,7 +205,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	//
 	// check if specified PasswordSecret secret exists
 	//
-	ctrlResult, err := r.verifySecretExist(instance, cond, instance.Spec.PasswordSecret)
+	ctrlResult, err := r.verifySecretExist(ctx, instance, cond, instance.Spec.PasswordSecret)
 	if (err != nil) || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -213,7 +213,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	//
 	// check if specified IdmSecret secret exists
 	//
-	ctrlResult, err = r.verifySecretExist(instance, cond, instance.Spec.IdmSecret)
+	ctrlResult, err = r.verifySecretExist(ctx, instance, cond, instance.Spec.IdmSecret)
 	if (err != nil) || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -221,7 +221,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	//
 	// check if specified CAConfigMap config map exists
 	//
-	ctrlResult, err = r.verifyConfigMapExist(instance, cond, instance.Spec.CAConfigMap)
+	ctrlResult, err = r.verifyConfigMapExist(ctx, instance, cond, instance.Spec.CAConfigMap)
 	if (err != nil) || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -230,7 +230,11 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	// create VIPs for networks where VIP parameter is true
 	// AND the service VIPs for Spec.AdditionalServiceVIPs
 	//
-	ctrlResult, err = r.ensureVIPs(instance, cond)
+	ctrlResult, err = r.ensureVIPs(
+		ctx,
+		instance,
+		cond,
+	)
 	if (err != nil) || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -239,6 +243,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	// Create VMSets
 	//
 	vmSets, err := r.createOrUpdateVMSets(
+		ctx,
 		instance,
 		cond,
 		deploymentSecret,
@@ -255,6 +260,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	// Create openstack client pod
 	//
 	osc, err := r.createOrUpdateOpenStackClient(
+		ctx,
 		instance,
 		cond,
 		deploymentSecret,
@@ -269,7 +275,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 	//var ctlPlaneState ospdirectorv1beta1.ControlPlaneProvisioningState
 
 	// 1) OpenStackClient pod status
-	clientPod, err := r.Kclient.CoreV1().Pods(instance.Namespace).Get(context.TODO(), osc.Name, metav1.GetOptions{})
+	clientPod, err := r.Kclient.CoreV1().Pods(instance.Namespace).Get(ctx, osc.Name, metav1.GetOptions{})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			timeout := 30
@@ -360,7 +366,7 @@ func (r *OpenStackControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) err
 			listOpts := []client.ListOption{
 				client.InNamespace(obj.GetNamespace()),
 			}
-			if err := r.Client.List(context.Background(), crs, listOpts...); err != nil {
+			if err := r.List(context.Background(), crs, listOpts...); err != nil {
 				r.Log.Error(err, "Unable to retrieve CRs %v")
 				return nil
 			}
@@ -407,6 +413,7 @@ func (r *OpenStackControlPlaneReconciler) getNormalizedStatus(status *ospdirecto
 }
 
 func (r *OpenStackControlPlaneReconciler) createVIPNetworkList(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 ) ([]string, error) {
@@ -424,6 +431,7 @@ func (r *OpenStackControlPlaneReconciler) createVIPNetworkList(
 
 			// get network with name_lower label to verify if VIP needs to be requested from Spec
 			network, err := openstacknet.GetOpenStackNetWithLabel(
+				ctx,
 				r,
 				instance.Namespace,
 				labelSelector,
@@ -457,6 +465,7 @@ func (r *OpenStackControlPlaneReconciler) createVIPNetworkList(
 // create or get hash of "tripleo-passwords" controlplane.TripleoPasswordSecret secret
 //
 func (r *OpenStackControlPlaneReconciler) createOrGetTripleoPasswords(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 	envVars *map[string]common.EnvSetter,
@@ -464,7 +473,7 @@ func (r *OpenStackControlPlaneReconciler) createOrGetTripleoPasswords(
 	//
 	// check if "tripleo-passwords" controlplane.TripleoPasswordSecret secret already exist
 	//
-	_, secretHash, err := common.GetSecret(r, controlplane.TripleoPasswordSecret, instance.Namespace)
+	_, secretHash, err := common.GetSecret(ctx, r, controlplane.TripleoPasswordSecret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 
@@ -490,7 +499,7 @@ func (r *OpenStackControlPlaneReconciler) createOrGetTripleoPasswords(
 				},
 			}
 
-			err = common.EnsureSecrets(r, instance, pwSecret, envVars)
+			err = common.EnsureSecrets(ctx, r, instance, pwSecret, envVars)
 			if err != nil {
 				cond.Message = fmt.Sprintf("Error creating TripleoPasswordsSecret %s", controlplane.TripleoPasswordSecret)
 				cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ControlPlaneReasonTripleoPasswordsSecretCreateError)
@@ -519,13 +528,14 @@ func (r *OpenStackControlPlaneReconciler) createOrGetTripleoPasswords(
 //          gets added to the controller VMs cloud-admin user using cloud-init
 //
 func (r *OpenStackControlPlaneReconciler) createOrGetDeploymentSecret(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 	envVars *map[string]common.EnvSetter,
 ) (*corev1.Secret, error) {
 	deploymentSecretName := strings.ToLower(controlplane.AppLabel) + "-ssh-keys"
 
-	deploymentSecret, secretHash, err := common.GetSecret(r, deploymentSecretName, instance.Namespace)
+	deploymentSecret, secretHash, err := common.GetSecret(ctx, r, deploymentSecretName, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 
@@ -551,7 +561,7 @@ func (r *OpenStackControlPlaneReconciler) createOrGetDeploymentSecret(
 				return deploymentSecret, err
 			}
 
-			secretHash, op, err = common.CreateOrUpdateSecret(r, instance, deploymentSecret)
+			secretHash, op, err = common.CreateOrUpdateSecret(ctx, r, instance, deploymentSecret)
 			if err != nil {
 				cond.Message = fmt.Sprintf("Error create or update ssh keys secret %s", deploymentSecretName)
 				cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.ControlPlaneReasonDeploymentSSHKeysSecretCreateOrUpdateError)
@@ -582,13 +592,14 @@ func (r *OpenStackControlPlaneReconciler) createOrGetDeploymentSecret(
 }
 
 func (r *OpenStackControlPlaneReconciler) verifySecretExist(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 	secretName string,
 ) (ctrl.Result, error) {
 	if secretName != "" {
 		// check if specified secret exists before creating the controlplane
-		_, _, err := common.GetSecret(r, secretName, instance.Namespace)
+		_, _, err := common.GetSecret(ctx, r, secretName, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
 				timeout := 30
@@ -619,13 +630,14 @@ func (r *OpenStackControlPlaneReconciler) verifySecretExist(
 }
 
 func (r *OpenStackControlPlaneReconciler) verifyConfigMapExist(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 	configMapName string,
 ) (ctrl.Result, error) {
 
 	if configMapName != "" {
-		_, _, err := common.GetConfigMapAndHashWithName(r, instance.Spec.CAConfigMap, instance.Namespace)
+		_, _, err := common.GetConfigMapAndHashWithName(ctx, r, instance.Spec.CAConfigMap, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
 				timeout := 30
@@ -658,6 +670,7 @@ func (r *OpenStackControlPlaneReconciler) verifyConfigMapExist(
 // Create VMSets
 //
 func (r *OpenStackControlPlaneReconciler) createOrUpdateVMSets(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 	deploymentSecret *corev1.Secret,
@@ -677,7 +690,7 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateVMSets(
 			},
 		}
 
-		op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, vmSet, func() error {
+		op, err := controllerutil.CreateOrUpdate(ctx, r.Client, vmSet, func() error {
 			vmSet.Spec.VMCount = vmRole.RoleCount
 			vmSet.Spec.Cores = vmRole.Cores
 			vmSet.Spec.Memory = vmRole.Memory
@@ -744,6 +757,7 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateVMSets(
 }
 
 func (r *OpenStackControlPlaneReconciler) createOrUpdateOpenStackClient(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 	deploymentSecret *corev1.Secret,
@@ -754,7 +768,7 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateOpenStackClient(
 			Namespace: instance.Namespace,
 		},
 	}
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, osc, func() error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, osc, func() error {
 		if instance.Spec.OpenStackClientImageURL != "" {
 			osc.Spec.ImageURL = instance.Spec.OpenStackClientImageURL
 		}
@@ -817,6 +831,7 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateOpenStackClient(
 }
 
 func (r *OpenStackControlPlaneReconciler) ensureVIPs(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackControlPlane,
 	cond *ospdirectorv1beta1.Condition,
 ) (ctrl.Result, error) {
@@ -825,7 +840,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 	//
 
 	// create list of networks where Spec.VIP == True
-	vipNetworksList, err := r.createVIPNetworkList(instance, cond)
+	vipNetworksList, err := r.createVIPNetworkList(ctx, instance, cond)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -836,7 +851,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 	// add osnetcfg CR label reference which is used in the in the osnetcfg
 	// controller to watch this resource and reconcile
 	//
-	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(r, instance, cond, vipNetworksList[0])
+	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(ctx, r, instance, cond, vipNetworksList[0])
 	if (err != nil) || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
 	}
@@ -856,7 +871,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 		currentLabels,
 		instance.Labels,
 	) {
-		err = r.Client.Update(context.TODO(), instance)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonAddOSNetLabelError)
@@ -872,6 +887,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 	// create controlplane VIPs for all networks which has VIP flag
 	//
 	ipsetStatus, ctrlResult, err := openstackipset.EnsureIPs(
+		ctx,
 		r,
 		instance,
 		cond,
@@ -899,6 +915,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 	if instance.Status.OSPVersion == ospdirectorv1beta1.OSPVersion(ospdirectorv1beta1.TemplateVersion17_0) {
 		for service, network := range instance.Spec.AdditionalServiceVIPs {
 			ipsetStatus, ctrlResult, err := openstackipset.EnsureIPs(
+				ctx,
 				r,
 				instance,
 				cond,

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -690,7 +690,7 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateVMSets(
 			},
 		}
 
-		op, err := controllerutil.CreateOrUpdate(ctx, r.Client, vmSet, func() error {
+		op, err := controllerutil.CreateOrPatch(ctx, r.Client, vmSet, func() error {
 			vmSet.Spec.VMCount = vmRole.RoleCount
 			vmSet.Spec.Cores = vmRole.Cores
 			vmSet.Spec.Memory = vmRole.Memory
@@ -768,7 +768,7 @@ func (r *OpenStackControlPlaneReconciler) createOrUpdateOpenStackClient(
 			Namespace: instance.Namespace,
 		},
 	}
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, osc, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, osc, func() error {
 		if instance.Spec.OpenStackClientImageURL != "" {
 			osc.Spec.ImageURL = instance.Spec.OpenStackClientImageURL
 		}

--- a/controllers/openstackdeploy_controller.go
+++ b/controllers/openstackdeploy_controller.go
@@ -163,7 +163,7 @@ func (r *OpenStackDeployReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			ansibleSettings,
 		)
 
-		op, err := controllerutil.CreateOrUpdate(ctx, r.Client, job, func() error {
+		op, err := controllerutil.CreateOrPatch(ctx, r.Client, job, func() error {
 			err := controllerutil.SetControllerReference(instance, job, r.Scheme)
 			if err != nil {
 

--- a/controllers/openstackephemeralheat_controller.go
+++ b/controllers/openstackephemeralheat_controller.go
@@ -336,7 +336,7 @@ func (r *OpenStackEphemeralHeatReconciler) ensureMariaDB(
 	// MariaDB Pod
 	mariadbPod := openstackephemeralheat.MariadbPod(instance)
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, mariadbPod, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, mariadbPod, func() error {
 		err := controllerutil.SetControllerReference(instance, mariadbPod, r.Scheme)
 		if err != nil {
 			return err
@@ -372,7 +372,7 @@ func (r *OpenStackEphemeralHeatReconciler) ensureMariaDB(
 	// MariaDB Service
 	mariadbService := openstackephemeralheat.MariadbService(instance, r.Scheme)
 
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, mariadbService, func() error {
+	op, err = controllerutil.CreateOrPatch(ctx, r.Client, mariadbService, func() error {
 		err := controllerutil.SetControllerReference(instance, mariadbService, r.Scheme)
 		if err != nil {
 			return err
@@ -408,7 +408,7 @@ func (r *OpenStackEphemeralHeatReconciler) ensureRabbitMQ(
 	// RabbitMQ Pod
 	rabbitmqPod := openstackephemeralheat.RabbitmqPod(instance)
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, rabbitmqPod, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, rabbitmqPod, func() error {
 		err := controllerutil.SetControllerReference(instance, rabbitmqPod, r.Scheme)
 		if err != nil {
 			return err
@@ -444,7 +444,7 @@ func (r *OpenStackEphemeralHeatReconciler) ensureRabbitMQ(
 	// RabbitMQ Service
 	rabbitmqService := openstackephemeralheat.RabbitmqService(instance, r.Scheme)
 
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, rabbitmqService, func() error {
+	op, err = controllerutil.CreateOrPatch(ctx, r.Client, rabbitmqService, func() error {
 		err := controllerutil.SetControllerReference(instance, rabbitmqService, r.Scheme)
 		if err != nil {
 			return err
@@ -480,7 +480,7 @@ func (r *OpenStackEphemeralHeatReconciler) ensureHeat(
 	// Heat Pod
 	heatPod := openstackephemeralheat.HeatAPIPod(instance)
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, heatPod, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, heatPod, func() error {
 		err := controllerutil.SetControllerReference(instance, heatPod, r.Scheme)
 		if err != nil {
 			return err
@@ -516,7 +516,7 @@ func (r *OpenStackEphemeralHeatReconciler) ensureHeat(
 	// Heat Service
 	heatService := openstackephemeralheat.HeatAPIService(instance, r.Scheme)
 
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, heatService, func() error {
+	op, err = controllerutil.CreateOrPatch(ctx, r.Client, heatService, func() error {
 		err := controllerutil.SetControllerReference(instance, heatService, r.Scheme)
 		if err != nil {
 			return err
@@ -544,7 +544,7 @@ func (r *OpenStackEphemeralHeatReconciler) ensureHeat(
 	// Heat Engine Replicaset
 	heatEngineReplicaset := openstackephemeralheat.HeatEngineReplicaSet(instance)
 
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, heatEngineReplicaset, func() error {
+	op, err = controllerutil.CreateOrPatch(ctx, r.Client, heatEngineReplicaset, func() error {
 		err := controllerutil.SetControllerReference(instance, heatEngineReplicaset, r.Scheme)
 		if err != nil {
 			return err

--- a/controllers/openstacknet_controller.go
+++ b/controllers/openstacknet_controller.go
@@ -350,7 +350,7 @@ func (r *OpenStackNetReconciler) createOrUpdateNetworkAttachmentDefinition(
 		return controllerutil.SetControllerReference(instance, networkAttachmentDefinition, r.Scheme)
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, networkAttachmentDefinition, apply)
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, networkAttachmentDefinition, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Updating %s networkAttachmentDefinition", instance.Name)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetError)

--- a/controllers/openstacknetattachment_controller.go
+++ b/controllers/openstacknetattachment_controller.go
@@ -343,7 +343,7 @@ func (r *OpenStackNetAttachmentReconciler) createOrUpdateNodeNetworkConfiguratio
 		return nil
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, networkConfigurationPolicy, apply)
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, networkConfigurationPolicy, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Updating %s networkConfigurationPolicy", bridgeName)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetAttachError)
@@ -475,7 +475,7 @@ func (r *OpenStackNetAttachmentReconciler) cleanupNodeNetworkConfigurationPolicy
 		//
 		// 1) Update nncp desired state to down to unconfigure the device on the worker nodes
 		//
-		op, err := controllerutil.CreateOrUpdate(ctx, r.Client, networkConfigurationPolicy, apply)
+		op, err := controllerutil.CreateOrPatch(ctx, r.Client, networkConfigurationPolicy, apply)
 		if err != nil {
 			cond.Message = fmt.Sprintf("Updating %s networkConfigurationPolicy", instance.Status.BridgeName)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(cond.Message)
@@ -548,7 +548,7 @@ func (r *OpenStackNetAttachmentReconciler) ensureSriov(
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, sriovNet, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, sriovNet, func() error {
 		sriovNet.Labels = common.GetLabels(instance, openstacknetattachment.AppLabel, map[string]string{})
 		sriovNet.Spec = sriovnetworkv1.SriovNetworkSpec{
 			SpoofChk:         instance.Spec.AttachConfiguration.NodeSriovConfigurationPolicy.DesiredState.SpoofCheck,
@@ -580,7 +580,7 @@ func (r *OpenStackNetAttachmentReconciler) ensureSriov(
 		sriovPolicy.Spec.NicSelector.RootDevices = []string{instance.Spec.AttachConfiguration.NodeSriovConfigurationPolicy.DesiredState.RootDevice}
 	}
 
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, sriovPolicy, func() error {
+	op, err = controllerutil.CreateOrPatch(ctx, r.Client, sriovPolicy, func() error {
 		sriovPolicy.Labels = common.GetLabels(instance, openstacknet.AppLabel, map[string]string{})
 		sriovPolicy.Spec = sriovnetworkv1.SriovNetworkNodePolicySpec{
 			DeviceType: instance.Spec.AttachConfiguration.NodeSriovConfigurationPolicy.DesiredState.DeviceType,

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -90,7 +90,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Fetch the OpenStackNetConfig instance
 	instance := &ospdirectorv1beta1.OpenStackNetConfig{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -134,7 +134,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		)
 
 		if statusChanged() {
-			if updateErr := r.Client.Status().Update(context.Background(), instance); updateErr != nil {
+			if updateErr := r.Status().Update(context.Background(), instance); updateErr != nil {
 				common.LogErrorForObject(r, updateErr, "Update status", instance)
 			}
 		}
@@ -150,7 +150,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// registering our finalizer.
 		if !controllerutil.ContainsFinalizer(instance, openstacknetconfig.FinalizerName) {
 			controllerutil.AddFinalizer(instance, openstacknetconfig.FinalizerName)
-			if err := r.Update(context.Background(), instance); err != nil {
+			if err := r.Update(ctx, instance); err != nil {
 				return ctrl.Result{}, err
 			}
 			common.LogForObject(r, fmt.Sprintf("Finalizer %s added to CR %s", openstacknetconfig.FinalizerName, instance.Name), instance)
@@ -172,6 +172,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 			// TODO: (mschuppert) cleanup single removed netConfig in list
 			for _, subnet := range net.Subnets {
 				if err := r.osnetCleanup(
+					ctx,
 					instance,
 					&subnet,
 					cond,
@@ -187,6 +188,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		//
 		for name, attachConfig := range instance.Spec.AttachConfigurations {
 			if err := r.attachCleanup(
+				ctx,
 				instance,
 				name,
 				&attachConfig,
@@ -209,7 +211,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 			client.MatchingLabels(labelSelector),
 		}
 
-		if err := r.GetClient().List(context.Background(), osNetAttList, listOpts...); err != nil {
+		if err := r.GetClient().List(ctx, osNetAttList, listOpts...); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -228,7 +230,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// X. as last step remove the finalizer on the operator CR to finish delete
 		controllerutil.RemoveFinalizer(instance, openstacknetconfig.FinalizerName)
-		err = r.Client.Update(context.TODO(), instance)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonRemoveFinalizerError)
@@ -267,6 +269,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	for name, attachConfig := range instance.Spec.AttachConfigurations {
 		// TODO: (mschuppert) cleanup single removed netAttachment in list
 		netAttachment, err := r.applyNetAttachmentConfig(
+			ctx,
 			instance,
 			name,
 			&attachConfig,
@@ -342,6 +345,7 @@ func (r *OpenStackNetConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	instance.Status.ProvisioningStatus.PhysNetDesiredCount = len(instance.Spec.OVNBridgeMacMappings.PhysNetworks)
 	instance.Status.ProvisioningStatus.PhysNetReadyCount = 0
 	macAddress, err := r.createOrUpdateOpenStackMACAddress(
+		ctx,
 		instance,
 		cond,
 	)
@@ -420,6 +424,7 @@ func (r *OpenStackNetConfigReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 func (r *OpenStackNetConfigReconciler) applyNetAttachmentConfig(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackNetConfig,
 	nodeConfName string,
 	nodeConfPolicy *ospdirectorv1beta1.NodeConfigurationPolicy,
@@ -458,7 +463,7 @@ func (r *OpenStackNetConfigReconciler) applyNetAttachmentConfig(
 		return controllerutil.SetControllerReference(instance, attachConfig, r.Scheme)
 	}
 
-	op, err := controllerutil.CreateOrUpdate(context.Background(), r.Client, attachConfig, apply)
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, attachConfig, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", attachConfig.Kind, attachConfig.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetAttachCondReasonCreateError)
@@ -525,6 +530,7 @@ func (r *OpenStackNetConfigReconciler) getNetAttachmentStatus(
 }
 
 func (r *OpenStackNetConfigReconciler) attachCleanup(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackNetConfig,
 	nodeConfName string,
 	nodeConfPolicy *ospdirectorv1beta1.NodeConfigurationPolicy,
@@ -544,7 +550,7 @@ func (r *OpenStackNetConfigReconciler) attachCleanup(
 	cond.Message = fmt.Sprintf("OpenStackNetAttachment %s delete started", attachConfig.Name)
 	cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigConfiguring)
 
-	if err := r.Client.Delete(context.TODO(), attachConfig, &client.DeleteOptions{}); err != nil {
+	if err := r.Delete(ctx, attachConfig, &client.DeleteOptions{}); err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return nil
 		}
@@ -573,7 +579,7 @@ func (r *OpenStackNetConfigReconciler) applyNetConfig(
 	//
 	// get OSNet object
 	//
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: strings.ToLower(osNet.Name), Namespace: osNet.Namespace}, osNet)
+	err := r.Get(ctx, types.NamespacedName{Name: strings.ToLower(osNet.Name), Namespace: osNet.Namespace}, osNet)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		cond.Message = fmt.Sprintf("Failed to get %s %s ", osNet.Kind, osNet.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonOSNetError)
@@ -647,7 +653,7 @@ func (r *OpenStackNetConfigReconciler) applyNetConfig(
 		return controllerutil.SetControllerReference(instance, osNet, r.Scheme)
 	}
 
-	op, err := controllerutil.CreateOrUpdate(context.Background(), r.Client, osNet, apply)
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, osNet, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", osNet.Kind, osNet.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetCondReasonCreateError)
@@ -753,6 +759,7 @@ func (r *OpenStackNetConfigReconciler) getNetStatus(
 }
 
 func (r *OpenStackNetConfigReconciler) osnetCleanup(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackNetConfig,
 	subnet *ospdirectorv1beta1.Subnet,
 	cond *ospdirectorv1beta1.Condition,
@@ -765,7 +772,7 @@ func (r *OpenStackNetConfigReconciler) osnetCleanup(
 	cond.Message = fmt.Sprintf("OpenStackNet %s delete started", osNet.Name)
 	cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.NetConfigConfiguring)
 
-	if err := r.Client.Delete(context.TODO(), osNet, &client.DeleteOptions{}); err != nil {
+	if err := r.Delete(ctx, osNet, &client.DeleteOptions{}); err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return nil
 		}
@@ -781,6 +788,7 @@ func (r *OpenStackNetConfigReconciler) osnetCleanup(
 // create or update the OpenStackMACAddress object
 //
 func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackNetConfig,
 	cond *ospdirectorv1beta1.Condition,
 ) (*ospdirectorv1beta1.OpenStackMACAddress, error) {
@@ -795,7 +803,7 @@ func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
 	//
 	// get OSMACAddress object
 	//
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: strings.ToLower(instance.Name), Namespace: instance.Namespace}, macAddress)
+	err := r.Get(ctx, types.NamespacedName{Name: strings.ToLower(instance.Name), Namespace: instance.Namespace}, macAddress)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		cond.Message = fmt.Sprintf("Failed to get %s %s ", macAddress.Kind, macAddress.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.MACCondReasonError)
@@ -827,7 +835,7 @@ func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
 
 	ipSetList := &ospdirectorv1beta1.OpenStackIPSetList{}
 	if err := r.GetClient().List(
-		context.Background(),
+		ctx,
 		ipSetList,
 		listOpts...,
 	); err != nil && !k8s_errors.IsNotFound(err) {
@@ -852,7 +860,7 @@ func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
 	}
 	vmSetList := &ospdirectorv1beta1.OpenStackVMSetList{}
 	if err := r.GetClient().List(
-		context.Background(),
+		ctx,
 		vmSetList,
 		listOpts...,
 	); err != nil && !k8s_errors.IsNotFound(err) {
@@ -864,7 +872,7 @@ func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
 	//
 	bmSetList := &ospdirectorv1beta1.OpenStackBaremetalSetList{}
 	if err := r.GetClient().List(
-		context.Background(),
+		ctx,
 		bmSetList,
 		listOpts...,
 	); err != nil && !k8s_errors.IsNotFound(err) {
@@ -932,7 +940,7 @@ func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
 	//
 	// create/update OSMACAddress
 	//
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, macAddress, func() error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, macAddress, func() error {
 		if len(instance.Spec.OVNBridgeMacMappings.PhysNetworks) == 0 {
 			macAddress.Spec.PhysNetworks = []ospdirectorv1beta1.Physnet{
 				{
@@ -1210,7 +1218,7 @@ func (r *OpenStackNetConfigReconciler) ensureIPReservation(
 		// For backward compatability check if owning object is osClient and set Role to <openstackclient.Role><instance.Name>
 		//
 		osClient := &ospdirectorv1beta1.OpenStackClient{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{
+		err := r.Get(ctx, types.NamespacedName{
 			Name:      osIPset.Labels[common.OwnerNameLabelSelector],
 			Namespace: osIPset.Namespace},
 			osClient)

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -463,7 +463,7 @@ func (r *OpenStackNetConfigReconciler) applyNetAttachmentConfig(
 		return controllerutil.SetControllerReference(instance, attachConfig, r.Scheme)
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, attachConfig, apply)
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, attachConfig, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", attachConfig.Kind, attachConfig.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetAttachCondReasonCreateError)
@@ -653,7 +653,7 @@ func (r *OpenStackNetConfigReconciler) applyNetConfig(
 		return controllerutil.SetControllerReference(instance, osNet, r.Scheme)
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, osNet, apply)
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, osNet, apply)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to create or update %s %s ", osNet.Kind, osNet.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.NetCondReasonCreateError)
@@ -940,7 +940,7 @@ func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
 	//
 	// create/update OSMACAddress
 	//
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, macAddress, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, macAddress, func() error {
 		if len(instance.Spec.OVNBridgeMacMappings.PhysNetworks) == 0 {
 			macAddress.Spec.PhysNetworks = []ospdirectorv1beta1.Physnet{
 				{

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -85,7 +85,7 @@ func (r *OpenStackProvisionServerReconciler) GetScheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=osp-director.openstack.org,resources=openstackprovisionservers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;create;update;delete;watch;
 // +kubebuilder:rbac:groups=core,resources=configmaps/finalizers,verbs=get;list;create;update;delete;watch;
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;create;update;delete;watch;
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;create;update;delete;patch;watch;
 // +kubebuilder:rbac:groups=core,resources=volumes,verbs=get;list;create;update;delete;watch;
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;update;watch;
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;update;watch;
@@ -373,7 +373,7 @@ func (r *OpenStackProvisionServerReconciler) deploymentCreateOrUpdate(
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, deployment, func() error {
 
 		replicas := int32(1)
 

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -901,7 +901,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, vm, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.Client, vm, func() error {
 
 		vm.Labels = common.GetLabels(instance, vmset.AppLabel, map[string]string{})
 

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -103,7 +103,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Fetch the controller VM instance
 	instance := &ospdirectorv1beta1.OpenStackVMSet{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -150,7 +150,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		instance.Status.ProvisioningStatus.State = ospdirectorv1beta1.ProvisioningState(cond.Type)
 
 		if statusChanged() {
-			if updateErr := r.Client.Status().Update(context.Background(), instance); updateErr != nil {
+			if updateErr := r.Status().Update(context.Background(), instance); updateErr != nil {
 				common.LogErrorForObject(r, updateErr, "Update status", instance)
 			}
 		}
@@ -160,7 +160,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}(cond)
 
 	// What VMs do we currently have for this OpenStackVMSet?
-	virtualMachineList, err := common.GetVirtualMachines(r, instance.Namespace, map[string]string{
+	virtualMachineList, err := common.GetVirtualMachines(ctx, r, instance.Namespace, map[string]string{
 		common.OwnerNameLabelSelector: instance.Name,
 	})
 	if err != nil {
@@ -192,7 +192,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// 2. Clean up resources used by the operator
 		// VirtualMachine resources
-		err := r.virtualMachineListFinalizerCleanup(instance, cond, virtualMachineList)
+		err := r.virtualMachineListFinalizerCleanup(ctx, instance, cond, virtualMachineList)
 		if err != nil && !k8s_errors.IsNotFound(err) {
 			// ignore not found errors if the object is already gone
 			return ctrl.Result{}, err
@@ -200,7 +200,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// 3. as last step remove the finalizer on the operator CR to finish delete
 		controllerutil.RemoveFinalizer(instance, vmset.FinalizerName)
-		err = r.Client.Update(context.TODO(), instance)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonRemoveFinalizerError)
@@ -237,6 +237,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// controller to watch this resource and reconcile
 	//
 	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(
+		ctx,
 		r,
 		instance,
 		cond,
@@ -258,7 +259,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		currentLabels,
 		instance.Labels,
 	) {
-		err = r.Client.Update(context.TODO(), instance)
+		err = r.Update(ctx, instance)
 		if err != nil {
 			cond.Message = fmt.Sprintf("Failed to update %s %s", instance.Kind, instance.Name)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonAddOSNetLabelError)
@@ -274,6 +275,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Generate fencing data potentially needed by all VMSets in this instance's namespace
 	//
 	err = r.generateNamespaceFencingData(
+		ctx,
 		instance,
 		cond,
 	)
@@ -285,6 +287,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// check for DeploymentSSHSecret and add AuthorizedKeys from DeploymentSSHSecret
 	//
 	templateParameters["AuthorizedKeys"], ctrlResult, err = common.GetDataFromSecret(
+		ctx,
 		r,
 		instance,
 		cond,
@@ -315,6 +318,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//
 	if instance.Spec.PasswordSecret != "" {
 		templateParameters["NodeRootPassword"], ctrlResult, err = r.getPasswordSecret(
+			ctx,
 			instance,
 			cond,
 		)
@@ -332,6 +336,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Create CloudInitSecret secret for the vmset
 	//
 	err = r.createCloudInitSecret(
+		ctx,
 		instance,
 		cond,
 		envVars,
@@ -345,7 +350,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//
 	// Get mapping of all OSNets with their binding type for this namespace
 	//
-	osNetBindings, err := openstacknet.GetOpenStackNetsBindingMap(r, instance.Namespace)
+	osNetBindings, err := openstacknet.GetOpenStackNetsBindingMap(ctx, r, instance.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -354,6 +359,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// NetworkAttachmentDefinition, SriovNetwork and SriovNetworkNodePolicy
 	//
 	nadMap, ctrlResult, err := r.verifyNetworkAttachments(
+		ctx,
 		instance,
 		cond,
 		osNetBindings,
@@ -366,6 +372,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//   check/update instance status for annotated for deletion marged VMs
 	//
 	err = r.checkVMsAnnotatedForDeletion(
+		ctx,
 		instance,
 		cond,
 	)
@@ -377,6 +384,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//   Handle VM removal from VMSet
 	//
 	deletedHosts, err := r.doVMDelete(
+		ctx,
 		instance,
 		cond,
 		virtualMachineList,
@@ -389,6 +397,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// create IPs for all networks
 	//
 	ipsetStatus, ctrlResult, err := openstackipset.EnsureIPs(
+		ctx,
 		r,
 		instance,
 		cond,
@@ -418,6 +427,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//   Create BaseImage for the VMSet
 	//
 	baseImageName, ctrlResult, err := r.createBaseImage(
+		ctx,
 		instance,
 		cond,
 	)
@@ -429,6 +439,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//   Create/Update NetworkData
 	//
 	vmDetails, err := r.createNetworkData(
+		ctx,
 		instance,
 		cond,
 		nadMap,
@@ -443,6 +454,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//   Create the VM objects
 	//
 	ctrlResult, err = r.createVMs(
+		ctx,
 		instance,
 		cond,
 		envVars,
@@ -473,6 +485,7 @@ func (r *OpenStackVMSetReconciler) getNormalizedStatus(status *ospdirectorv1beta
 }
 
 func (r *OpenStackVMSetReconciler) generateNamespaceFencingData(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 ) error {
@@ -501,7 +514,7 @@ func (r *OpenStackVMSetReconciler) generateNamespaceFencingData(
 		},
 	}
 
-	if err := common.EnsureSecrets(r, instance, saSecretTemplate, nil); err != nil {
+	if err := common.EnsureSecrets(ctx, r, instance, saSecretTemplate, nil); err != nil {
 		cond.Message = "Error creating Kubevirt Fencing ServiceAccount Secret"
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.VMSetCondReasonKubevirtFencingServiceAccountError)
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeError)
@@ -530,7 +543,7 @@ func (r *OpenStackVMSetReconciler) generateNamespaceFencingData(
 	templateParameters["Namespace"] = instance.Namespace
 
 	// Read-back the secret for the kubevirt agent service account token
-	kubevirtAgentTokenSecret, err := r.Kclient.CoreV1().Secrets(instance.Namespace).Get(context.TODO(), vmset.KubevirtFencingServiceAccountSecret, metav1.GetOptions{})
+	kubevirtAgentTokenSecret, err := r.Kclient.CoreV1().Secrets(instance.Namespace).Get(ctx, vmset.KubevirtFencingServiceAccountSecret, metav1.GetOptions{})
 	if err != nil {
 		cond.Message = "Error getting the Kubevirt Fencing ServiceAccount Secret"
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.VMSetCondReasonKubevirtFencingServiceAccountError)
@@ -555,7 +568,7 @@ func (r *OpenStackVMSetReconciler) generateNamespaceFencingData(
 		},
 	}
 
-	err = common.EnsureSecrets(r, instance, kubeconfigTemplate, nil)
+	err = common.EnsureSecrets(ctx, r, instance, kubeconfigTemplate, nil)
 	if err != nil {
 		cond.Message = "Error creating secret holding the kubeconfig used by the pacemaker fencing agent"
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.VMSetCondReasonNamespaceFencingDataError)
@@ -569,6 +582,7 @@ func (r *OpenStackVMSetReconciler) generateNamespaceFencingData(
 }
 
 func (r *OpenStackVMSetReconciler) generateVirtualMachineNetworkData(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	envVars *map[string]common.EnvSetter,
@@ -588,6 +602,7 @@ func (r *OpenStackVMSetReconciler) generateVirtualMachineNetworkData(
 
 	// get ctlplane network
 	network, err := openstacknet.GetOpenStackNetWithLabel(
+		ctx,
 		r,
 		instance.Namespace,
 		labelSelector,
@@ -628,7 +643,7 @@ func (r *OpenStackVMSetReconciler) generateVirtualMachineNetworkData(
 		},
 	}
 
-	err = common.EnsureSecrets(r, instance, networkdata, envVars)
+	err = common.EnsureSecrets(ctx, r, instance, networkdata, envVars)
 	if err != nil {
 		return err
 	}
@@ -637,6 +652,7 @@ func (r *OpenStackVMSetReconciler) generateVirtualMachineNetworkData(
 }
 
 func (r *OpenStackVMSetReconciler) virtualMachineListFinalizerCleanup(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	virtualMachineList *virtv1.VirtualMachineList,
@@ -644,7 +660,7 @@ func (r *OpenStackVMSetReconciler) virtualMachineListFinalizerCleanup(
 	r.Log.Info(fmt.Sprintf("Removing finalizers from VirtualMachines in VMSet: %s", instance.Name))
 
 	for _, virtualMachine := range virtualMachineList.Items {
-		err := r.virtualMachineFinalizerCleanup(&virtualMachine, cond)
+		err := r.virtualMachineFinalizerCleanup(ctx, &virtualMachine, cond)
 
 		if err != nil {
 			return err
@@ -655,11 +671,12 @@ func (r *OpenStackVMSetReconciler) virtualMachineListFinalizerCleanup(
 }
 
 func (r *OpenStackVMSetReconciler) virtualMachineFinalizerCleanup(
+	ctx context.Context,
 	virtualMachine *virtv1.VirtualMachine,
 	cond *ospdirectorv1beta1.Condition,
 ) error {
 	controllerutil.RemoveFinalizer(virtualMachine, vmset.FinalizerName)
-	err := r.Client.Update(context.TODO(), virtualMachine)
+	err := r.Update(ctx, virtualMachine)
 
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to update %s %s", virtualMachine.Kind, virtualMachine.Name)
@@ -691,6 +708,7 @@ func (r *OpenStackVMSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *OpenStackVMSetReconciler) vmCreateInstance(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	envVars map[string]common.EnvSetter,
@@ -705,7 +723,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 
 	// get deployment userdata from secret
 	userdataSecret := fmt.Sprintf("%s-cloudinit", instance.Name)
-	secret, _, err := common.GetSecret(r, userdataSecret, instance.Namespace)
+	secret, _, err := common.GetSecret(ctx, r, userdataSecret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			cond.Message = fmt.Sprintf("CloudInit userdata %s secret not found!!", userdataSecret)
@@ -883,7 +901,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, vm, func() error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, vm, func() error {
 
 		vm.Labels = common.GetLabels(instance, vmset.AppLabel, map[string]string{})
 
@@ -908,6 +926,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 				openstacknet.SubNetNameLabelSelector: netNameLower,
 			}
 			network, err := openstacknet.GetOpenStackNetWithLabel(
+				ctx,
 				r,
 				instance.Namespace,
 				labelSelector,
@@ -996,11 +1015,12 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 // check if specified password secret exists
 //
 func (r *OpenStackVMSetReconciler) getPasswordSecret(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 ) (string, ctrl.Result, error) {
 
-	passwordSecret, _, err := common.GetSecret(r, instance.Spec.PasswordSecret, instance.Namespace)
+	passwordSecret, _, err := common.GetSecret(ctx, r, instance.Spec.PasswordSecret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			timeout := 30
@@ -1033,6 +1053,7 @@ func (r *OpenStackVMSetReconciler) getPasswordSecret(
 // Create CloudInitSecret secret for the vmset
 //
 func (r *OpenStackVMSetReconciler) createCloudInitSecret(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	envVars map[string]common.EnvSetter,
@@ -1052,7 +1073,7 @@ func (r *OpenStackVMSetReconciler) createCloudInitSecret(
 		},
 	}
 
-	err := common.EnsureSecrets(r, instance, cloudinit, &envVars)
+	err := common.EnsureSecrets(ctx, r, instance, cloudinit, &envVars)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Error creating CloudInitSecret secret for the vmset %s", instance.Name)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.VMSetCondReasonCloudInitSecretError)
@@ -1068,12 +1089,13 @@ func (r *OpenStackVMSetReconciler) createCloudInitSecret(
 // NetworkAttachmentDefinition, SriovNetwork and SriovNetworkNodePolicy
 //
 func (r *OpenStackVMSetReconciler) verifyNetworkAttachments(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	osNetBindings map[string]ospdirectorv1beta1.AttachType,
 ) (map[string]networkv1.NetworkAttachmentDefinition, ctrl.Result, error) {
 	// Verify that NetworkAttachmentDefinition for each non-SRIOV-configured network exists, and...
-	nadMap, err := common.GetAllNetworkAttachmentDefinitions(r, instance)
+	nadMap, err := common.GetAllNetworkAttachmentDefinitions(ctx, r, instance)
 	if err != nil {
 		return nadMap, ctrl.Result{}, err
 	}
@@ -1083,11 +1105,11 @@ func (r *OpenStackVMSetReconciler) verifyNetworkAttachments(
 		common.OwnerControllerNameLabelSelector: openstacknet.AppLabel,
 		common.OwnerNameSpaceLabelSelector:      instance.Namespace,
 	}
-	snMap, err := openstacknet.GetSriovNetworksWithLabel(r, sriovLabelSelectorMap, "openshift-sriov-network-operator")
+	snMap, err := openstacknet.GetSriovNetworksWithLabel(ctx, r, sriovLabelSelectorMap, "openshift-sriov-network-operator")
 	if err != nil {
 		return nadMap, ctrl.Result{}, err
 	}
-	snnpMap, err := openstacknet.GetSriovNetworkNodePoliciesWithLabel(r, sriovLabelSelectorMap, "openshift-sriov-network-operator")
+	snnpMap, err := openstacknet.GetSriovNetworkNodePoliciesWithLabel(ctx, r, sriovLabelSelectorMap, "openshift-sriov-network-operator")
 	if err != nil {
 		return nadMap, ctrl.Result{}, err
 	}
@@ -1099,6 +1121,7 @@ func (r *OpenStackVMSetReconciler) verifyNetworkAttachments(
 
 		// get network with name_lower label
 		network, err := openstacknet.GetOpenStackNetWithLabel(
+			ctx,
 			r,
 			instance.Namespace,
 			map[string]string{
@@ -1151,12 +1174,13 @@ func (r *OpenStackVMSetReconciler) verifyNetworkAttachments(
 //   check/update instance status for annotated for deletion marked VMs
 //
 func (r *OpenStackVMSetReconciler) checkVMsAnnotatedForDeletion(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 ) error {
 	// check for deletion marked VMs
 	currentVMHostsStatus := instance.Status.DeepCopy().VMHosts
-	deletionAnnotatedVMs, err := r.getDeletedVMOSPHostnames(instance, cond)
+	deletionAnnotatedVMs, err := r.getDeletedVMOSPHostnames(ctx, instance, cond)
 	if err != nil {
 		return err
 	}
@@ -1198,7 +1222,7 @@ func (r *OpenStackVMSetReconciler) checkVMsAnnotatedForDeletion(
 			instance,
 		)
 
-		err = r.Client.Status().Update(context.TODO(), instance)
+		err = r.Status().Update(context.Background(), instance)
 		if err != nil {
 			cond.Message = "Failed to update CR status for annotated for deletion marked VMs"
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonCRStatusUpdateError)
@@ -1213,6 +1237,7 @@ func (r *OpenStackVMSetReconciler) checkVMsAnnotatedForDeletion(
 }
 
 func (r *OpenStackVMSetReconciler) getDeletedVMOSPHostnames(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 ) ([]string, error) {
@@ -1225,7 +1250,7 @@ func (r *OpenStackVMSetReconciler) getDeletedVMOSPHostnames(
 		common.OwnerNameLabelSelector:      instance.Name,
 	}
 
-	vmHostList, err := common.GetVirtualMachines(r, instance.Namespace, labelSelector)
+	vmHostList, err := common.GetVirtualMachines(ctx, r, instance.Namespace, labelSelector)
 	if err != nil {
 		cond.Message = fmt.Sprintf("Failed to get virtual machines with labelSelector %v ", labelSelector)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.VMSetCondReasonVirtualMachineGetError)
@@ -1258,6 +1283,7 @@ func (r *OpenStackVMSetReconciler) getDeletedVMOSPHostnames(
 //   Create BaseImage for the VMSet
 //
 func (r *OpenStackVMSetReconciler) createBaseImage(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 ) (string, ctrl.Result, error) {
@@ -1274,7 +1300,7 @@ func (r *OpenStackVMSetReconciler) createBaseImage(
 	//   annotations -> cdi.kubevirt.io/storage.pod.phase: Succeeded
 	pvc := &corev1.PersistentVolumeClaim{}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: baseImageName, Namespace: instance.Namespace}, pvc)
+	err := r.Get(ctx, types.NamespacedName{Name: baseImageName, Namespace: instance.Namespace}, pvc)
 	if err != nil && k8s_errors.IsNotFound(err) {
 		cond.Message = fmt.Sprintf("PersistentVolumeClaim %s not found reconcile again in 10 seconds", baseImageName)
 		cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.VMSetCondReasonPersitentVolumeClaimNotFound)
@@ -1309,6 +1335,7 @@ func (r *OpenStackVMSetReconciler) createBaseImage(
 }
 
 func (r *OpenStackVMSetReconciler) doVMDelete(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	virtualMachineList *virtv1.VirtualMachineList,
@@ -1335,6 +1362,7 @@ func (r *OpenStackVMSetReconciler) doVMDelete(
 				// Choose VirtualMachines to remove from the prepared list of VirtualMachines
 				// that have the common.HostRemovalAnnotation annotation
 				deletedHost, err := r.virtualMachineDeprovision(
+					ctx,
 					instance,
 					cond,
 					&removalAnnotatedVirtualMachines[0],
@@ -1371,6 +1399,7 @@ func (r *OpenStackVMSetReconciler) doVMDelete(
 }
 
 func (r *OpenStackVMSetReconciler) virtualMachineDeprovision(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	virtualMachine *virtv1.VirtualMachine,
@@ -1379,7 +1408,7 @@ func (r *OpenStackVMSetReconciler) virtualMachineDeprovision(
 
 	// First check if the finalizer is still there and remove it if so
 	if controllerutil.ContainsFinalizer(virtualMachine, vmset.FinalizerName) {
-		err := r.virtualMachineFinalizerCleanup(virtualMachine, cond)
+		err := r.virtualMachineFinalizerCleanup(ctx, virtualMachine, cond)
 
 		if err != nil {
 			return "", err
@@ -1387,7 +1416,7 @@ func (r *OpenStackVMSetReconciler) virtualMachineDeprovision(
 	}
 
 	// Delete the VirtualMachine
-	err := r.Client.Delete(context.TODO(), virtualMachine, &client.DeleteOptions{})
+	err := r.Delete(ctx, virtualMachine, &client.DeleteOptions{})
 	if err != nil {
 		return virtualMachine.Name, err
 	}
@@ -1396,6 +1425,7 @@ func (r *OpenStackVMSetReconciler) virtualMachineDeprovision(
 	// Also remove networkdata secret
 	secret := fmt.Sprintf("%s-%s-networkdata", instance.Name, virtualMachine.Name)
 	err = common.DeleteSecretsWithName(
+		ctx,
 		r,
 		cond,
 		secret,
@@ -1416,6 +1446,7 @@ func (r *OpenStackVMSetReconciler) virtualMachineDeprovision(
 //   Create/Update NetworkData
 //
 func (r *OpenStackVMSetReconciler) createNetworkData(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	nadMap map[string]networkv1.NetworkAttachmentDefinition,
@@ -1448,6 +1479,7 @@ func (r *OpenStackVMSetReconciler) createNetworkData(
 		}
 
 		err := r.generateVirtualMachineNetworkData(
+			ctx,
 			instance,
 			cond,
 			&envVars,
@@ -1499,6 +1531,7 @@ func (r *OpenStackVMSetReconciler) createNetworkData(
 //   Create the VM objects
 //
 func (r *OpenStackVMSetReconciler) createVMs(
+	ctx context.Context,
 	instance *ospdirectorv1beta1.OpenStackVMSet,
 	cond *ospdirectorv1beta1.Condition,
 	envVars map[string]common.EnvSetter,
@@ -1510,7 +1543,7 @@ func (r *OpenStackVMSetReconciler) createVMs(
 		for _, ctl := range vmDetails {
 			// Add chosen baseImageName to controller details, then create the VM instance
 			ctl.BaseImageName = baseImageName
-			err := r.vmCreateInstance(instance, cond, envVars, &ctl, osNetBindings)
+			err := r.vmCreateInstance(ctx, instance, cond, envVars, &ctl, osNetBindings)
 			if err != nil {
 				return ctrl.Result{}, err
 			}

--- a/pkg/common/baremetal.go
+++ b/pkg/common/baremetal.go
@@ -25,7 +25,12 @@ import (
 )
 
 // GetBmhHosts -
-func GetBmhHosts(r ReconcilerCommon, namespace string, labelSelector map[string]string) (*metal3v1alpha1.BareMetalHostList, error) {
+func GetBmhHosts(
+	ctx context.Context,
+	r ReconcilerCommon,
+	namespace string,
+	labelSelector map[string]string,
+) (*metal3v1alpha1.BareMetalHostList, error) {
 
 	bmhHostsList := &metal3v1alpha1.BareMetalHostList{}
 
@@ -38,7 +43,7 @@ func GetBmhHosts(r ReconcilerCommon, namespace string, labelSelector map[string]
 		listOpts = append(listOpts, labels)
 	}
 
-	err := r.GetClient().List(context.TODO(), bmhHostsList, listOpts...)
+	err := r.GetClient().List(ctx, bmhHostsList, listOpts...)
 	if err != nil {
 		return bmhHostsList, err
 	}
@@ -47,11 +52,16 @@ func GetBmhHosts(r ReconcilerCommon, namespace string, labelSelector map[string]
 }
 
 // GetDeletionAnnotatedBmhHosts -
-func GetDeletionAnnotatedBmhHosts(r ReconcilerCommon, namespace string, labelSelector map[string]string) ([]string, error) {
+func GetDeletionAnnotatedBmhHosts(
+	ctx context.Context,
+	r ReconcilerCommon,
+	namespace string,
+	labelSelector map[string]string,
+) ([]string, error) {
 
 	annotatedBMHs := []string{}
 
-	baremetalHostList, err := GetBmhHosts(r, namespace, labelSelector)
+	baremetalHostList, err := GetBmhHosts(ctx, r, namespace, labelSelector)
 	if err != nil {
 		return annotatedBMHs, err
 	}

--- a/pkg/common/controlplane.go
+++ b/pkg/common/controlplane.go
@@ -30,7 +30,11 @@ import (
 )
 
 // GetControlPlane -
-func GetControlPlane(r ReconcilerCommon, obj metav1.Object) (ospdirectorv1beta1.OpenStackControlPlane, reconcile.Result, error) {
+func GetControlPlane(
+	ctx context.Context,
+	r ReconcilerCommon,
+	obj metav1.Object,
+) (ospdirectorv1beta1.OpenStackControlPlane, reconcile.Result, error) {
 
 	controlPlane := ospdirectorv1beta1.OpenStackControlPlane{}
 
@@ -41,7 +45,7 @@ func GetControlPlane(r ReconcilerCommon, obj metav1.Object) (ospdirectorv1beta1.
 		client.InNamespace(obj.GetNamespace()),
 		client.Limit(1000),
 	}
-	err := r.GetClient().List(context.TODO(), controlPlaneList, controlPlaneListOpts...)
+	err := r.GetClient().List(ctx, controlPlaneList, controlPlaneListOpts...)
 	if err != nil {
 		return controlPlane, ctrl.Result{}, err
 	}

--- a/pkg/common/job_util.go
+++ b/pkg/common/job_util.go
@@ -33,14 +33,19 @@ import (
 
 // DeleteJob func
 // kclient required to properly cleanup the job depending pods with DeleteOptions
-func DeleteJob(job *batchv1.Job, kclient kubernetes.Interface, log logr.Logger) (bool, error) {
+func DeleteJob(
+	ctx context.Context,
+	job *batchv1.Job,
+	kclient kubernetes.Interface,
+	log logr.Logger,
+) (bool, error) {
 
 	// Check if this Job already exists
-	foundJob, err := kclient.BatchV1().Jobs(job.Namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
+	foundJob, err := kclient.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
 	if err == nil {
 		log.Info("Deleting Job", "Job.Namespace", job.Namespace, "Job.Name", job.Name)
 		background := metav1.DeletePropagationBackground
-		err = kclient.BatchV1().Jobs(foundJob.Namespace).Delete(context.TODO(), foundJob.Name, metav1.DeleteOptions{PropagationPolicy: &background})
+		err = kclient.BatchV1().Jobs(foundJob.Namespace).Delete(ctx, foundJob.Name, metav1.DeleteOptions{PropagationPolicy: &background})
 		if err != nil {
 			return false, err
 		}
@@ -50,10 +55,15 @@ func DeleteJob(job *batchv1.Job, kclient kubernetes.Interface, log logr.Logger) 
 }
 
 // WaitOnJob func
-func WaitOnJob(job *batchv1.Job, client client.Client, log logr.Logger) (bool, error) {
+func WaitOnJob(
+	ctx context.Context,
+	job *batchv1.Job,
+	client client.Client,
+	log logr.Logger,
+) (bool, error) {
 	// Check if this Job already exists
 	foundJob := &batchv1.Job{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, foundJob)
+	err := client.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, foundJob)
 	if err != nil {
 		log.Info("WaitOnJob err")
 		return true, err

--- a/pkg/common/network.go
+++ b/pkg/common/network.go
@@ -25,7 +25,11 @@ import (
 )
 
 // GetAllNetworkAttachmentDefinitions - get all NetworkAttachmentDefinition
-func GetAllNetworkAttachmentDefinitions(r ReconcilerCommon, obj metav1.Object) (map[string]networkv1.NetworkAttachmentDefinition, error) {
+func GetAllNetworkAttachmentDefinitions(
+	ctx context.Context,
+	r ReconcilerCommon,
+	obj metav1.Object,
+) (map[string]networkv1.NetworkAttachmentDefinition, error) {
 
 	nadMap := make(map[string]networkv1.NetworkAttachmentDefinition)
 
@@ -35,7 +39,7 @@ func GetAllNetworkAttachmentDefinitions(r ReconcilerCommon, obj metav1.Object) (
 		client.InNamespace(obj.GetNamespace()),
 	}
 
-	err := r.GetClient().List(context.TODO(), nadList, nadListOpts...)
+	err := r.GetClient().List(ctx, nadList, nadListOpts...)
 	if err != nil {
 		return nadMap, err
 	}

--- a/pkg/common/pod.go
+++ b/pkg/common/pod.go
@@ -28,11 +28,16 @@ import (
 )
 
 // GetAllPodsWithLabel - get all pods from namespace with a specific label
-func GetAllPodsWithLabel(r ReconcilerCommon, labelSelectorMap map[string]string, namespace string) (*corev1.PodList, error) {
+func GetAllPodsWithLabel(
+	ctx context.Context,
+	r ReconcilerCommon,
+	labelSelectorMap map[string]string,
+	namespace string,
+) (*corev1.PodList, error) {
 	labelSelectorString := labels.Set(labelSelectorMap).String()
 
 	podList, err := r.GetKClient().CoreV1().Pods(namespace).List(
-		context.TODO(),
+		ctx,
 		metav1.ListOptions{
 			LabelSelector: labelSelectorString,
 		},
@@ -45,9 +50,14 @@ func GetAllPodsWithLabel(r ReconcilerCommon, labelSelectorMap map[string]string,
 }
 
 // DeletePodsWithLabel - Delete all pods in namespace of the obj matching label selector
-func DeletePodsWithLabel(r ReconcilerCommon, obj metav1.Object, labelSelectorMap map[string]string) error {
+func DeletePodsWithLabel(
+	ctx context.Context,
+	r ReconcilerCommon,
+	obj metav1.Object,
+	labelSelectorMap map[string]string,
+) error {
 	err := r.GetClient().DeleteAllOf(
-		context.TODO(),
+		ctx,
 		&corev1.Pod{},
 		client.InNamespace(obj.GetNamespace()),
 		client.MatchingLabels(labelSelectorMap),

--- a/pkg/common/pvc.go
+++ b/pkg/common/pvc.go
@@ -37,13 +37,13 @@ type Pvc struct {
 }
 
 // CreateOrUpdatePvc -
-func CreateOrUpdatePvc(r ReconcilerCommon, obj metav1.Object, pv *Pvc) (*corev1.PersistentVolumeClaim, controllerutil.OperationResult, error) {
+func CreateOrUpdatePvc(ctx context.Context, r ReconcilerCommon, obj metav1.Object, pv *Pvc) (*corev1.PersistentVolumeClaim, controllerutil.OperationResult, error) {
 
 	pvc := &corev1.PersistentVolumeClaim{}
 	pvc.Name = pv.Name
 	pvc.Namespace = pv.Namespace
 
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.GetClient(), pvc, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.GetClient(), pvc, func() error {
 
 		pvc.Labels = pv.Labels
 

--- a/pkg/common/replicaset.go
+++ b/pkg/common/replicaset.go
@@ -27,9 +27,14 @@ import (
 )
 
 // DeleteReplicasetsWithLabel - Delete all replicasets in namespace of the obj matching label selector
-func DeleteReplicasetsWithLabel(r ReconcilerCommon, obj metav1.Object, labelSelectorMap map[string]string) error {
+func DeleteReplicasetsWithLabel(
+	ctx context.Context,
+	r ReconcilerCommon,
+	obj metav1.Object,
+	labelSelectorMap map[string]string,
+) error {
 	err := r.GetClient().DeleteAllOf(
-		context.TODO(),
+		ctx,
 		&appsv1.ReplicaSet{},
 		client.InNamespace(obj.GetNamespace()),
 		client.MatchingLabels(labelSelectorMap),

--- a/pkg/common/virtualmachine.go
+++ b/pkg/common/virtualmachine.go
@@ -8,7 +8,12 @@ import (
 )
 
 // GetVirtualMachines -
-func GetVirtualMachines(r ReconcilerCommon, namespace string, labelSelectorMap map[string]string) (*virtv1.VirtualMachineList, error) {
+func GetVirtualMachines(
+	ctx context.Context,
+	r ReconcilerCommon,
+	namespace string,
+	labelSelectorMap map[string]string,
+) (*virtv1.VirtualMachineList, error) {
 	virtualMachineList := &virtv1.VirtualMachineList{}
 
 	listOpts := []client.ListOption{
@@ -20,7 +25,7 @@ func GetVirtualMachines(r ReconcilerCommon, namespace string, labelSelectorMap m
 		listOpts = append(listOpts, labels)
 	}
 
-	err := r.GetClient().List(context.TODO(), virtualMachineList, listOpts...)
+	err := r.GetClient().List(ctx, virtualMachineList, listOpts...)
 	if err != nil {
 		return virtualMachineList, err
 	}
@@ -29,7 +34,12 @@ func GetVirtualMachines(r ReconcilerCommon, namespace string, labelSelectorMap m
 }
 
 // GetVirtualMachineInstances -
-func GetVirtualMachineInstances(r ReconcilerCommon, namespace string, labelSelectorMap map[string]string) (*virtv1.VirtualMachineInstanceList, error) {
+func GetVirtualMachineInstances(
+	ctx context.Context,
+	r ReconcilerCommon,
+	namespace string,
+	labelSelectorMap map[string]string,
+) (*virtv1.VirtualMachineInstanceList, error) {
 	virtualMachineInstanceList := &virtv1.VirtualMachineInstanceList{}
 
 	listOpts := []client.ListOption{
@@ -41,7 +51,7 @@ func GetVirtualMachineInstances(r ReconcilerCommon, namespace string, labelSelec
 		listOpts = append(listOpts, labels)
 	}
 
-	err := r.GetClient().List(context.TODO(), virtualMachineInstanceList, listOpts...)
+	err := r.GetClient().List(ctx, virtualMachineInstanceList, listOpts...)
 	if err != nil {
 		return virtualMachineInstanceList, err
 	}

--- a/pkg/openstackbackup/funcs.go
+++ b/pkg/openstackbackup/funcs.go
@@ -15,7 +15,11 @@ import (
 )
 
 // GetCRLists - Get lists of all OSP-D operator resources in the namespace that we care to save/restore
-func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1.CrsForBackup, error) {
+func GetCRLists(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+) (ospdirectorv1beta1.CrsForBackup, error) {
 	crLists := ospdirectorv1beta1.CrsForBackup{}
 
 	listOpts := []client.ListOption{
@@ -26,7 +30,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osBms := ospdirectorv1beta1.OpenStackBaremetalSetList{}
 
-	if err := r.GetClient().List(context.Background(), &osBms, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osBms, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -39,7 +43,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osClients := ospdirectorv1beta1.OpenStackClientList{}
 
-	if err := r.GetClient().List(context.Background(), &osClients, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osClients, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -52,7 +56,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osCtlPlanes := ospdirectorv1beta1.OpenStackControlPlaneList{}
 
-	if err := r.GetClient().List(context.Background(), &osCtlPlanes, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osCtlPlanes, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -65,7 +69,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osMacAddresses := ospdirectorv1beta1.OpenStackMACAddressList{}
 
-	if err := r.GetClient().List(context.Background(), &osMacAddresses, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osMacAddresses, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -78,7 +82,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osNets := ospdirectorv1beta1.OpenStackNetList{}
 
-	if err := r.GetClient().List(context.Background(), &osNets, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osNets, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -91,7 +95,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osNetAttachments := ospdirectorv1beta1.OpenStackNetAttachmentList{}
 
-	if err := r.GetClient().List(context.Background(), &osNetAttachments, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osNetAttachments, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -104,7 +108,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osNetConfigs := ospdirectorv1beta1.OpenStackNetConfigList{}
 
-	if err := r.GetClient().List(context.Background(), &osNetConfigs, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osNetConfigs, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -117,7 +121,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osProvServers := ospdirectorv1beta1.OpenStackProvisionServerList{}
 
-	if err := r.GetClient().List(context.Background(), &osProvServers, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osProvServers, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -130,7 +134,7 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 
 	osVms := ospdirectorv1beta1.OpenStackVMSetList{}
 
-	if err := r.GetClient().List(context.Background(), &osVms, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, &osVms, listOpts...); err != nil {
 		return crLists, err
 	}
 
@@ -143,7 +147,12 @@ func GetCRLists(r common.ReconcilerCommon, namespace string) (ospdirectorv1beta1
 }
 
 // GetConfigMapList - Get list of all OSP-D operator config maps in the namespace that we care to save/restore
-func GetConfigMapList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenStackBackupRequest, desiredCrs *ospdirectorv1beta1.CrsForBackup) (corev1.ConfigMapList, error) {
+func GetConfigMapList(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	request *ospdirectorv1beta1.OpenStackBackupRequest,
+	desiredCrs *ospdirectorv1beta1.CrsForBackup,
+) (corev1.ConfigMapList, error) {
 	configMapList := &corev1.ConfigMapList{}
 
 	labels := client.HasLabels{
@@ -155,7 +164,7 @@ func GetConfigMapList(r common.ReconcilerCommon, request *ospdirectorv1beta1.Ope
 		labels,
 	}
 
-	err := r.GetClient().List(context.TODO(), configMapList, listOpts...)
+	err := r.GetClient().List(ctx, configMapList, listOpts...)
 
 	if err != nil {
 		return *configMapList, err
@@ -173,7 +182,7 @@ func GetConfigMapList(r common.ReconcilerCommon, request *ospdirectorv1beta1.Ope
 		labels,
 	}
 
-	err = r.GetClient().List(context.TODO(), osCGConfigMapList, listOpts...)
+	err = r.GetClient().List(ctx, osCGConfigMapList, listOpts...)
 
 	if err != nil {
 		return *configMapList, err
@@ -189,7 +198,7 @@ func GetConfigMapList(r common.ReconcilerCommon, request *ospdirectorv1beta1.Ope
 
 	// Also get additional config maps potentially enumerated in the request CR
 	for _, item := range request.Spec.AdditionalConfigMaps {
-		if err := addConfigMapToList(r, request.Namespace, item, configMapList); err != nil {
+		if err := addConfigMapToList(ctx, r, request.Namespace, item, configMapList); err != nil {
 			return *configMapList, err
 		}
 	}
@@ -201,7 +210,13 @@ func GetConfigMapList(r common.ReconcilerCommon, request *ospdirectorv1beta1.Ope
 	return *configMapList, nil
 }
 
-func addConfigMapToList(r common.ReconcilerCommon, namespace string, name string, configMapList *corev1.ConfigMapList) error {
+func addConfigMapToList(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	name string,
+	configMapList *corev1.ConfigMapList,
+) error {
 	found := false
 
 	for _, cm := range configMapList.Items {
@@ -214,7 +229,7 @@ func addConfigMapToList(r common.ReconcilerCommon, namespace string, name string
 	if !found {
 		cm := &corev1.ConfigMap{}
 
-		if err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, cm); err != nil {
+		if err := r.GetClient().Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cm); err != nil {
 			return err
 		}
 
@@ -225,7 +240,12 @@ func addConfigMapToList(r common.ReconcilerCommon, namespace string, name string
 }
 
 // GetSecretList - Get list of all OSP-D operator secrets in the namespace that we care to save/restore
-func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenStackBackupRequest, desiredCrs *ospdirectorv1beta1.CrsForBackup) (corev1.SecretList, error) {
+func GetSecretList(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	request *ospdirectorv1beta1.OpenStackBackupRequest,
+	desiredCrs *ospdirectorv1beta1.CrsForBackup,
+) (corev1.SecretList, error) {
 	secretList := &corev1.SecretList{}
 
 	labels := client.HasLabels{
@@ -237,7 +257,7 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 		labels,
 	}
 
-	err := r.GetClient().List(context.TODO(), secretList, listOpts...)
+	err := r.GetClient().List(ctx, secretList, listOpts...)
 
 	if err != nil {
 		return *secretList, err
@@ -246,12 +266,12 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 	// Also get certain secrets used by our CRs
 	for _, item := range desiredCrs.OpenStackBaremetalSets.Items {
 		if item.Spec.DeploymentSSHSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.DeploymentSSHSecret, secretList); err != nil {
+			if err := addSecretToList(ctx, r, request.Namespace, item.Spec.DeploymentSSHSecret, secretList); err != nil {
 				return *secretList, err
 			}
 		}
 		if item.Spec.PasswordSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.PasswordSecret, secretList); err != nil {
+			if err := addSecretToList(ctx, r, request.Namespace, item.Spec.PasswordSecret, secretList); err != nil {
 				return *secretList, err
 			}
 		}
@@ -259,12 +279,12 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 
 	for _, item := range desiredCrs.OpenStackVMSets.Items {
 		if item.Spec.DeploymentSSHSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.DeploymentSSHSecret, secretList); err != nil {
+			if err := addSecretToList(ctx, r, request.Namespace, item.Spec.DeploymentSSHSecret, secretList); err != nil {
 				return *secretList, err
 			}
 		}
 		if item.Spec.PasswordSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.PasswordSecret, secretList); err != nil {
+			if err := addSecretToList(ctx, r, request.Namespace, item.Spec.PasswordSecret, secretList); err != nil {
 				return *secretList, err
 			}
 		}
@@ -272,7 +292,7 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 
 	for _, item := range desiredCrs.OpenStackControlPlanes.Items {
 		if item.Spec.PasswordSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.PasswordSecret, secretList); err != nil {
+			if err := addSecretToList(ctx, r, request.Namespace, item.Spec.PasswordSecret, secretList); err != nil {
 				return *secretList, err
 			}
 		}
@@ -280,7 +300,7 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 
 	for _, item := range desiredCrs.OpenStackClients.Items {
 		if item.Spec.DeploymentSSHSecret != "" {
-			if err := addSecretToList(r, request.Namespace, item.Spec.DeploymentSSHSecret, secretList); err != nil {
+			if err := addSecretToList(ctx, r, request.Namespace, item.Spec.DeploymentSSHSecret, secretList); err != nil {
 				return *secretList, err
 			}
 		}
@@ -288,7 +308,7 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 
 	// Also get additional secrets potentially enumerated in the request CR
 	for _, item := range request.Spec.AdditionalSecrets {
-		if err := addSecretToList(r, request.Namespace, item, secretList); err != nil {
+		if err := addSecretToList(ctx, r, request.Namespace, item, secretList); err != nil {
 			return *secretList, err
 		}
 	}
@@ -300,7 +320,13 @@ func GetSecretList(r common.ReconcilerCommon, request *ospdirectorv1beta1.OpenSt
 	return *secretList, nil
 }
 
-func addSecretToList(r common.ReconcilerCommon, namespace string, name string, secretList *corev1.SecretList) error {
+func addSecretToList(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	name string,
+	secretList *corev1.SecretList,
+) error {
 	found := false
 
 	for _, secret := range secretList.Items {
@@ -313,7 +339,7 @@ func addSecretToList(r common.ReconcilerCommon, namespace string, name string, s
 	if !found {
 		secret := &corev1.Secret{}
 
-		if err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
+		if err := r.GetClient().Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
 			return err
 		}
 
@@ -554,74 +580,81 @@ func GetAreResourcesRestored(backup *ospdirectorv1beta1.OpenStackBackup, crLists
 }
 
 // CleanNamespace - deleted CRs, ConfigMaps and Secrets in this namespace
-func CleanNamespace(r common.ReconcilerCommon, namespace string, crLists ospdirectorv1beta1.CrsForBackup, cmList corev1.ConfigMapList, secretList corev1.SecretList) (bool, error) {
+func CleanNamespace(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	crLists ospdirectorv1beta1.CrsForBackup,
+	cmList corev1.ConfigMapList,
+	secretList corev1.SecretList,
+) (bool, error) {
 	foundRemaining := false
 
 	// Delete OpenStackConfigGenerators as these should not be needed at this point
-	if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackConfigGenerator{}, client.InNamespace(namespace)); err != nil {
+	if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackConfigGenerator{}, client.InNamespace(namespace)); err != nil {
 		return false, err
 	}
 
 	// OSP-D CRs can be mass-deleted
 	if len(crLists.OpenStackBaremetalSets.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackBaremetalSet{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackBaremetalSet{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackProvisionServers.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackProvisionServer{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackProvisionServer{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackControlPlanes.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackControlPlane{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackControlPlane{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackVMSets.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackVMSet{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackVMSet{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackClients.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackClient{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackClient{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackMACAddresses.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackMACAddress{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackMACAddress{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackNets.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackNet{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackNet{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackNetAttachments.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackNetAttachment{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackNetAttachment{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
 
 	if len(crLists.OpenStackNetConfigs.Items) > 0 {
 		foundRemaining = true
-		if err := r.GetClient().DeleteAllOf(context.TODO(), &ospdirectorv1beta1.OpenStackNetConfig{}, client.InNamespace(namespace)); err != nil {
+		if err := r.GetClient().DeleteAllOf(ctx, &ospdirectorv1beta1.OpenStackNetConfig{}, client.InNamespace(namespace)); err != nil {
 			return false, err
 		}
 	}
@@ -629,14 +662,14 @@ func CleanNamespace(r common.ReconcilerCommon, namespace string, crLists ospdire
 	// Can't mass-delete ConfigMaps and Secrets because k8s infrastructure uses namespace for these as well
 	for _, cm := range cmList.Items {
 		foundRemaining = true
-		if err := r.GetClient().Delete(context.TODO(), &cm, &client.DeleteOptions{}); err != nil && !k8s_errors.IsNotFound(err) {
+		if err := r.GetClient().Delete(ctx, &cm, &client.DeleteOptions{}); err != nil && !k8s_errors.IsNotFound(err) {
 			return false, err
 		}
 	}
 
 	for _, secret := range secretList.Items {
 		foundRemaining = true
-		if err := r.GetClient().Delete(context.TODO(), &secret, &client.DeleteOptions{}); err != nil && !k8s_errors.IsNotFound(err) {
+		if err := r.GetClient().Delete(ctx, &secret, &client.DeleteOptions{}); err != nil && !k8s_errors.IsNotFound(err) {
 			return false, err
 		}
 	}

--- a/pkg/openstackconfigversion/git_util.go
+++ b/pkg/openstackconfigversion/git_util.go
@@ -109,13 +109,18 @@ func filterPatches(filePatches []diff.FilePatch) []diff.FilePatch {
 }
 
 // SyncGit func
-func SyncGit(inst *ospdirectorv1beta1.OpenStackConfigGenerator, client client.Client, log logr.Logger) (map[string]ospdirectorv1beta1.OpenStackConfigVersion, error) {
+func SyncGit(
+	ctx context.Context,
+	inst *ospdirectorv1beta1.OpenStackConfigGenerator,
+	client client.Client,
+	log logr.Logger,
+) (map[string]ospdirectorv1beta1.OpenStackConfigVersion, error) {
 
 	configVersions := make(map[string]ospdirectorv1beta1.OpenStackConfigVersion)
 
 	// Check if this Secret already exists
 	foundSecret := &corev1.Secret{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: inst.Spec.GitSecret, Namespace: inst.Namespace}, foundSecret)
+	err := client.Get(ctx, types.NamespacedName{Name: inst.Spec.GitSecret, Namespace: inst.Namespace}, foundSecret)
 	if err != nil {
 		log.Error(err, "GitRepo secret was not found.")
 		return nil, err
@@ -181,7 +186,7 @@ func SyncGit(inst *ospdirectorv1beta1.OpenStackConfigGenerator, client client.Cl
 					if err != nil {
 						return nil, err
 					}
-					patch, err := commit.PatchContext(context.TODO(), commitLatest)
+					patch, err := commit.PatchContext(ctx, commitLatest)
 
 					filterPatch := Patch{
 						message:     patch.Message(),

--- a/pkg/openstackipset/funcs.go
+++ b/pkg/openstackipset/funcs.go
@@ -21,6 +21,7 @@ import (
 // EnsureIPs - Creates IPSet and verify/wait for IPs created
 //
 func EnsureIPs(
+	ctx context.Context,
 	r common.ReconcilerCommon,
 	obj client.Object,
 	cond *ospdirectorv1beta1.Condition,
@@ -39,6 +40,7 @@ func EnsureIPs(
 	// create IPSet to request IPs for all networks
 	//
 	_, err := createOrUpdateIPSet(
+		ctx,
 		r,
 		obj,
 		cond,
@@ -58,7 +60,7 @@ func EnsureIPs(
 	// get ipset and verify all IPs got created
 	//
 	ipSet := &ospdirectorv1beta1.OpenStackIPSet{}
-	err = r.GetClient().Get(context.TODO(), types.NamespacedName{
+	err = r.GetClient().Get(ctx, types.NamespacedName{
 		Name:      strings.ToLower(name),
 		Namespace: obj.GetNamespace()},
 		ipSet)
@@ -97,7 +99,7 @@ func EnsureIPs(
 	// get OSNetCfg object
 	//
 	osnetcfg := &ospdirectorv1beta1.OpenStackNetConfig{}
-	err = r.GetClient().Get(context.TODO(), types.NamespacedName{
+	err = r.GetClient().Get(ctx, types.NamespacedName{
 		Name:      strings.ToLower(obj.GetLabels()[openstacknetconfig.OpenStackNetConfigReconcileLabel]),
 		Namespace: obj.GetNamespace()},
 		osnetcfg)
@@ -134,6 +136,7 @@ func EnsureIPs(
 // createOrUpdateIPSet - Creates or updates IPSet
 //
 func createOrUpdateIPSet(
+	ctx context.Context,
 	r common.ReconcilerCommon,
 	obj client.Object,
 	cond *ospdirectorv1beta1.Condition,
@@ -153,7 +156,7 @@ func createOrUpdateIPSet(
 		},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.GetClient(), ipSet, func() error {
+	op, err := controllerutil.CreateOrPatch(ctx, r.GetClient(), ipSet, func() error {
 		ipSet.Labels = common.MergeStringMaps(
 			ipSet.Labels,
 			common.GetLabels(obj, controlplane.AppLabel, map[string]string{}),

--- a/pkg/openstacknet/funcs.go
+++ b/pkg/openstacknet/funcs.go
@@ -17,12 +17,16 @@ import (
 )
 
 // GetOpenStackNetsBindingMap - Returns map of OpenStackNet name to binding type
-func GetOpenStackNetsBindingMap(r common.ReconcilerCommon, namespace string) (map[string]ospdirectorv1beta1.AttachType, error) {
+func GetOpenStackNetsBindingMap(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+) (map[string]ospdirectorv1beta1.AttachType, error) {
 
 	//
 	// Acquire a list and map of all OpenStackNetworks available in this namespace
 	//
-	osNetList, err := GetOpenStackNetsWithLabel(r, namespace, map[string]string{})
+	osNetList, err := GetOpenStackNetsWithLabel(ctx, r, namespace, map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +41,7 @@ func GetOpenStackNetsBindingMap(r common.ReconcilerCommon, namespace string) (ma
 		// get osnetattachment used by this network
 		//
 		attachType, err := openstacknetattachment.GetOpenStackNetAttachmentType(
+			ctx,
 			r,
 			namespace,
 			osNet.Spec.AttachConfiguration,
@@ -52,7 +57,12 @@ func GetOpenStackNetsBindingMap(r common.ReconcilerCommon, namespace string) (ma
 }
 
 // GetOpenStackNetsWithLabel - Return a list of all OpenStackNets in the namespace that have (optional) labels
-func GetOpenStackNetsWithLabel(r common.ReconcilerCommon, namespace string, labelSelector map[string]string) (*ospdirectorv1beta1.OpenStackNetList, error) {
+func GetOpenStackNetsWithLabel(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	labelSelector map[string]string,
+) (*ospdirectorv1beta1.OpenStackNetList, error) {
 	osNetList := &ospdirectorv1beta1.OpenStackNetList{}
 
 	listOpts := []client.ListOption{
@@ -64,7 +74,7 @@ func GetOpenStackNetsWithLabel(r common.ReconcilerCommon, namespace string, labe
 		listOpts = append(listOpts, labels)
 	}
 
-	if err := r.GetClient().List(context.Background(), osNetList, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, osNetList, listOpts...); err != nil {
 		return nil, err
 	}
 
@@ -72,9 +82,15 @@ func GetOpenStackNetsWithLabel(r common.ReconcilerCommon, namespace string, labe
 }
 
 // GetOpenStackNetWithLabel - Return OpenStackNet with labels
-func GetOpenStackNetWithLabel(r common.ReconcilerCommon, namespace string, labelSelector map[string]string) (*ospdirectorv1beta1.OpenStackNet, error) {
+func GetOpenStackNetWithLabel(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	labelSelector map[string]string,
+) (*ospdirectorv1beta1.OpenStackNet, error) {
 
 	osNetList, err := GetOpenStackNetsWithLabel(
+		ctx,
 		r,
 		namespace,
 		labelSelector,
@@ -92,11 +108,13 @@ func GetOpenStackNetWithLabel(r common.ReconcilerCommon, namespace string, label
 
 // GetOpenStackNetsMapWithLabel - Return a map[NameLower] of all OpenStackNets in the namespace that have (optional) labels
 func GetOpenStackNetsMapWithLabel(
+	ctx context.Context,
 	r common.ReconcilerCommon,
 	namespace string,
 	labelSelector map[string]string,
 ) (map[string]ospdirectorv1beta1.OpenStackNet, error) {
 	osNetList, err := GetOpenStackNetsWithLabel(
+		ctx,
 		r,
 		namespace,
 		labelSelector,

--- a/pkg/openstacknet/sriov.go
+++ b/pkg/openstacknet/sriov.go
@@ -9,13 +9,18 @@ import (
 )
 
 // GetSriovNetworksWithLabel - Returns list of sriovnetworks labeled with labelSelector
-func GetSriovNetworksWithLabel(r common.ReconcilerCommon, labelSelector map[string]string, namespace string) (map[string]sriovnetworkv1.SriovNetwork, error) {
+func GetSriovNetworksWithLabel(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	labelSelector map[string]string,
+	namespace string,
+) (map[string]sriovnetworkv1.SriovNetwork, error) {
 	sriovNetworks := &sriovnetworkv1.SriovNetworkList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(namespace),
 		client.MatchingLabels(labelSelector),
 	}
-	if err := r.GetClient().List(context.Background(), sriovNetworks, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, sriovNetworks, listOpts...); err != nil {
 		return nil, err
 	}
 
@@ -29,13 +34,18 @@ func GetSriovNetworksWithLabel(r common.ReconcilerCommon, labelSelector map[stri
 }
 
 // GetSriovNetworkNodePoliciesWithLabel - Returns list of sriovnetworknodepolicies labeled with labelSelector
-func GetSriovNetworkNodePoliciesWithLabel(r common.ReconcilerCommon, labelSelector map[string]string, namespace string) (map[string]sriovnetworkv1.SriovNetworkNodePolicy, error) {
+func GetSriovNetworkNodePoliciesWithLabel(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	labelSelector map[string]string,
+	namespace string,
+) (map[string]sriovnetworkv1.SriovNetworkNodePolicy, error) {
 	sriovNetworkNodePolicies := &sriovnetworkv1.SriovNetworkNodePolicyList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(namespace),
 		client.MatchingLabels(labelSelector),
 	}
-	if err := r.GetClient().List(context.Background(), sriovNetworkNodePolicies, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, sriovNetworkNodePolicies, listOpts...); err != nil {
 		return nil, err
 	}
 

--- a/pkg/openstacknetattachment/funcs.go
+++ b/pkg/openstacknetattachment/funcs.go
@@ -16,8 +16,14 @@ import (
 //
 // GetOpenStackNetAttachmentWithLabel - Return OpenStackNet with labels
 //
-func GetOpenStackNetAttachmentWithLabel(r common.ReconcilerCommon, namespace string, labelSelector map[string]string) (*ospdirectorv1beta1.OpenStackNetAttachment, error) {
+func GetOpenStackNetAttachmentWithLabel(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	labelSelector map[string]string,
+) (*ospdirectorv1beta1.OpenStackNetAttachment, error) {
 	osNetAttachList, err := GetOpenStackNetAttachmentsWithLabel(
+		ctx,
 		r,
 		namespace,
 		labelSelector,
@@ -34,7 +40,12 @@ func GetOpenStackNetAttachmentWithLabel(r common.ReconcilerCommon, namespace str
 }
 
 // GetOpenStackNetAttachmentsWithLabel - Return a list of all OpenStackNetAttachmentss in the namespace that have (optional) labels
-func GetOpenStackNetAttachmentsWithLabel(r common.ReconcilerCommon, namespace string, labelSelector map[string]string) (*ospdirectorv1beta1.OpenStackNetAttachmentList, error) {
+func GetOpenStackNetAttachmentsWithLabel(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	labelSelector map[string]string,
+) (*ospdirectorv1beta1.OpenStackNetAttachmentList, error) {
 	osNetAttachList := &ospdirectorv1beta1.OpenStackNetAttachmentList{}
 
 	listOpts := []client.ListOption{
@@ -46,7 +57,7 @@ func GetOpenStackNetAttachmentsWithLabel(r common.ReconcilerCommon, namespace st
 		listOpts = append(listOpts, labels)
 	}
 
-	if err := r.GetClient().List(context.Background(), osNetAttachList, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, osNetAttachList, listOpts...); err != nil {
 		return nil, err
 	}
 
@@ -54,8 +65,14 @@ func GetOpenStackNetAttachmentsWithLabel(r common.ReconcilerCommon, namespace st
 }
 
 // GetOpenStackNetAttachmentWithAttachReference - Return OpenStackNetAttachment for the reference name use in the osnet config
-func GetOpenStackNetAttachmentWithAttachReference(r common.ReconcilerCommon, namespace string, attachReference string) (*ospdirectorv1beta1.OpenStackNetAttachment, error) {
+func GetOpenStackNetAttachmentWithAttachReference(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	attachReference string,
+) (*ospdirectorv1beta1.OpenStackNetAttachment, error) {
 	osNetAttach, err := GetOpenStackNetAttachmentWithLabel(
+		ctx,
 		r,
 		namespace,
 		map[string]string{
@@ -70,9 +87,15 @@ func GetOpenStackNetAttachmentWithAttachReference(r common.ReconcilerCommon, nam
 }
 
 // GetOpenStackNetAttachmentType - Return type of OpenStackNetAttachment, either bridge or sriov
-func GetOpenStackNetAttachmentType(r common.ReconcilerCommon, namespace string, attachReference string) (*ospdirectorv1beta1.AttachType, error) {
+func GetOpenStackNetAttachmentType(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	attachReference string,
+) (*ospdirectorv1beta1.AttachType, error) {
 
 	osNetAttach, err := GetOpenStackNetAttachmentWithAttachReference(
+		ctx,
 		r,
 		namespace,
 		attachReference,
@@ -85,9 +108,15 @@ func GetOpenStackNetAttachmentType(r common.ReconcilerCommon, namespace string, 
 }
 
 // GetOpenStackNetAttachmentBridgeName - Return name of the Bridge configured by the OpenStackNetAttachment
-func GetOpenStackNetAttachmentBridgeName(r common.ReconcilerCommon, namespace string, attachReference string) (string, error) {
+func GetOpenStackNetAttachmentBridgeName(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	namespace string,
+	attachReference string,
+) (string, error) {
 
 	osNetAttach, err := GetOpenStackNetAttachmentWithAttachReference(
+		ctx,
 		r,
 		namespace,
 		attachReference,

--- a/pkg/openstacknetattachment/sriov.go
+++ b/pkg/openstacknetattachment/sriov.go
@@ -9,13 +9,19 @@ import (
 )
 
 // GetSriovNetworksWithLabel - Returns list of sriovnetworks labeled with labelSelector
-func GetSriovNetworksWithLabel(r common.ReconcilerCommon, labelSelector map[string]string, namespace string) (map[string]sriovnetworkv1.SriovNetwork, error) {
+func GetSriovNetworksWithLabel(
+	ctx context.Context,
+
+	r common.ReconcilerCommon,
+	labelSelector map[string]string,
+	namespace string,
+) (map[string]sriovnetworkv1.SriovNetwork, error) {
 	sriovNetworks := &sriovnetworkv1.SriovNetworkList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(namespace),
 		client.MatchingLabels(labelSelector),
 	}
-	if err := r.GetClient().List(context.Background(), sriovNetworks, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, sriovNetworks, listOpts...); err != nil {
 		return nil, err
 	}
 
@@ -29,13 +35,18 @@ func GetSriovNetworksWithLabel(r common.ReconcilerCommon, labelSelector map[stri
 }
 
 // GetSriovNetworkNodePoliciesWithLabel - Returns list of sriovnetworknodepolicies labeled with labelSelector
-func GetSriovNetworkNodePoliciesWithLabel(r common.ReconcilerCommon, labelSelector map[string]string, namespace string) (map[string]sriovnetworkv1.SriovNetworkNodePolicy, error) {
+func GetSriovNetworkNodePoliciesWithLabel(
+	ctx context.Context,
+	r common.ReconcilerCommon,
+	labelSelector map[string]string,
+	namespace string,
+) (map[string]sriovnetworkv1.SriovNetworkNodePolicy, error) {
 	sriovNetworkNodePolicies := &sriovnetworkv1.SriovNetworkNodePolicyList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(namespace),
 		client.MatchingLabels(labelSelector),
 	}
-	if err := r.GetClient().List(context.Background(), sriovNetworkNodePolicies, listOpts...); err != nil {
+	if err := r.GetClient().List(ctx, sriovNetworkNodePolicies, listOpts...); err != nil {
 		return nil, err
 	}
 

--- a/pkg/openstacknetconfig/funcs.go
+++ b/pkg/openstacknetconfig/funcs.go
@@ -1,6 +1,7 @@
 package openstacknetconfig
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 // the in the osnetcfg controller to watch this resource and reconcile
 //
 func AddOSNetConfigRefLabel(
+	ctx context.Context,
 	r common.ReconcilerCommon,
 	obj client.Object,
 	cond *ospdirectorv1beta1.Condition,
@@ -38,7 +40,7 @@ func AddOSNetConfigRefLabel(
 		labelSelector := map[string]string{
 			openstacknet.SubNetNameLabelSelector: subnetName,
 		}
-		osnet, err := openstacknet.GetOpenStackNetWithLabel(r, obj.GetNamespace(), labelSelector)
+		osnet, err := openstacknet.GetOpenStackNetWithLabel(ctx, r, obj.GetNamespace(), labelSelector)
 		if err != nil && k8s_errors.IsNotFound(err) {
 			cond.Message = fmt.Sprintf("OpenStackNet %s not found reconcile again in 10 seconds", subnetName)
 			cond.Reason = ospdirectorv1beta1.ConditionReason(ospdirectorv1beta1.CommonCondReasonOSNetNotFound)


### PR DESCRIPTION
This changes to create/update resources from CreateOrUpdate to
CreateOrPatch. CreateOrPatch only performs the patch if the before
and after resources (minus status) differ. This should reduce the
amount of updates performed on the CR objects.
    
[1] https://github.com/kubernetes-sigs/controller-runtime/blob/v0.9.7/pkg/controller/controllerutil/controllerutil.go#L232

Also adds context parameter to methods/funcs where used and passes
the ctx from main reconcile method.