### PR TITLE
Mark macaddresses, and ipset as internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ The OSP Director Operator creates a set of Custom Resource Definitions on top of
 
 Hardware Provisioning CRDs
 --------------------------
-- openstacknetattachment: manages NodeNetworkConfigurationPolicy and NodeSriovConfigurationPolicy used to attach networks to virtual machines
+- openstacknetattachment: (internal) manages NodeNetworkConfigurationPolicy and NodeSriovConfigurationPolicy used to attach networks to virtual machines
 - openstacknetconfig: high level CRD to specify openstacknetattachments and openstacknets to describe the full network configuration. The set of reserved IP/MAC addresses per node are reflected in the status.
 - openstackbaremetalset: create sets of baremetal hosts for a specific TripleO role (Compute, Storage, etc.)
 - openstackcontrolplane: A CRD used to create the OpenStack control plane and manage associated openstackvmsets
-- openstacknet: Create networks which are used to assign IPs to the vmset and baremetalset resources below
-- openstackipset: Contains a set of IPs for a given network and role. Used internally to manage IP addresses.
+- openstacknet: (internal) Create networks which are used to assign IPs to the vmset and baremetalset resources below
+- openstackipset: (internal) Contains a set of IPs for a given network and role. Used internally to manage IP addresses.
 - openstackprovisionservers: used to serve custom images for baremetal provisioning with Metal3
 - openstackvmset: create sets of VMs using OpenShift Virtualization for a specific TripleO role (Controller, Database, NetworkController, etc.)
 

--- a/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operatorframework.io/suggested-namespace: openstack
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
-    operators.operatorframework.io/internal-objects: '["openstacknetattachments.osp-director.openstack.org","openstacknets.osp-director.openstack.org","openstackprovisionservers.osp-director.openstack.org","openstackephemeralheats.osp-director.openstack.org"]'
+    operators.operatorframework.io/internal-objects: '["openstacknetattachments.osp-director.openstack.org","openstacknets.osp-director.openstack.org","openstackprovisionservers.osp-director.openstack.org","openstackephemeralheats.osp-director.openstack.org","openstackmacaddresses.osp-director.openstack.org","openstackipsets.osp-director.openstack.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: osp-director-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
This updates the CSV and Readme so that these are marked
as internal.

Also updates the README so that netattachements are identified
as internal there (these are already marked as such in the CSV)