### PR TITLE
Add missing example annotations to CSV

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -7,10 +7,15 @@ resources:
 - osp-director_v1beta1_openstackclient.yaml
 - osp-director_v1beta1_openstacknet.yaml
 - osp-director_v1beta1_openstackconfiggenerator.yaml
+- osp-director_v1beta1_openstackconfigversion.yaml
 - osp-director_v1beta1_openstacknetconfig.yaml
 - osp-director_v1beta1_openstacknetattachment.yaml
 - osp-director_v1beta1_openstackdeploy.yaml
 - osp-director_v1beta1_openstackipset.yaml
+- osp-director_v1beta1_openstackephemeralheat.yaml
+- osp-director_v1beta1_openstackmacaddress.yaml
+- osp-director_v1beta1_openstackbackuprequest.yaml
+- osp-director_v1beta1_openstackbackup.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples
 # These patches will "correct" some values for samples injected into the CSV,
 # but leave the samples as-is for functional testing purposes


### PR DESCRIPTION
This adds several missing CRDs into the bundle annotations