### PR TITLE
Add osnetcfg and osnet labels via webhook and validations + fix kuttl

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -23,6 +23,7 @@ resources:
   path: github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - controller: true
@@ -42,6 +43,7 @@ resources:
   path: github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - controller: true
@@ -177,4 +179,8 @@ resources:
   kind: OpenStackIPSet
   path: github.com/openstack-k8s-operators/osp-director-operator/api/v1beta1
   version: v1beta1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/api/v1beta1/common_funcs.go
+++ b/api/v1beta1/common_funcs.go
@@ -1,0 +1,21 @@
+package v1beta1
+
+// MergeStringMaps - merge two or more string->map maps
+func MergeStringMaps(baseMap map[string]string, extraMaps ...map[string]string) map[string]string {
+	InitMap(&baseMap)
+
+	for _, extraMap := range extraMaps {
+		for key, value := range extraMap {
+			baseMap[key] = value
+		}
+	}
+
+	return baseMap
+}
+
+// InitMap - Inititialise a map to an empty map if it is nil.
+func InitMap(m *map[string]string) {
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+}

--- a/api/v1beta1/common_openstacknet.go
+++ b/api/v1beta1/common_openstacknet.go
@@ -1,0 +1,233 @@
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/apps/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//
+// AddOSNetNameLowerLabels - add osnetcfg CR label reference which is used in
+// the in the osnetcfg controller to watch this resource and reconcile
+//
+func AddOSNetNameLowerLabels(
+	log logr.Logger,
+	labels map[string]string,
+	networkNameLowerNames []string,
+) map[string]string {
+	osNetLabels := map[string]string{}
+	removedOsNets := map[string]bool{}
+	newOsNets := map[string]bool{}
+	networkNameLowerNamesMap := map[string]bool{}
+
+	for _, n := range networkNameLowerNames {
+		label := fmt.Sprintf("%s/%s", SubNetNameLabelSelector, n)
+		networkNameLowerNamesMap[label] = true
+	}
+
+	//
+	// get current osNet Labels and verify if nets got removed
+	//
+	for _, label := range reflect.ValueOf(labels).MapKeys() {
+		//
+		// has label key SubNetNameLabelSelector string included?
+		//
+		if strings.HasSuffix(label.String(), SubNetNameLabelSelector) {
+			l := label.String()
+			osNetLabels[l] = labels[l]
+
+			//
+			// if l is not in networkNameLowerNamesMap it got removed
+			//
+			if _, ok := networkNameLowerNamesMap[l]; !ok {
+				delete(labels, l)
+				removedOsNets[l] = true
+
+			}
+		}
+	}
+
+	if len(newOsNets) > 0 {
+		controlplanelog.Info(fmt.Sprintf("removing network labels: %v",
+			removedOsNets,
+		))
+	}
+
+	//
+	// identify if nets got added
+	//
+	for label := range networkNameLowerNamesMap {
+		//
+		// if label is not in osNetLabels its a new one
+		//
+		if _, ok := osNetLabels[label]; !ok {
+			labels[label] = strconv.FormatBool(true)
+			newOsNets[label] = true
+		}
+
+	}
+
+	if len(newOsNets) > 0 {
+		controlplanelog.Info(fmt.Sprintf("adding network labels: %v",
+			newOsNets,
+		))
+	}
+
+	return labels
+}
+
+//
+// AddOSNetConfigRefLabel - add osnetcfg CR label reference which is used in
+// the in the osnetcfg controller to watch this resource and reconcile
+//
+func AddOSNetConfigRefLabel(
+	namespace string,
+	subnetName string,
+	labels map[string]string,
+) (map[string]string, error) {
+
+	//
+	// Get OSnet with SubNetNameLabelSelector: subnetName
+	//
+	labelSelector := map[string]string{
+		SubNetNameLabelSelector: subnetName,
+	}
+	osnet, err := GetOpenStackNetWithLabel(namespace, labelSelector)
+	if err != nil && k8s_errors.IsNotFound(err) {
+		return labels, fmt.Errorf(fmt.Sprintf("OpenStackNet %s not found reconcile again in 10 seconds", subnetName))
+	} else if err != nil {
+		return labels, fmt.Errorf(fmt.Sprintf("Failed to get OpenStackNet %s ", subnetName))
+	}
+
+	//
+	// get ownerReferences entry with Kind OpenStackNetConfig
+	//
+	for _, ownerRef := range osnet.ObjectMeta.OwnerReferences {
+		if ownerRef.Kind == "OpenStackNetConfig" {
+			//
+			// merge with obj labels
+			//
+			labels = MergeStringMaps(
+				labels,
+				map[string]string{
+					OpenStackNetConfigReconcileLabel: ownerRef.Name,
+				},
+			)
+
+			break
+		}
+	}
+
+	return labels, nil
+}
+
+// GetOpenStackNetsWithLabel - Return a list of all OpenStackNets in the namespace that have (optional) labels
+func GetOpenStackNetsWithLabel(
+	namespace string,
+	labelSelector map[string]string,
+) (*OpenStackNetList, error) {
+	osNetList := &OpenStackNetList{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+
+	if len(labelSelector) > 0 {
+		labels := client.MatchingLabels(labelSelector)
+		listOpts = append(listOpts, labels)
+	}
+
+	if err := webhookClient.List(context.TODO(), osNetList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	return osNetList, nil
+}
+
+// GetOpenStackNetWithLabel - Return OpenStackNet with labels
+func GetOpenStackNetWithLabel(
+	namespace string,
+	labelSelector map[string]string,
+) (*OpenStackNet, error) {
+
+	osNetList, err := GetOpenStackNetsWithLabel(
+		namespace,
+		labelSelector,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(osNetList.Items) == 0 {
+		return nil, k8s_errors.NewNotFound(v1.Resource("openstacknet"), fmt.Sprint(labelSelector))
+	} else if len(osNetList.Items) > 1 {
+		return nil, fmt.Errorf("multiple OpenStackNet with label %v not found", labelSelector)
+	}
+	return &osNetList.Items[0], nil
+}
+
+// GetOpenStackNetsMapWithLabel - Return a map[NameLower] of all OpenStackNets in the namespace that have (optional) labels
+func GetOpenStackNetsMapWithLabel(
+	namespace string,
+	labelSelector map[string]string,
+) (map[string]OpenStackNet, error) {
+	osNetList, err := GetOpenStackNetsWithLabel(
+		namespace,
+		labelSelector,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	osNetMap := map[string]OpenStackNet{}
+	for _, osNet := range osNetList.Items {
+		osNetMap[osNet.Spec.NameLower] = osNet
+	}
+
+	return osNetMap, nil
+}
+
+// CreateVIPNetworkList - return list of all networks from all VM roles which has vip flag
+func CreateVIPNetworkList(
+	instance *OpenStackControlPlane,
+) ([]string, error) {
+
+	// create uniq list networls of all VirtualMachineRoles
+	networkList := make(map[string]bool)
+	uniqNetworksList := []string{}
+
+	for _, vmRole := range instance.Spec.VirtualMachineRoles {
+		for _, netNameLower := range vmRole.Networks {
+			// get network with name_lower label
+			labelSelector := map[string]string{
+				SubNetNameLabelSelector: netNameLower,
+			}
+
+			// get network with name_lower label to verify if VIP needs to be requested from Spec
+			network, err := GetOpenStackNetWithLabel(
+				instance.Namespace,
+				labelSelector,
+			)
+			if err != nil {
+				if k8s_errors.IsNotFound(err) {
+					return uniqNetworksList, fmt.Errorf(fmt.Sprintf("OpenStackNet with NameLower %s not found!", netNameLower))
+				}
+				// Error reading the object - requeue the request.
+				return uniqNetworksList, fmt.Errorf(fmt.Sprintf("Error getting OSNet with labelSelector %v", labelSelector))
+			}
+
+			if _, value := networkList[netNameLower]; !value && network.Spec.VIP {
+				networkList[netNameLower] = true
+				uniqNetworksList = append(uniqNetworksList, netNameLower)
+			}
+		}
+	}
+
+	return uniqNetworksList, nil
+}

--- a/api/v1beta1/common_openstacknet.go
+++ b/api/v1beta1/common_openstacknet.go
@@ -167,7 +167,7 @@ func GetOpenStackNetWithLabel(
 	if len(osNetList.Items) == 0 {
 		return nil, k8s_errors.NewNotFound(v1.Resource("openstacknet"), fmt.Sprint(labelSelector))
 	} else if len(osNetList.Items) > 1 {
-		return nil, fmt.Errorf("multiple OpenStackNet with label %v not found", labelSelector)
+		return nil, fmt.Errorf("multiple OpenStackNet with label %v found", labelSelector)
 	}
 	return &osNetList.Items[0], nil
 }

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -122,6 +122,22 @@ const (
 	CommonCondReasonCIDRParseError ConditionReason = "CIDRParseError"
 	// CommonCondReasonServiceNotFound - service not found
 	CommonCondReasonServiceNotFound ConditionReason = "ServiceNotFound"
+
+	//
+	// LabelSelectors
+	//
+
+	// NetworkNameLabelSelector -
+	NetworkNameLabelSelector = "ooo-netname"
+	// NetworkNameLowerLabelSelector -
+	NetworkNameLowerLabelSelector = "ooo-netname-lower"
+	// SubNetNameLabelSelector -
+	SubNetNameLabelSelector = "ooo-subnetname"
+	// ControlPlaneNetworkLabelSelector - is the network a ctlplane network?
+	ControlPlaneNetworkLabelSelector = "ooo-ctlplane-network"
+	// OpenStackNetConfigReconcileLabel - label set on objects on which change
+	// trigger a reconcile of the osnetconfig
+	OpenStackNetConfigReconcileLabel = "osnetconfig-reconcile-dep"
 )
 
 // Hash - struct to add hashes to status

--- a/api/v1beta1/common_webhook.go
+++ b/api/v1beta1/common_webhook.go
@@ -128,7 +128,7 @@ func validateNetworks(namespace string, networks []string) error {
 		}
 		osnet, err := GetOpenStackNetWithLabel(namespace, labelSelector)
 		if err != nil && k8s_errors.IsNotFound(err) {
-			return fmt.Errorf(fmt.Sprintf("%s %s instance is supported at this time", osnet.GetObjectKind().GroupVersionKind().Kind, subnetName))
+			return fmt.Errorf(fmt.Sprintf("%s %s not found, validate the object network list!", osnet.GetObjectKind().GroupVersionKind().Kind, subnetName))
 		} else if err != nil {
 			return fmt.Errorf(fmt.Sprintf("Failed to get %s %s", osnet.Kind, subnetName))
 		}

--- a/api/v1beta1/openstackbaremetalset_types.go
+++ b/api/v1beta1/openstackbaremetalset_types.go
@@ -27,6 +27,7 @@ type HardwareReqType string
 type OpenStackBaremetalSetSpec struct {
 	// Count The number of baremetalhosts to attempt to aquire
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
 	Count int `json:"count,omitempty"`
 	// Remote URL pointing to desired RHEL qcow2 image
 	BaseImageURL string `json:"baseImageUrl,omitempty"`

--- a/api/v1beta1/openstackbaremetalset_webhook.go
+++ b/api/v1beta1/openstackbaremetalset_webhook.go
@@ -24,6 +24,7 @@ package v1beta1
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -56,12 +57,26 @@ func (r *OpenStackBaremetalSet) ValidateCreate() error {
 		return err
 	}
 
+	//
+	// validate that for all configured subnets an osnet exists
+	//
+	if err := validateNetworks(r.GetNamespace(), r.Spec.Networks); err != nil {
+		return err
+	}
+
 	return r.validateCr()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *OpenStackBaremetalSet) ValidateUpdate(old runtime.Object) error {
 	baremetalsetlog.Info("validate update", "name", r.Name)
+
+	//
+	// validate that for all configured subnets an osnet exists
+	//
+	if err := validateNetworks(r.GetNamespace(), r.Spec.Networks); err != nil {
+		return err
+	}
 
 	return r.validateCr()
 
@@ -72,6 +87,52 @@ func (r *OpenStackBaremetalSet) ValidateDelete() error {
 	baremetalsetlog.Info("validate delete", "name", r.Name)
 
 	return checkBackupOperationBlocksAction(r.Namespace, APIActionDelete)
+}
+
+//+kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstackbaremetalset,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackbaremetalsets,verbs=create;update,versions=v1beta1,name=mopenstackbaremetalset.kb.io,admissionReviewVersions={v1,v1beta1}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *OpenStackBaremetalSet) Default() {
+	baremetalsetlog.Info("default", "name", r.Name)
+
+	//
+	// set OpenStackNetConfig reference label if not already there
+	// Note, any rename of the osnetcfg won't be reflected
+	//
+	if _, ok := r.GetLabels()[OpenStackNetConfigReconcileLabel]; !ok {
+		labels, err := AddOSNetConfigRefLabel(
+			r.Namespace,
+			r.Spec.Networks[0],
+			r.DeepCopy().GetLabels(),
+		)
+		if err != nil {
+			baremetalsetlog.Error(err, fmt.Sprintf("error adding OpenStackNetConfig reference label on %s - %s: %s", r.Kind, r.Name, err))
+		}
+		if !equality.Semantic.DeepEqual(
+			labels,
+			r.GetLabels(),
+		) {
+			r.SetLabels(labels)
+			baremetalsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
+		}
+	}
+
+	//
+	// add labels of all networks used by this CR
+	//
+	labels := AddOSNetNameLowerLabels(
+		baremetalsetlog,
+		r.DeepCopy().GetLabels(),
+		r.Spec.Networks,
+	)
+	if !equality.Semantic.DeepEqual(
+		labels,
+		r.GetLabels(),
+	) {
+		r.SetLabels(labels)
+		baremetalsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
+	}
+
 }
 
 func (r *OpenStackBaremetalSet) validateCr() error {
@@ -87,7 +148,7 @@ func (r *OpenStackBaremetalSet) validateCr() error {
 }
 func (r *OpenStackBaremetalSet) checkBaseImageReqs() error {
 	if r.Spec.BaseImageURL == "" && r.Spec.ProvisionServerName == "" {
-		return fmt.Errorf("Either \"baseImageUrl\" or \"provisionServerName\" must be provided")
+		return fmt.Errorf("either \"baseImageUrl\" or \"provisionServerName\" must be provided")
 	}
 
 	return nil

--- a/api/v1beta1/openstackbaremetalset_webhook.go
+++ b/api/v1beta1/openstackbaremetalset_webhook.go
@@ -108,13 +108,9 @@ func (r *OpenStackBaremetalSet) Default() {
 		if err != nil {
 			baremetalsetlog.Error(err, fmt.Sprintf("error adding OpenStackNetConfig reference label on %s - %s: %s", r.Kind, r.Name, err))
 		}
-		if !equality.Semantic.DeepEqual(
-			labels,
-			r.GetLabels(),
-		) {
-			r.SetLabels(labels)
-			baremetalsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
-		}
+
+		r.SetLabels(labels)
+		baremetalsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
 	}
 
 	//

--- a/api/v1beta1/openstackclient_webhook.go
+++ b/api/v1beta1/openstackclient_webhook.go
@@ -71,13 +71,9 @@ func (r *OpenStackClient) Default() {
 		if err != nil {
 			openstackclientlog.Error(err, fmt.Sprintf("error adding OpenStackNetConfig reference label on %s - %s: %s", r.Kind, r.Name, err))
 		}
-		if !equality.Semantic.DeepEqual(
-			labels,
-			r.GetLabels(),
-		) {
-			r.SetLabels(labels)
-			openstackclientlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
-		}
+
+		r.SetLabels(labels)
+		openstackclientlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
 	}
 
 	//

--- a/api/v1beta1/openstackcontrolplane_webhook.go
+++ b/api/v1beta1/openstackcontrolplane_webhook.go
@@ -201,13 +201,9 @@ func (r *OpenStackControlPlane) Default() {
 		if err != nil {
 			controlplanelog.Error(err, fmt.Sprintf("error adding OpenStackNetConfig reference label on %s - %s: %s", r.Kind, r.Name, err))
 		}
-		if !equality.Semantic.DeepEqual(
-			labels,
-			r.GetLabels(),
-		) {
-			r.SetLabels(labels)
-			controlplanelog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
-		}
+
+		r.SetLabels(labels)
+		controlplanelog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
 	}
 
 	//

--- a/api/v1beta1/openstackipset_webhook.go
+++ b/api/v1beta1/openstackipset_webhook.go
@@ -1,0 +1,95 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var openstackipsetlog = logf.Log.WithName("openstackipset-resource")
+
+// SetupWebhookWithManager - register this webhook with the controller manager
+func (r *OpenStackIPSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
+
+	if webhookClient == nil {
+		webhookClient = mgr.GetClient()
+	}
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstackipset,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackipsets,verbs=create;update,versions=v1beta1,name=mopenstackipset.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Defaulter = &OpenStackIPSet{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *OpenStackIPSet) Default() {
+	openstackipsetlog.Info("default", "name", r.Name)
+
+	//
+	// set OpenStackNetConfig reference label if not already there
+	// Note, any rename of the osnetcfg won't be reflected
+	//
+	if _, ok := r.GetLabels()[OpenStackNetConfigReconcileLabel]; !ok {
+		labels, err := AddOSNetConfigRefLabel(
+			r.Namespace,
+			r.Spec.Networks[0],
+			r.GetLabels(),
+		)
+		if err != nil {
+			controlplanelog.Error(err, fmt.Sprintf("error adding OpenStackNetConfig reference label on %s - %s: %s", r.Kind, r.Name, err))
+		}
+		r.SetLabels(labels)
+	}
+}
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-osp-director-openstack-org-v1beta1-openstackipset,mutating=false,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackipsets,verbs=create;update,versions=v1beta1,name=vopenstackipset.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Validator = &OpenStackIPSet{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *OpenStackIPSet) ValidateCreate() error {
+	openstackipsetlog.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *OpenStackIPSet) ValidateUpdate(old runtime.Object) error {
+	openstackipsetlog.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *OpenStackIPSet) ValidateDelete() error {
+	openstackipsetlog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}

--- a/api/v1beta1/openstackvmset_webhook.go
+++ b/api/v1beta1/openstackvmset_webhook.go
@@ -107,13 +107,9 @@ func (r *OpenStackVMSet) Default() {
 		if err != nil {
 			vmsetlog.Error(err, fmt.Sprintf("error adding OpenStackNetConfig reference label on %s - %s: %s", r.Kind, r.Name, err))
 		}
-		if !equality.Semantic.DeepEqual(
-			labels,
-			r.GetLabels(),
-		) {
-			r.SetLabels(labels)
-			vmsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
-		}
+
+		r.SetLabels(labels)
+		vmsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
 	}
 
 	//

--- a/api/v1beta1/openstackvmset_webhook.go
+++ b/api/v1beta1/openstackvmset_webhook.go
@@ -22,6 +22,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -54,12 +57,26 @@ func (r *OpenStackVMSet) ValidateCreate() error {
 		return err
 	}
 
+	//
+	// validate that for all configured subnets an osnet exists
+	//
+	if err := validateNetworks(r.GetNamespace(), r.Spec.Networks); err != nil {
+		return err
+	}
+
 	return r.validateCr()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *OpenStackVMSet) ValidateUpdate(old runtime.Object) error {
 	vmsetlog.Info("validate update", "name", r.Name)
+
+	//
+	// validate that for all configured subnets an osnet exists
+	//
+	if err := validateNetworks(r.GetNamespace(), r.Spec.Networks); err != nil {
+		return err
+	}
 
 	return r.validateCr()
 }
@@ -69,6 +86,52 @@ func (r *OpenStackVMSet) ValidateDelete() error {
 	vmsetlog.Info("validate delete", "name", r.Name)
 
 	return checkBackupOperationBlocksAction(r.Namespace, APIActionDelete)
+}
+
+//+kubebuilder:webhook:path=/mutate-osp-director-openstack-org-v1beta1-openstackvmset,mutating=true,failurePolicy=fail,sideEffects=None,groups=osp-director.openstack.org,resources=openstackvmsets,verbs=create;update,versions=v1beta1,name=mopenstackvmset.kb.io,admissionReviewVersions={v1,v1beta1}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *OpenStackVMSet) Default() {
+	vmsetlog.Info("default", "name", r.Name)
+
+	//
+	// set OpenStackNetConfig reference label if not already there
+	// Note, any rename of the osnetcfg won't be reflected
+	//
+	if _, ok := r.GetLabels()[OpenStackNetConfigReconcileLabel]; !ok {
+		labels, err := AddOSNetConfigRefLabel(
+			r.Namespace,
+			r.Spec.Networks[0],
+			r.DeepCopy().GetLabels(),
+		)
+		if err != nil {
+			vmsetlog.Error(err, fmt.Sprintf("error adding OpenStackNetConfig reference label on %s - %s: %s", r.Kind, r.Name, err))
+		}
+		if !equality.Semantic.DeepEqual(
+			labels,
+			r.GetLabels(),
+		) {
+			r.SetLabels(labels)
+			vmsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
+		}
+	}
+
+	//
+	// add labels of all networks used by this CR
+	//
+	labels := AddOSNetNameLowerLabels(
+		vmsetlog,
+		r.DeepCopy().GetLabels(),
+		r.Spec.Networks,
+	)
+	if !equality.Semantic.DeepEqual(
+		labels,
+		r.GetLabels(),
+	) {
+		r.SetLabels(labels)
+		vmsetlog.Info(fmt.Sprintf("%s %s labels set to %v", r.GetObjectKind().GroupVersionKind().Kind, r.Name, r.GetLabels()))
+	}
+
 }
 
 func (r *OpenStackVMSet) validateCr() error {

--- a/api/v1beta1/webhook_suite_test.go
+++ b/api/v1beta1/webhook_suite_test.go
@@ -93,6 +93,9 @@ var _ = BeforeSuite(func() {
 	err = (&OpenStackNetAttachment{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&OpenStackIPSet{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -244,6 +244,7 @@ spec:
                                     type: string
                                   type: array
                                 count:
+                                  default: 0
                                   description: Count The number of baremetalhosts
                                     to attempt to aquire
                                   minimum: 0

--- a/config/crd/bases/osp-director.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbaremetalsets.yaml
@@ -75,6 +75,7 @@ spec:
                   type: string
                 type: array
               count:
+                default: 0
                 description: Count The number of baremetalhosts to attempt to aquire
                 minimum: 0
                 type: integer

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -46,21 +46,20 @@ patchesStrategicMerge:
 # patches here are for enabling the CA injection for each CRD
 - patches/cainjection_in_openstackcontrolplanes.yaml
 - patches/cainjection_in_openstackvmsets.yaml
-#- patches/cainjection_in_openstackprovisionservers.yaml
+- patches/cainjection_in_openstackprovisionservers.yaml
 - patches/cainjection_in_openstackbaremetalsets.yaml
-#- patches/cainjection_in_openstackclients.yaml
+- patches/cainjection_in_openstackclients.yaml
 - patches/cainjection_in_openstacknets.yaml
-#- patches/cainjection_in_openstackpredictableips.yaml
-#- patches/cainjection_in_openstackconfiggenerators.yaml
+- patches/cainjection_in_openstackconfiggenerators.yaml
 - patches/cainjection_in_openstackephemeralheats.yaml
 #- patches/cainjection_in_openstackmacaddresses.yaml
 #- patches/cainjection_in_openstackconfigversions.yaml
 - patches/cainjection_in_openstacknetconfigs.yaml
 - patches/cainjection_in_openstacknetattachments.yaml
-#- patches/cainjection_in_openstackbackups.yaml
-#- patches/cainjection_in_openstackbackuprequests.yaml
+- patches/cainjection_in_openstackbackups.yaml
+- patches/cainjection_in_openstackbackuprequests.yaml
 - patches/cainjection_in_openstackdeploys.yaml
-#- patches/cainjection_in_openstackipsets.yaml
+- patches/cainjection_in_openstackipsets.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
@@ -27,8 +27,8 @@ spec:
       kind: ProvisionServer
       name: openstackprovisionservers.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackBackupRequest is the Schema for the openstackbackuprequests
-        API
+    - description: OpenStackBackupRequest a request to backup the OpenStack Director
+        Operator
       displayName: OpenStack Backup Request
       kind: OpenStackBackupRequest
       name: openstackbackuprequests.osp-director.openstack.org
@@ -58,8 +58,7 @@ spec:
       kind: OpenStackConfigGenerator
       name: openstackconfiggenerators.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackConfigVersion is the Schema for the openstackconfigversions
-        API
+    - description: OpenStackConfigVersion represents a set of executable Ansible playbooks
       displayName: OpenStack Config Version
       kind: OpenStackConfigVersion
       name: openstackconfigversions.osp-director.openstack.org
@@ -70,35 +69,38 @@ spec:
       kind: OpenStackControlPlane
       name: openstackcontrolplanes.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackDeploy is the Schema for the openstackdeploys API
+    - description: OpenStackDeploy executes a set of Ansible playbooks for the supplied
+        OSConfigVersion
       displayName: OpenStack Deploy
       kind: OpenStackDeploy
       name: openstackdeploys.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackEphemeralHeat is the Schema for the openstackephemeralheats
-        API
+    - description: OpenStackEphemeralHeat an ephermeral OpenStack Heat deployment
+        used internally by the OSConfigGenerator to generate Ansible playbooks
       displayName: OpenStack Ephemeral Heat
       kind: OpenStackEphemeralHeat
       name: openstackephemeralheats.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackIPSet is the Schema for the openstackipsets API
+    - description: OpenStackIPSet a resource to request a set of IPs for the given
+        networks
       displayName: OpenStack IPSet
       kind: OpenStackIPSet
       name: openstackipsets.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackMACAddress is the Schema for the openstackmacaddresses
-        API
+    - description: OpenStackMACAddress represents Mac address reservations for static
+        OVN bridge mappings
       displayName: OpenStack MACAddress
       kind: OpenStackMACAddress
       name: openstackmacaddresses.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackNetAttachment is the Schema for the openstacknetattachments
-        API
+    - description: OpenStackNetAttachment are used to describe the node network configuration
+        policy and configured as part of OSNetConfig resources
       displayName: OpenStack NetAttachment
       kind: OpenStackNetAttachment
       name: openstacknetattachments.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackNetConfig is the Schema for the openstacknetconfigs API
+    - description: OpenStackNetConfig high level CRD to specify openstacknetattachments
+        and openstacknets to describe the full network configuration
       displayName: OpenStack NetConfig
       kind: OpenStackNetConfig
       name: openstacknetconfigs.osp-director.openstack.org
@@ -109,8 +111,8 @@ spec:
       kind: OpenStackNet
       name: openstacknets.osp-director.openstack.org
       version: v1beta1
-    - description: OpenStackProvisionServer is the Schema for the openstackprovisionservers
-        API
+    - description: OpenStackProvisionServer used to serve custom images for baremetal
+        provisioning with Metal3
       displayName: OpenStack ProvisionServer
       kind: OpenStackProvisionServer
       name: openstackprovisionservers.osp-director.openstack.org

--- a/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
+++ b/config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
@@ -8,6 +8,8 @@ spec:
   count: 1
   # The image to install on the provisioned nodes
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
+  # use this provisionServerName instead of creating a new one use baseImageUrl
+  provisionServerName: openstack
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys
   # Networks to associate with this host
@@ -21,7 +23,7 @@ spec:
   # to the secret data
   passwordSecret: userpassword
   # The interface on the nodes that will be assigned an IP from the ctlCidr
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp1s0
   # Arbitrary label selector for BaremetalHosts (optional)
   bmhLabelSelector:
     arbitraryKey: arbitraryValue

--- a/config/samples/osp-director_v1beta1_openstacknetconfig.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknetconfig.yaml
@@ -4,6 +4,29 @@ metadata:
   name: openstacknetconfig
 spec:
   attachConfigurations:
+    br-ctlplane:
+      nodeNetworkConfigurationPolicy:
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        desiredState:
+          interfaces:
+          - bridge:
+              options:
+                stp:
+                  enabled: false
+              port:
+              - name: enp1s0
+            description: Linux bridge with enp1s0 as a port
+            name: br-ctlplane
+            type: linux-bridge
+            state: up
+            ipv4:
+              dhcp: true
+              enabled: true
+            ipv6:
+              dhcp: true
+              enabled: true
+            mtu: 1500
     br-osp:
       nodeNetworkConfigurationPolicy:
         nodeSelector:
@@ -18,9 +41,22 @@ spec:
               - name: enp7s0
             description: Linux bridge with enp7s0 as a port
             name: br-osp
-            state: up
             type: linux-bridge
-            mtu: 1500
+            state: up
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
+            mtu: 9000
+          - name: enp7s0
+            description: Configuring enp7s0 on workers
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
+            mtu: 9000
     br-ex:
       nodeNetworkConfigurationPolicy:
         nodeSelector:
@@ -35,23 +71,27 @@ spec:
               - name: enp6s0
             description: Linux bridge with enp6s0 as a port
             name: br-ex
-            state: up
             type: linux-bridge
+            state: up
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
             mtu: 1500
+  dnsServers: ['172.22.0.1']
   networks:
   - name: Control
     nameLower: ctlplane
     subnets:
     - name: ctlplane
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
-      attachConfiguration: br-osp
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
+      attachConfiguration: br-ctlplane
   - name: InternalApi
     nameLower: internal_api
-    mtu: 1350
     subnets:
     - name: internal_api
       ipv4:
@@ -72,7 +112,7 @@ spec:
       attachConfiguration: br-ex
   - name: Storage
     nameLower: storage
-    mtu: 1350
+    mtu: 9000
     subnets:
     - name: storage
       ipv4:
@@ -83,7 +123,6 @@ spec:
       attachConfiguration: br-osp
   - name: StorageMgmt
     nameLower: storage_mgmt
-    mtu: 1350
     subnets:
     - name: storage_mgmt
       ipv4:
@@ -95,7 +134,7 @@ spec:
   - name: Tenant
     nameLower: tenant
     vip: False
-    mtu: 1350
+    mtu: 9000
     subnets:
     - name: tenant
       ipv4:
@@ -114,7 +153,7 @@ spec:
   reservations:
     compute-0:
       ipReservations:
-        ctlplane: 192.168.25.40
+        ctlplane: 172.22.0.140
         internal_api: 172.17.0.40
         storage: 172.18.0.40
         tenant: 172.20.0.40
@@ -123,7 +162,7 @@ spec:
         datacentre2: fa:16:3b:bb:bb:bb
     controller-0:
       ipReservations:
-        ctlplane: 192.168.25.20
+        ctlplane: 172.22.0.120
         external: 10.0.0.20
         internal_api: 172.17.0.20
         storage: 172.18.0.20
@@ -134,7 +173,7 @@ spec:
         datacentre2: fa:16:3b:aa:aa:aa
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.21
+        ctlplane: 172.22.0.121
         external: 10.0.0.21
         internal_api: 172.17.0.21
         storage: 172.18.0.21
@@ -145,7 +184,7 @@ spec:
         datacentre2: fa:16:3b:aa:aa:bb
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.22
+        ctlplane: 172.22.0.122
         external: 10.0.0.22
         internal_api: 172.17.0.22
         storage: 172.18.0.22
@@ -153,13 +192,13 @@ spec:
         tenant: 172.20.0.22
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
         external: 10.0.0.10
         internal_api: 172.17.0.10
         storage: 172.18.0.10
         storage_mgmt: 172.19.0.10
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
         external: 10.0.0.251
         internal_api: 172.17.0.251

--- a/config/samples/osp-director_v1beta1_openstacknetconfig_single_net.yaml
+++ b/config/samples/osp-director_v1beta1_openstacknetconfig_single_net.yaml
@@ -27,15 +27,15 @@ spec:
     subnets:
     - name: ctlplane
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
       attachConfiguration: br-osp
   reservations:
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251

--- a/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
+++ b/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   port: 8080
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
+  interface: br-ctlplane

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,6 +13,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-osp-director-openstack-org-v1beta1-openstackbaremetalset
+  failurePolicy: Fail
+  name: mopenstackbaremetalset.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackbaremetalsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-osp-director-openstack-org-v1beta1-openstackclient
   failurePolicy: Fail
   name: mopenstackclient.kb.io
@@ -118,6 +139,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-osp-director-openstack-org-v1beta1-openstackipset
+  failurePolicy: Fail
+  name: mopenstackipset.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackipsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-osp-director-openstack-org-v1beta1-openstacknet
   failurePolicy: Fail
   name: mopenstacknet.kb.io
@@ -194,6 +236,27 @@ webhooks:
     - UPDATE
     resources:
     - openstackprovisionservers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-osp-director-openstack-org-v1beta1-openstackvmset
+  failurePolicy: Fail
+  name: mopenstackvmset.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackvmsets
   sideEffects: None
 
 ---
@@ -272,6 +335,28 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-osp-director-openstack-org-v1beta1-openstackclient
+  failurePolicy: Fail
+  name: vopenstackclient.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - openstackclients
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-osp-director-openstack-org-v1beta1-openstackcontrolplane
   failurePolicy: Fail
   name: vopenstackcontrolplane.kb.io
@@ -286,6 +371,27 @@ webhooks:
     - DELETE
     resources:
     - openstackcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-osp-director-openstack-org-v1beta1-openstackipset
+  failurePolicy: Fail
+  name: vopenstackipset.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackipsets
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -47,8 +47,6 @@ import (
 	"github.com/openstack-k8s-operators/osp-director-operator/pkg/baremetalset"
 	common "github.com/openstack-k8s-operators/osp-director-operator/pkg/common"
 	openstackipset "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstackipset"
-	openstacknet "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstacknet"
-	openstacknetconfig "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstacknetconfig"
 	"github.com/openstack-k8s-operators/osp-director-operator/pkg/provisionserver"
 )
 
@@ -234,25 +232,28 @@ func (r *OpenStackBaremetalSetReconciler) Reconcile(ctx context.Context, req ctr
 
 	var ctrlResult reconcile.Result
 	currentLabels := instance.DeepCopy().Labels
+
 	//
+	// Only kept for running local
 	// add osnetcfg CR label reference which is used in the in the osnetcfg
 	// controller to watch this resource and reconcile
 	//
-	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(
-		ctx,
-		r,
-		instance,
-		cond,
-		instance.Spec.Networks[0],
-	)
-	if (err != nil) || (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
+	if _, ok := currentLabels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]; !ok {
+		common.LogForObject(r, "osnetcfg reference label not added by webhook, adding it!", instance)
+		instance.Labels, err = ospdirectorv1beta1.AddOSNetConfigRefLabel(
+			instance.Namespace,
+			instance.Spec.Networks[0],
+			currentLabels,
+		)
+		if err != nil {
+			return ctrlResult, err
+		}
 	}
 
 	//
 	// add labels of all networks used by this CR
 	//
-	instance.Labels = openstacknet.AddOSNetNameLowerLabels(r, instance, cond, instance.Spec.Networks)
+	instance.Labels = ospdirectorv1beta1.AddOSNetNameLowerLabels(r.GetLogger(), instance.Labels, instance.Spec.Networks)
 
 	//
 	// update instance to sync labels if changed
@@ -956,13 +957,11 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(
 	netNameLower := "ctlplane"
 	// get network with name_lower label
 	labelSelector := map[string]string{
-		openstacknet.SubNetNameLabelSelector: netNameLower,
+		ospdirectorv1beta1.SubNetNameLabelSelector: netNameLower,
 	}
 
 	// get ctlplane network
-	ctlPlaneNetwork, err := openstacknet.GetOpenStackNetWithLabel(
-		ctx,
-		r,
+	ctlPlaneNetwork, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
 		instance.Namespace,
 		labelSelector,
 	)

--- a/controllers/openstackconfiggenerator_controller.go
+++ b/controllers/openstackconfiggenerator_controller.go
@@ -879,7 +879,7 @@ func (r *OpenStackConfigGeneratorReconciler) createTripleoDeployCM(
 			Type:               common.TemplateTypeConfig,
 			InstanceType:       instance.Kind,
 			AdditionalTemplate: map[string]string{},
-			CustomData: common.MergeStringMaps(
+			CustomData: ospdirectorv1beta1.MergeStringMaps(
 				roleNicTemplates,
 				fencingTemplate,
 			),

--- a/controllers/openstacknet_controller.go
+++ b/controllers/openstacknet_controller.go
@@ -324,8 +324,8 @@ func (r *OpenStackNetReconciler) createOrUpdateNetworkAttachmentDefinition(
 	networkAttachmentDefinition.Namespace = instance.Namespace
 
 	apply := func() error {
-		common.InitMap(&networkAttachmentDefinition.Labels)
-		common.InitMap(&networkAttachmentDefinition.Annotations)
+		ospdirectorv1beta1.InitMap(&networkAttachmentDefinition.Labels)
+		ospdirectorv1beta1.InitMap(&networkAttachmentDefinition.Annotations)
 
 		//
 		// Labels

--- a/controllers/openstacknetattachment_controller.go
+++ b/controllers/openstacknetattachment_controller.go
@@ -331,7 +331,7 @@ func (r *OpenStackNetAttachmentReconciler) createOrUpdateNodeNetworkConfiguratio
 	instance.Status.BridgeName = bridgeName
 
 	apply := func() error {
-		common.InitMap(&networkConfigurationPolicy.Labels)
+		ospdirectorv1beta1.InitMap(&networkConfigurationPolicy.Labels)
 		networkConfigurationPolicy.Labels[common.OwnerUIDLabelSelector] = string(instance.UID)
 		networkConfigurationPolicy.Labels[common.OwnerNameLabelSelector] = instance.Name
 		networkConfigurationPolicy.Labels[common.OwnerNameSpaceLabelSelector] = instance.Namespace

--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -401,7 +401,7 @@ func (r *OpenStackNetConfigReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		//
 		// verify object has OpenStackNetConfigReconcileLabel
 		//
-		reconcileCR, ok := labels[openstacknetconfig.OpenStackNetConfigReconcileLabel]
+		reconcileCR, ok := labels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]
 		if !ok {
 			return []reconcile.Request{}
 		}
@@ -444,7 +444,7 @@ func (r *OpenStackNetConfigReconciler) applyNetAttachmentConfig(
 	attachConfig.Namespace = instance.Namespace
 
 	apply := func() error {
-		common.InitMap(&attachConfig.Labels)
+		ospdirectorv1beta1.InitMap(&attachConfig.Labels)
 		attachConfig.Labels[common.OwnerUIDLabelSelector] = string(instance.UID)
 		attachConfig.Labels[common.OwnerNameLabelSelector] = instance.Name
 		attachConfig.Labels[common.OwnerNameSpaceLabelSelector] = instance.Namespace
@@ -612,15 +612,15 @@ func (r *OpenStackNetConfigReconciler) applyNetConfig(
 	}
 
 	apply := func() error {
-		common.InitMap(&osNet.Labels)
+		ospdirectorv1beta1.InitMap(&osNet.Labels)
 		osNet.Labels[common.OwnerUIDLabelSelector] = string(instance.UID)
 		osNet.Labels[common.OwnerNameLabelSelector] = instance.Name
 		osNet.Labels[common.OwnerNameSpaceLabelSelector] = instance.Namespace
 		osNet.Labels[common.OwnerControllerNameLabelSelector] = openstacknetconfig.AppLabel
-		osNet.Labels[openstacknet.NetworkNameLabelSelector] = net.Name
-		osNet.Labels[openstacknet.NetworkNameLowerLabelSelector] = net.NameLower
-		osNet.Labels[openstacknet.SubNetNameLabelSelector] = subnet.Name
-		osNet.Labels[openstacknet.ControlPlaneNetworkLabelSelector] = strconv.FormatBool(net.IsControlPlane)
+		osNet.Labels[ospdirectorv1beta1.NetworkNameLabelSelector] = net.Name
+		osNet.Labels[ospdirectorv1beta1.NetworkNameLowerLabelSelector] = net.NameLower
+		osNet.Labels[ospdirectorv1beta1.SubNetNameLabelSelector] = subnet.Name
+		osNet.Labels[ospdirectorv1beta1.ControlPlaneNetworkLabelSelector] = strconv.FormatBool(net.IsControlPlane)
 
 		osNet.Spec.AttachConfiguration = subnet.AttachConfiguration
 		osNet.Spec.MTU = net.MTU
@@ -826,7 +826,7 @@ func (r *OpenStackNetConfigReconciler) createOrUpdateOpenStackMACAddress(
 	// get all IPsets
 	//
 	labelSelector := map[string]string{
-		openstacknetconfig.OpenStackNetConfigReconcileLabel: instance.Name,
+		ospdirectorv1beta1.OpenStackNetConfigReconcileLabel: instance.Name,
 	}
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
@@ -1189,7 +1189,7 @@ func (r *OpenStackNetConfigReconciler) ensureIPReservation(
 
 	// reduce object scope by limit to the added name_lower network label
 	labelSelector := map[string]string{
-		fmt.Sprintf("%s/%s", openstacknet.SubNetNameLabelSelector, osNet.Spec.NameLower): strconv.FormatBool(true),
+		fmt.Sprintf("%s/%s", ospdirectorv1beta1.SubNetNameLabelSelector, osNet.Spec.NameLower): strconv.FormatBool(true),
 	}
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/openstack-k8s-operators/osp-director-operator/pkg/common"
 	openstackipset "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstackipset"
 	openstacknet "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstacknet"
-	openstacknetconfig "github.com/openstack-k8s-operators/osp-director-operator/pkg/openstacknetconfig"
 	vmset "github.com/openstack-k8s-operators/osp-director-operator/pkg/vmset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -232,25 +231,28 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	var ctrlResult ctrl.Result
 
 	currentLabels := instance.DeepCopy().Labels
+
 	//
+	// Only kept for running local
 	// add osnetcfg CR label reference which is used in the in the osnetcfg
 	// controller to watch this resource and reconcile
 	//
-	instance.Labels, ctrlResult, err = openstacknetconfig.AddOSNetConfigRefLabel(
-		ctx,
-		r,
-		instance,
-		cond,
-		instance.Spec.Networks[0],
-	)
-	if (err != nil) || (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
+	if _, ok := currentLabels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]; !ok {
+		common.LogForObject(r, "osnetcfg reference label not added by webhook, adding it!", instance)
+		instance.Labels, err = ospdirectorv1beta1.AddOSNetConfigRefLabel(
+			instance.Namespace,
+			instance.Spec.Networks[0],
+			currentLabels,
+		)
+		if err != nil {
+			return ctrlResult, err
+		}
 	}
 
 	//
 	// add labels of all networks used by this CR
 	//
-	instance.Labels = openstacknet.AddOSNetNameLowerLabels(r, instance, cond, instance.Spec.Networks)
+	instance.Labels = ospdirectorv1beta1.AddOSNetNameLowerLabels(r.GetLogger(), instance.Labels, instance.Spec.Networks)
 
 	//
 	// update instance to sync labels if changed
@@ -597,13 +599,11 @@ func (r *OpenStackVMSetReconciler) generateVirtualMachineNetworkData(
 	netNameLower := "ctlplane"
 	// get network with name_lower label
 	labelSelector := map[string]string{
-		openstacknet.SubNetNameLabelSelector: netNameLower,
+		ospdirectorv1beta1.SubNetNameLabelSelector: netNameLower,
 	}
 
 	// get ctlplane network
-	network, err := openstacknet.GetOpenStackNetWithLabel(
-		ctx,
-		r,
+	network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
 		instance.Namespace,
 		labelSelector,
 	)
@@ -923,11 +923,9 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 
 			// get network with name_lower label
 			labelSelector := map[string]string{
-				openstacknet.SubNetNameLabelSelector: netNameLower,
+				ospdirectorv1beta1.SubNetNameLabelSelector: netNameLower,
 			}
-			network, err := openstacknet.GetOpenStackNetWithLabel(
-				ctx,
-				r,
+			network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
 				instance.Namespace,
 				labelSelector,
 			)
@@ -1120,12 +1118,10 @@ func (r *OpenStackVMSetReconciler) verifyNetworkAttachments(
 		cond.Type = ospdirectorv1beta1.ConditionType(ospdirectorv1beta1.CommonCondTypeWaiting)
 
 		// get network with name_lower label
-		network, err := openstacknet.GetOpenStackNetWithLabel(
-			ctx,
-			r,
+		network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
 			instance.Namespace,
 			map[string]string{
-				openstacknet.SubNetNameLabelSelector: netNameLower,
+				ospdirectorv1beta1.SubNetNameLabelSelector: netNameLower,
 			},
 		)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -397,6 +397,11 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackClient")
 			os.Exit(1)
 		}
+
+		if err = (&ospdirectorv1beta1.OpenStackIPSet{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "OpenStackIPSet")
+			os.Exit(1)
+		}
 	}
 
 	// +kubebuilder:scaffold:builder

--- a/pkg/common/map.go
+++ b/pkg/common/map.go
@@ -18,28 +18,8 @@ package common
 
 import "sort"
 
-// InitMap - Inititialise a map to an empty map if it is nil.
-func InitMap(m *map[string]string) {
-	if *m == nil {
-		*m = make(map[string]string)
-	}
-}
-
 // MergeMaps - merge two or more maps
 func MergeMaps(baseMap map[string]interface{}, extraMaps ...map[string]interface{}) map[string]interface{} {
-	for _, extraMap := range extraMaps {
-		for key, value := range extraMap {
-			baseMap[key] = value
-		}
-	}
-
-	return baseMap
-}
-
-// MergeStringMaps - merge two or more string->map maps
-func MergeStringMaps(baseMap map[string]string, extraMaps ...map[string]string) map[string]string {
-	InitMap(&baseMap)
-
 	for _, extraMap := range extraMaps {
 		for key, value := range extraMap {
 			baseMap[key] = value

--- a/pkg/openstackipset/funcs.go
+++ b/pkg/openstackipset/funcs.go
@@ -100,7 +100,7 @@ func EnsureIPs(
 	//
 	osnetcfg := &ospdirectorv1beta1.OpenStackNetConfig{}
 	err = r.GetClient().Get(ctx, types.NamespacedName{
-		Name:      strings.ToLower(obj.GetLabels()[openstacknetconfig.OpenStackNetConfigReconcileLabel]),
+		Name:      strings.ToLower(obj.GetLabels()[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]),
 		Namespace: obj.GetNamespace()},
 		osnetcfg)
 	if err != nil {
@@ -157,7 +157,7 @@ func createOrUpdateIPSet(
 	}
 
 	op, err := controllerutil.CreateOrPatch(ctx, r.GetClient(), ipSet, func() error {
-		ipSet.Labels = common.MergeStringMaps(
+		ipSet.Labels = ospdirectorv1beta1.MergeStringMaps(
 			ipSet.Labels,
 			common.GetLabels(obj, controlplane.AppLabel, map[string]string{}),
 		)

--- a/pkg/openstacknet/const.go
+++ b/pkg/openstacknet/const.go
@@ -22,13 +22,4 @@ const (
 
 	// FinalizerName -
 	FinalizerName = "openstacknet.osp-director.openstack.org"
-
-	// NetworkNameLabelSelector -
-	NetworkNameLabelSelector = "ooo-netname"
-	// NetworkNameLowerLabelSelector -
-	NetworkNameLowerLabelSelector = "ooo-netname-lower"
-	// SubNetNameLabelSelector -
-	SubNetNameLabelSelector = "ooo-subnetname"
-	// ControlPlaneNetworkLabelSelector - is the network a ctlplane network?
-	ControlPlaneNetworkLabelSelector = "ooo-ctlplane-network"
 )

--- a/pkg/openstacknetconfig/const.go
+++ b/pkg/openstacknetconfig/const.go
@@ -22,8 +22,4 @@ const (
 
 	// FinalizerName -
 	FinalizerName = "openstacknetconfig.osp-director.openstack.org"
-
-	// OpenStackNetConfigReconcileLabel - label set on objects on which change
-	// trigger a reconcile of the osnetconfig
-	OpenStackNetConfigReconcileLabel = "osnetconfig-reconcile-dep"
 )

--- a/tests/kuttl/common/tests/create_openstackcontrolplane-assert.yaml
+++ b/tests/kuttl/common/tests/create_openstackcontrolplane-assert.yaml
@@ -12,12 +12,18 @@
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:
+  labels:
+    ooo-subnetname/ctlplane: "true"
+    ooo-subnetname/external: "true"
+    ooo-subnetname/internal_api: "true"
+    ooo-subnetname/storage: "true"
+    ooo-subnetname/storage_mgmt: "true"
+    osnetconfig-reconcile-dep: openstacknetconfig
   name: overcloud
   namespace: openstack
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -42,8 +48,10 @@ spec:
       - storage_mgmt
       - tenant
       roleCount: 0
+      storageAccessMode: ReadWriteMany
       roleName: Controller
       storageClass: host-nfs-storageclass
+      storageVolumeMode: Filesystem
 status:
   ospVersion: "16.2"
   provisioningStatus:
@@ -58,7 +66,7 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
         external: 10.0.0.10/24
         internal_api: 172.17.0.10/24
         storage: 172.18.0.10/24
@@ -70,6 +78,14 @@ kind: OpenStackVMSet
 metadata:
   finalizers:
   - openstackvmsets.osp-director.openstack.org/virtualmachine
+  labels:
+    ooo-subnetname/ctlplane: "true"
+    ooo-subnetname/external: "true"
+    ooo-subnetname/internal_api: "true"
+    ooo-subnetname/storage: "true"
+    ooo-subnetname/storage_mgmt: "true"
+    ooo-subnetname/tenant: "true"
+    osnetconfig-reconcile-dep: openstacknetconfig
   name: controller
   namespace: openstack
 spec:
@@ -101,13 +117,17 @@ status:
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackClient
 metadata:
+  labels:
+    ooo-subnetname/ctlplane: "true"
+    ooo-subnetname/external: "true"
+    ooo-subnetname/internal_api: "true"
+    osnetconfig-reconcile-dep: openstacknetconfig
   name: openstackclient
   namespace: openstack
 spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -123,7 +143,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
         external: 10.0.0.251/24
         internal_api: 172.17.0.251/24
       provisioningState: Provisioned
@@ -144,12 +164,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
-  attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
+  attachConfiguration: br-ctlplane
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -159,7 +179,7 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         serviceVIP: false
         vip: true
     OpenstackClientopenstackclient:
@@ -167,7 +187,7 @@ spec:
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         serviceVIP: false
         vip: false
   routes: []
@@ -178,10 +198,10 @@ status:
   reservations:
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 2
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -262,7 +282,7 @@ spec:
   cidr: 172.17.0.0/24
   domainName: internalapi.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 1500
   name: InternalApi
   nameLower: internal_api
   roleReservations:
@@ -318,7 +338,7 @@ spec:
   cidr: 172.18.0.0/24
   domainName: storage.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 9000
   name: Storage
   nameLower: storage
   roleReservations:
@@ -363,7 +383,7 @@ spec:
   cidr: 172.19.0.0/24
   domainName: storagemgmt.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 1500
   name: StorageMgmt
   nameLower: storage_mgmt
   roleReservations:
@@ -408,7 +428,7 @@ spec:
   cidr: 172.20.0.0/24
   domainName: tenant.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 9000
   name: Tenant
   nameLower: tenant
   roleReservations: {}

--- a/tests/kuttl/common/tests/create_openstackcontrolplane_single_net-assert.yaml
+++ b/tests/kuttl/common/tests/create_openstackcontrolplane_single_net-assert.yaml
@@ -17,7 +17,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -51,7 +50,7 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -91,7 +90,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -105,7 +103,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -124,12 +122,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -139,14 +137,14 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -156,10 +154,10 @@ status:
   reservations:
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 2
 ---
 apiVersion: v1

--- a/tests/kuttl/common/tests/create_openstackcontrolplane_single_net_ipv6-assert.yaml
+++ b/tests/kuttl/common/tests/create_openstackcontrolplane_single_net_ipv6-assert.yaml
@@ -17,7 +17,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -52,7 +51,7 @@ status:
       hostname: controlplane
       ipaddresses:
         ctlplane: 2001:db8:fd00:2000::10/64
-      provisioningState: Provisioned
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -91,7 +90,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane

--- a/tests/kuttl/common/tests/create_openstacknetconfig-assert.yaml
+++ b/tests/kuttl/common/tests/create_openstacknetconfig-assert.yaml
@@ -17,6 +17,37 @@ metadata:
   namespace: openstack
 spec:
   attachConfigurations:
+    br-ctlplane:
+      nodeNetworkConfigurationPolicy:
+        desiredState:
+          interfaces:
+          - bridge:
+              options:
+                stp:
+                  enabled: false
+              port:
+              - name: enp1s0
+            description: Linux bridge with enp1s0 as a port
+            ipv4:
+              dhcp: true
+              enabled: true
+            ipv6:
+              dhcp: true
+              enabled: true
+            mtu: 1500
+            name: br-ctlplane
+            state: up
+            type: linux-bridge
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+      nodeSriovConfigurationPolicy:
+        desiredState:
+          deviceType: vfio-pci
+          mtu: 9000
+          numVfs: 0
+          port: ""
+          spoofCheck: "on"
+          trust: "off"
     br-ex:
       nodeNetworkConfigurationPolicy:
         desiredState:
@@ -28,6 +59,10 @@ spec:
               port:
               - name: enp6s0
             description: Linux bridge with enp6s0 as a port
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
             mtu: 1500
             name: br-ex
             state: up
@@ -53,10 +88,23 @@ spec:
               port:
               - name: enp7s0
             description: Linux bridge with enp7s0 as a port
-            mtu: 1500
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
+            mtu: 9000
             name: br-osp
             state: up
             type: linux-bridge
+          - description: Configuring enp7s0 on workers
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
+            mtu: 9000
+            name: enp7s0
+            state: up
+            type: ethernet
         nodeSelector:
           node-role.kubernetes.io/worker: ""
       nodeSriovConfigurationPolicy:
@@ -67,7 +115,8 @@ spec:
           port: ""
           spoofCheck: "on"
           trust: "off"
-  dnsServers: []
+  dnsServers:
+  - 172.22.0.1
   domainName: localdomain
   networks:
   - isControlPlane: true
@@ -75,12 +124,12 @@ spec:
     name: Control
     nameLower: ctlplane
     subnets:
-    - attachConfiguration: br-osp
+    - attachConfiguration: br-ctlplane
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
       ipv6:
         allocationEnd: ""
         allocationStart: ""
@@ -90,7 +139,7 @@ spec:
       vlan: 0
     vip: true
   - isControlPlane: false
-    mtu: 1350
+    mtu: 1500
     name: InternalApi
     nameLower: internal_api
     subnets:
@@ -128,7 +177,7 @@ spec:
       vlan: 0
     vip: true
   - isControlPlane: false
-    mtu: 1350
+    mtu: 9000
     name: Storage
     nameLower: storage
     subnets:
@@ -147,7 +196,7 @@ spec:
       vlan: 30
     vip: true
   - isControlPlane: false
-    mtu: 1350
+    mtu: 1500
     name: StorageMgmt
     nameLower: storage_mgmt
     subnets:
@@ -166,7 +215,7 @@ spec:
       vlan: 40
     vip: true
   - isControlPlane: false
-    mtu: 1350
+    mtu: 9000
     name: Tenant
     nameLower: tenant
     subnets:
@@ -194,7 +243,7 @@ spec:
   reservations:
     compute-0:
       ipReservations:
-        ctlplane: 192.168.25.40
+        ctlplane: 172.22.0.140
         internal_api: 172.17.0.40
         storage: 172.18.0.40
         tenant: 172.20.0.40
@@ -203,7 +252,7 @@ spec:
         datacentre2: fa:16:3b:bb:bb:bb
     controller-0:
       ipReservations:
-        ctlplane: 192.168.25.20
+        ctlplane: 172.22.0.120
         external: 10.0.0.20
         internal_api: 172.17.0.20
         storage: 172.18.0.20
@@ -214,7 +263,7 @@ spec:
         datacentre2: fa:16:3b:aa:aa:aa
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.21
+        ctlplane: 172.22.0.121
         external: 10.0.0.21
         internal_api: 172.17.0.21
         storage: 172.18.0.21
@@ -225,7 +274,7 @@ spec:
         datacentre2: fa:16:3b:aa:aa:bb
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.22
+        ctlplane: 172.22.0.122
         external: 10.0.0.22
         internal_api: 172.17.0.22
         storage: 172.18.0.22
@@ -234,7 +283,7 @@ spec:
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
         external: 10.0.0.10
         internal_api: 172.17.0.10
         storage: 172.18.0.10
@@ -242,20 +291,67 @@ spec:
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
         external: 10.0.0.251
         internal_api: 172.17.0.251
       macReservations: {}
 status:
   provisioningStatus:
-    attachDesiredCount: 2
-    attachReadyCount: 2
+    attachDesiredCount: 3
+    attachReadyCount: 3
     netDesiredCount: 6
     netReadyCount: 6
     physNetDesiredCount: 2
     physNetReadyCount: 2
     reason: OpenStackNetConfig openstacknetconfig all resources configured
     state: Configured
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetAttachment
+metadata:
+  finalizers:
+  - openstacknetattachment
+  labels:
+    bridge: br-ctlplane
+    ooo-attach-reference: br-ctlplane
+    ooo-attach-type: bridge
+    osp-director.openstack.org/controller: osp-openstacknetconfig
+    osp-director.openstack.org/name: openstacknetconfig
+    osp-director.openstack.org/namespace: openstack
+  name: br-ctlplane-bridge
+  namespace: openstack
+spec:
+  attachConfiguration:
+    nodeNetworkConfigurationPolicy:
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: enp1s0
+          description: Linux bridge with enp1s0 as a port
+          ipv4:
+            dhcp: true
+            enabled: true
+          ipv6:
+            dhcp: true
+            enabled: true
+          mtu: 1500
+          name: br-ctlplane
+          state: up
+          type: linux-bridge
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+    nodeSriovConfigurationPolicy:
+      desiredState:
+        deviceType: vfio-pci
+        mtu: 9000
+        numVfs: 0
+        port: ""
+        spoofCheck: "on"
+        trust: "off"
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackNetAttachment
@@ -283,6 +379,10 @@ spec:
             port:
             - name: enp6s0
           description: Linux bridge with enp6s0 as a port
+          ipv4:
+            enabled: false
+          ipv6:
+            enabled: false
           mtu: 1500
           name: br-ex
           state: up
@@ -324,10 +424,23 @@ spec:
             port:
             - name: enp7s0
           description: Linux bridge with enp7s0 as a port
-          mtu: 1500
+          ipv4:
+            enabled: false
+          ipv6:
+            enabled: false
+          mtu: 9000
           name: br-osp
           state: up
           type: linux-bridge
+        - description: Configuring enp7s0 on workers
+          ipv4:
+            enabled: false
+          ipv6:
+            enabled: false
+          mtu: 9000
+          name: enp7s0
+          state: up
+          type: ethernet
       nodeSelector:
         node-role.kubernetes.io/worker: ""
     nodeSriovConfigurationPolicy:
@@ -338,6 +451,49 @@ spec:
         port: ""
         spoofCheck: "on"
         trust: "off"
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  finalizers:
+  - openstacknetattachment
+  labels:
+    ooo-bridge: br-ctlplane
+    osp-director.openstack.org/controller: osp-openstacknetattach
+    osp-director.openstack.org/name: br-ctlplane-bridge
+    osp-director.openstack.org/namespace: openstack
+  name: br-ctlplane
+spec:
+  desiredState:
+    interfaces:
+    - bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: enp1s0
+      description: Linux bridge with enp1s0 as a port
+      ipv4:
+        dhcp: true
+        enabled: true
+      ipv6:
+        dhcp: true
+        enabled: true
+      mtu: 1500
+      name: br-ctlplane
+      state: up
+      type: linux-bridge
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+status:
+  conditions:
+  - message: 3/3 nodes successfully configured
+    reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+  - reason: SuccessfullyConfigured
+    status: "False"
+    type: Degraded
 ---
 apiVersion: nmstate.io/v1alpha1
 kind: NodeNetworkConfigurationPolicy
@@ -360,6 +516,11 @@ spec:
         port:
         - name: enp6s0
       description: Linux bridge with enp6s0 as a port
+      ipv4:
+        enabled: false
+      ipv6:
+        enabled: false
+      mtu: 1500
       name: br-ex
       state: up
       type: linux-bridge
@@ -367,7 +528,8 @@ spec:
     node-role.kubernetes.io/worker: ""
 status:
   conditions:
-  - reason: SuccessfullyConfigured
+  - message: 3/3 nodes successfully configured
+    reason: SuccessfullyConfigured
     status: "True"
     type: Available
   - reason: SuccessfullyConfigured
@@ -395,14 +557,29 @@ spec:
         port:
         - name: enp7s0
       description: Linux bridge with enp7s0 as a port
+      ipv4:
+        enabled: false
+      ipv6:
+        enabled: false
+      mtu: 9000
       name: br-osp
       state: up
       type: linux-bridge
+    - description: Configuring enp7s0 on workers
+      ipv4:
+        enabled: false
+      ipv6:
+        enabled: false
+      mtu: 9000
+      name: enp7s0
+      state: up
+      type: ethernet
   nodeSelector:
     node-role.kubernetes.io/worker: ""
 status:
   conditions:
-  - reason: SuccessfullyConfigured
+  - message: 3/3 nodes successfully configured
+    reason: SuccessfullyConfigured
     status: "True"
     type: Available
   - reason: SuccessfullyConfigured
@@ -425,12 +602,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
-  attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
+  attachConfiguration: br-ctlplane
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -509,7 +686,7 @@ spec:
   cidr: 172.17.0.0/24
   domainName: internalapi.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 1500
   name: InternalApi
   nameLower: internal_api
   roleReservations: {}
@@ -548,7 +725,7 @@ spec:
   cidr: 172.18.0.0/24
   domainName: storage.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 9000
   name: Storage
   nameLower: storage
   roleReservations: {}
@@ -587,7 +764,7 @@ spec:
   cidr: 172.19.0.0/24
   domainName: storagemgmt.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 1500
   name: StorageMgmt
   nameLower: storage_mgmt
   roleReservations: {}
@@ -626,7 +803,7 @@ spec:
   cidr: 172.20.0.0/24
   domainName: tenant.localdomain
   gateway: ""
-  mtu: 1350
+  mtu: 9000
   name: Tenant
   nameLower: tenant
   roleReservations: {}

--- a/tests/kuttl/common/tests/create_openstacknetconfig_single_net-assert.yaml
+++ b/tests/kuttl/common/tests/create_openstacknetconfig_single_net-assert.yaml
@@ -53,10 +53,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -75,11 +75,11 @@ spec:
   reservations:
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
 status:
   hosts: {}
   provisioningStatus:
@@ -183,11 +183,11 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
-  gateway: 192.168.25.1
+  cidr: 172.22.0.0/24
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane

--- a/tests/kuttl/common/tests/scale_down_openstackcontrolplane_single_controller-assert.yaml
+++ b/tests/kuttl/common/tests/scale_down_openstackcontrolplane_single_controller-assert.yaml
@@ -24,7 +24,7 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
         external: 10.0.0.10/24
         internal_api: 172.17.0.10/24
         storage: 172.18.0.10/24
@@ -68,7 +68,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.22/24
+        ctlplane: 172.22.0.122/24
         external: 10.0.0.22/24
         internal_api: 172.17.0.22/24
         storage: 172.18.0.22/24
@@ -102,48 +102,48 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: true
         hostname: controller-0
-        ip: 192.168.25.20
+        ip: 172.22.0.120
         vip: false
       - deleted: true
         hostname: controller-1
-        ip: 192.168.25.21
+        ip: 172.22.0.121
         vip: false
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.22
+        ip: 172.22.0.122
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
 status:
   currentState: Configured
   reservations:
     controller-0:
       deleted: true
-      ip: 192.168.25.20
+      ip: 172.22.0.120
     controller-1:
       deleted: true
-      ip: 192.168.25.21
+      ip: 172.22.0.121
     controller-2:
       deleted: false
-      ip: 192.168.25.22
+      ip: 172.22.0.122
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 5
 ---
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/common/tests/scale_up_openstackcontrolplane_3_controllers-assert.yaml
+++ b/tests/kuttl/common/tests/scale_up_openstackcontrolplane_3_controllers-assert.yaml
@@ -57,7 +57,7 @@ status:
       hostRef: controller-0
       hostname: controller-0
       ipaddresses:
-        ctlplane: 192.168.25.20/24
+        ctlplane: 172.22.0.120/24
         external: 10.0.0.20/24
         internal_api: 172.17.0.20/24
         storage: 172.18.0.20/24
@@ -71,7 +71,7 @@ status:
       hostRef: controller-1
       hostname: controller-1
       ipaddresses:
-        ctlplane: 192.168.25.21/24
+        ctlplane: 172.22.0.121/24
         external: 10.0.0.21/24
         internal_api: 172.17.0.21/24
         storage: 172.18.0.21/24
@@ -85,7 +85,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.22/24
+        ctlplane: 172.22.0.122/24
         external: 10.0.0.22/24
         internal_api: 172.17.0.22/24
         storage: 172.18.0.22/24
@@ -145,7 +145,7 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         serviceVIP: false
         vip: true
     Controller:
@@ -153,17 +153,17 @@ spec:
       reservations:
       - deleted: false
         hostname: controller-0
-        ip: 192.168.25.20
+        ip: 172.22.0.120
         serviceVIP: false
         vip: false
       - deleted: false
         hostname: controller-1
-        ip: 192.168.25.21
+        ip: 172.22.0.121
         serviceVIP: false
         vip: false
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.22
+        ip: 172.22.0.122
         serviceVIP: false
         vip: false
     OpenstackClientopenstackclient:
@@ -171,7 +171,7 @@ spec:
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         serviceVIP: false
         vip: false
 status:
@@ -179,19 +179,19 @@ status:
   reservations:
     controller-0:
       deleted: false
-      ip: 192.168.25.20
+      ip: 172.22.0.120
     controller-1:
       deleted: false
-      ip: 192.168.25.21
+      ip: 172.22.0.121
     controller-2:
       deleted: false
-      ip: 192.168.25.22
+      ip: 172.22.0.122
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 5
 ---
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/common/tests/scale_up_openstackcontrolplane_single_controller_single_net-assert.yaml
+++ b/tests/kuttl/common/tests/scale_up_openstackcontrolplane_single_controller_single_net-assert.yaml
@@ -52,7 +52,7 @@ status:
       hostRef: controller-0
       hostname: controller-0
       ipaddresses:
-        ctlplane: 192.168.25.100/24
+        ctlplane: 172.22.0.100/24
       provisioningState: Provisioned
 ---
 apiVersion: kubevirt.io/v1alpha3
@@ -81,34 +81,34 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: false
         hostname: controller-0
-        ip: 192.168.25.100
+        ip: 172.22.0.100
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
 status:
   currentState: Configured
   reservations:
     controller-0:
       deleted: false
-      ip: 192.168.25.100
+      ip: 172.22.0.100
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 3
 ---
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
@@ -11,18 +11,24 @@ kind: OpenStackBaremetalSet
 metadata:
   finalizers:
   - baremetalset.osp-director.openstack.org-compute
+  labels:
+    ooo-subnetname/ctlplane: "true"
+    ooo-subnetname/internal_api: "true"
+    ooo-subnetname/tenant: "true"
+    osnetconfig-reconcile-dep: openstacknetconfig
   name: compute
   namespace: openstack
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   count: 0
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp1s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
   - ctlplane
   - internal_api
   - tenant
   passwordSecret: userpassword
+  provisionServerName: openstack
   roleName: Compute
 status:
   provisioningStatus:
@@ -32,11 +38,12 @@ status:
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackProvisionServer
 metadata:
-  name: compute-provisionserver
+  name: openstack
   namespace: openstack
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
-  port: 6190
+  interface: br-ctlplane
+  port: 8080
 status:
   provisioningStatus:
     reason: OpenStackProvisionServer has been provisioned

--- a/tests/kuttl/tests/openstackbaremetalset_scale/03-create_openstackbaremetalset.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/03-create_openstackbaremetalset.yaml
@@ -4,6 +4,9 @@ commands:
   # Create the required userpassword Secret
   - command: oc apply -f ../../common/manifests/userpassword.yaml
     namespaced: true
+  # Create the provisionserver
+  - command: oc apply -f ../../../../config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
+    namespaced: true
   # Create the OpenStackBaremetalSet from sample YAML
   - command: oc apply -f ../../../../config/samples/osp-director_v1beta1_openstackbaremetalset.yaml
     namespaced: true

--- a/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/04-assert.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   count: 2
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp1s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
   - ctlplane
@@ -33,12 +33,12 @@ status:
   baremetalHosts:
     compute-0:
       annotatedForDeletion: false
-      ctlplaneIP: 192.168.25.40/24
+      ctlplaneIP: 172.22.0.140/24
       hostname: compute-0
       provisioningState: provisioned
     compute-1:
       annotatedForDeletion: false
-      ctlplaneIP: 192.168.25.100/24
+      ctlplaneIP: 172.22.0.100/24
       hostname: compute-1
       provisioningState: provisioned
   provisioningStatus:
@@ -134,12 +134,12 @@ spec:
       reservations:
       - deleted: false
         hostname: compute-0
-        ip: 192.168.25.40
+        ip: 172.22.0.140
         serviceVIP: false
         vip: false
       - deleted: false
         hostname: compute-1
-        ip: 192.168.25.100
+        ip: 172.22.0.100
         serviceVIP: false
         vip: false
     ControlPlane:
@@ -147,7 +147,7 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         serviceVIP: false
         vip: true
     OpenstackClientopenstackclient:
@@ -155,7 +155,7 @@ spec:
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         serviceVIP: false
         vip: false
 status:
@@ -168,16 +168,16 @@ status:
   reservations:
     compute-0:
       deleted: false
-      ip: 192.168.25.40
+      ip: 172.22.0.140
     compute-1:
       deleted: false
-      ip: 192.168.25.100
+      ip: 172.22.0.100
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 4
 ---
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/06-assert.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   count: 1
-  ctlplaneInterface: enp7s0
+  ctlplaneInterface: enp1s0
   deploymentSSHSecret: osp-controlplane-ssh-keys
   networks:
   - ctlplane
@@ -29,7 +29,7 @@ status:
   baremetalHosts:
     compute-1:
       annotatedForDeletion: false
-      ctlplaneIP: 192.168.25.100/24
+      ctlplaneIP: 172.22.0.100/24
       hostname: compute-1
       provisioningState: provisioned
   provisioningStatus:
@@ -104,12 +104,12 @@ spec:
       reservations:
       - deleted: true
         hostname: compute-0
-        ip: 192.168.25.40
+        ip: 172.22.0.140
         serviceVIP: false
         vip: false
       - deleted: false
         hostname: compute-1
-        ip: 192.168.25.100
+        ip: 172.22.0.100
         serviceVIP: false
         vip: false
     ControlPlane:
@@ -117,7 +117,7 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         serviceVIP: false
         vip: true
     OpenstackClientopenstackclient:
@@ -125,7 +125,7 @@ spec:
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         serviceVIP: false
         vip: false
 status:
@@ -138,16 +138,16 @@ status:
   reservations:
     compute-0:
       deleted: true
-      ip: 192.168.25.40
+      ip: 172.22.0.140
     compute-1:
       deleted: false
-      ip: 192.168.25.100
+      ip: 172.22.0.100
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 4
 ---
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/tests/openstackbaremetalset_scale/09-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/09-assert.yaml
@@ -19,7 +19,7 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         serviceVIP: false
         vip: true
     OpenstackClientopenstackclient:
@@ -27,7 +27,7 @@ spec:
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         serviceVIP: false
         vip: false
 status:
@@ -40,10 +40,10 @@ status:
   reservations:
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 2
 ---
 apiVersion: osp-director.openstack.org/v1beta1

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/04-add_static_reservation.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/04-add_static_reservation.yaml
@@ -9,5 +9,5 @@ commands:
       oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "add", "path": "/spec/reservations/controller-1", "value": {"ipReservations":{}, "macReservations": {}}}]'
     namespaced: true
   - command: |
-      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "add", "path": "/spec/reservations/controller-1/ipReservations", "value": {"ctlplane": "192.168.25.41" }}]'
+      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "add", "path": "/spec/reservations/controller-1/ipReservations", "value": {"ctlplane": "172.22.0.121" }}]'
     namespaced: true

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/04-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/04-assert.yaml
@@ -49,10 +49,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -71,15 +71,15 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   provisioningStatus:

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/05-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/05-assert.yaml
@@ -52,10 +52,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -74,32 +74,32 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controller-2:
       ipReservations: {}
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
 status:
 status:
   hosts:
     controller-0:
       ipaddresses:
-        ctlplane: 192.168.25.100/24
+        ctlplane: 172.22.0.100/24
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/05-webhook_validations.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/05-webhook_validations.yaml
@@ -14,16 +14,16 @@ commands:
     namespaced: true
   - command: |
       # add static reservation with dupe dynamic IP entry (IP from controller-0)
-      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "replace", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "192.168.25.100"}]'
+      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "replace", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "172.22.0.100"}]'
     namespaced: true
     ignoreFailure: true
   - command: |
       # add static reservation with dupe static IP entry (IP from controller-1)
-      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "replace", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "192.168.25.41"}]'
+      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "replace", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "172.22.0.121"}]'
     namespaced: true
     ignoreFailure: true
   - command: |
       # add static reservation with wrong IP format
-      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "add", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "192.168.25.25.42" }]'
+      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "add", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "172.22.22.0.122" }]'
     namespaced: true
     ignoreFailure: true

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/06-add_second_reservation.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/06-add_second_reservation.yaml
@@ -10,5 +10,5 @@ commands:
       oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "add", "path": "/spec/reservations/controller-2", "value": {"ipReservations":{}, "macReservations": {}}}]'
     namespaced: true
   - command: |
-      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "replace", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "192.168.25.42"}]'
+      oc patch -n openstack osnetcfg openstacknetconfig --type='json' -p='[{"op": "replace", "path": "/spec/reservations/controller-2/ipReservations/ctlplane", "value": "172.22.0.122"}]'
     namespaced: true

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/06-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/06-assert.yaml
@@ -49,10 +49,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -71,19 +71,19 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.42
+        ctlplane: 172.22.0.122
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
 status:
   provisioningStatus:

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/07-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/07-assert.yaml
@@ -53,10 +53,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -75,38 +75,38 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.42
+        ctlplane: 172.22.0.122
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   hosts:
     controller-0:
       ipaddresses:
-        ctlplane: 192.168.25.100/24
+        ctlplane: 172.22.0.100/24
     controller-1:
       ipaddresses:
-        ctlplane: 192.168.25.41/24
+        ctlplane: 172.22.0.121/24
     controller-2:
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1
@@ -126,7 +126,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -160,8 +159,8 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
-      provisioningState: Provisioned
+        ctlplane: 172.22.0.110/24
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -198,7 +197,7 @@ status:
       hostRef: controller-0
       hostname: controller-0
       ipaddresses:
-        ctlplane: 192.168.25.100/24
+        ctlplane: 172.22.0.100/24
       networkDataSecretName: controller-controller-0-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -208,7 +207,7 @@ status:
       hostRef: controller-1
       hostname: controller-1
       ipaddresses:
-        ctlplane: 192.168.25.41/24
+        ctlplane: 172.22.0.121/24
       networkDataSecretName: controller-controller-1-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -218,7 +217,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
       networkDataSecretName: controller-controller-2-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -232,7 +231,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -246,7 +244,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -265,12 +263,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -280,29 +278,29 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: false
         hostname: controller-0
-        ip: 192.168.25.100
+        ip: 172.22.0.100
         vip: false
       - deleted: false
         hostname: controller-1
-        ip: 192.168.25.41
+        ip: 172.22.0.121
         vip: false
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.42
+        ip: 172.22.0.122
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -312,17 +310,17 @@ status:
   reservations:
     controller-0:
       deleted: false
-      ip: 192.168.25.100
+      ip: 172.22.0.100
     controller-1:
       deleted: false
-      ip: 192.168.25.41
+      ip: 172.22.0.121
     controller-2:
       deleted: false
-      ip: 192.168.25.42
+      ip: 172.22.0.122
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 5

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/08-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/08-assert.yaml
@@ -52,10 +52,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -74,32 +74,32 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.42
+        ctlplane: 172.22.0.122
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   hosts:
     controller-2:
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1
@@ -119,7 +119,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -153,8 +152,8 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
-      provisioningState: Provisioned
+        ctlplane: 172.22.0.110/24
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -191,7 +190,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
       networkDataSecretName: controller-controller-2-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -205,7 +204,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -219,7 +217,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -238,12 +236,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -253,29 +251,29 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: true
         hostname: controller-0
-        ip: 192.168.25.100
+        ip: 172.22.0.100
         vip: false
       - deleted: true
         hostname: controller-1
-        ip: 192.168.25.41
+        ip: 172.22.0.121
         vip: false
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.42
+        ip: 172.22.0.122
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -285,17 +283,17 @@ status:
   reservations:
     controller-0:
       deleted: true
-      ip: 192.168.25.100
+      ip: 172.22.0.100
     controller-1:
       deleted: true
-      ip: 192.168.25.41
+      ip: 172.22.0.121
     controller-2:
       deleted: false
-      ip: 192.168.25.42
+      ip: 172.22.0.122
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 5

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/09-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/09-assert.yaml
@@ -52,10 +52,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -74,32 +74,32 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.42
+        ctlplane: 172.22.0.122
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   hosts:
     controller-2:
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1
@@ -119,7 +119,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -153,8 +152,8 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
-      provisioningState: Provisioned
+        ctlplane: 172.22.0.110/24
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -191,7 +190,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
       networkDataSecretName: controller-controller-2-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -205,7 +204,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -219,7 +217,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -238,12 +236,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -253,21 +251,21 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.42
+        ip: 172.22.0.122
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -277,11 +275,11 @@ status:
   reservations:
     controller-2:
       deleted: false
-      ip: 192.168.25.42
+      ip: 172.22.0.122
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 3

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/10-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/10-assert.yaml
@@ -50,10 +50,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -93,19 +93,19 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.42
+        ctlplane: 172.22.0.122
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   provisioningStatus:

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/11-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv4/11-assert.yaml
@@ -48,10 +48,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -90,19 +90,19 @@ spec:
   reservations:
     controller-1:
       ipReservations:
-        ctlplane: 192.168.25.41
+        ctlplane: 172.22.0.121
       macReservations: {}
     controller-2:
       ipReservations:
-        ctlplane: 192.168.25.42
+        ctlplane: 172.22.0.122
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   hosts:
@@ -114,16 +114,16 @@ status:
       ovnBridgeMacAdresses: {}
     controller-2:
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
         internal_api: 172.17.0.11/24
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
         internal_api: 172.17.0.10/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1
@@ -141,12 +141,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -156,21 +156,21 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.42
+        ip: 172.22.0.122
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -180,13 +180,13 @@ status:
   reservations:
     controller-2:
       deleted: false
-      ip: 192.168.25.42
+      ip: 172.22.0.122
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 3
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -269,7 +269,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.42/24
+        ctlplane: 172.22.0.122/24
         internal_api: 172.17.0.11/24
       networkDataSecretName: controller-controller-2-networkdata
       provisioningState: Provisioned

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv6/07-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv6/07-assert.yaml
@@ -126,7 +126,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -161,7 +160,7 @@ status:
       hostname: controlplane
       ipaddresses:
         ctlplane: 2001:db8:fd00:2000::10/64
-      provisioningState: Provisioned
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -232,7 +231,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv6/08-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv6/08-assert.yaml
@@ -119,7 +119,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -154,7 +153,7 @@ status:
       hostname: controlplane
       ipaddresses:
         ctlplane: 2001:db8:fd00:2000::10/64
-      provisioningState: Provisioned
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -205,7 +204,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane

--- a/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv6/09-assert.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_ip_reservation_ipv6/09-assert.yaml
@@ -119,7 +119,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -154,7 +153,7 @@ status:
       hostname: controlplane
       ipaddresses:
         ctlplane: 2001:db8:fd00:2000::10/64
-      provisioningState: Provisioned
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -205,7 +204,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane

--- a/tests/kuttl/tests/ovnBridgeMacMappings/02-assert.yaml
+++ b/tests/kuttl/tests/ovnBridgeMacMappings/02-assert.yaml
@@ -53,10 +53,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -79,11 +79,11 @@ spec:
         datacentre: fa:16:3a:aa:aa:aa
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   provisioningStatus:

--- a/tests/kuttl/tests/ovnBridgeMacMappings/03-assert.yaml
+++ b/tests/kuttl/tests/ovnBridgeMacMappings/03-assert.yaml
@@ -52,10 +52,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -81,11 +81,11 @@ spec:
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
 status:
   provisioningStatus:

--- a/tests/kuttl/tests/ovnBridgeMacMappings/04-assert.yaml
+++ b/tests/kuttl/tests/ovnBridgeMacMappings/04-assert.yaml
@@ -53,10 +53,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -87,11 +87,11 @@ spec:
         datacentre: fa:16:3a:aa:aa:cc
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
 status:
   provisioningStatus:

--- a/tests/kuttl/tests/ovnBridgeMacMappings/06-assert.yaml
+++ b/tests/kuttl/tests/ovnBridgeMacMappings/06-assert.yaml
@@ -55,10 +55,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -89,36 +89,36 @@ spec:
         datacentre: fa:16:3a:aa:aa:cc
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   hosts:
     controller-0:
       ipaddresses:
-        ctlplane: 192.168.25.100/24
+        ctlplane: 172.22.0.100/24
       ovnBridgeMacAdresses:
         datacentre: fa:16:3a:aa:aa:aa
     controller-1:
       ipaddresses:
-        ctlplane: 192.168.25.101/24
+        ctlplane: 172.22.0.101/24
       ovnBridgeMacAdresses:
         datacentre: fa:16:3a:aa:aa:bb
     controller-2:
       ipaddresses:
-        ctlplane: 192.168.25.102/24
+        ctlplane: 172.22.0.102/24
       ovnBridgeMacAdresses:
         datacentre: fa:16:3a:aa:aa:cc
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1
@@ -138,7 +138,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -172,8 +171,8 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
-      provisioningState: Provisioned
+        ctlplane: 172.22.0.110/24
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -210,7 +209,7 @@ status:
       hostRef: controller-0
       hostname: controller-0
       ipaddresses:
-        ctlplane: 192.168.25.100/24
+        ctlplane: 172.22.0.100/24
       networkDataSecretName: controller-controller-0-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -220,7 +219,7 @@ status:
       hostRef: controller-1
       hostname: controller-1
       ipaddresses:
-        ctlplane: 192.168.25.101/24
+        ctlplane: 172.22.0.101/24
       networkDataSecretName: controller-controller-1-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -230,7 +229,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.102/24
+        ctlplane: 172.22.0.102/24
       networkDataSecretName: controller-controller-2-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -244,7 +243,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -258,7 +256,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -277,12 +275,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -292,29 +290,29 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: false
         hostname: controller-0
-        ip: 192.168.25.100
+        ip: 172.22.0.100
         vip: false
       - deleted: false
         hostname: controller-1
-        ip: 192.168.25.101
+        ip: 172.22.0.101
         vip: false
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.102
+        ip: 172.22.0.102
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -324,19 +322,19 @@ status:
   reservations:
     controller-0:
       deleted: false
-      ip: 192.168.25.100
+      ip: 172.22.0.100
     controller-1:
       deleted: false
-      ip: 192.168.25.101
+      ip: 172.22.0.101
     controller-2:
       deleted: false
-      ip: 192.168.25.102
+      ip: 172.22.0.102
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 5
 ---
 apiVersion: v1

--- a/tests/kuttl/tests/ovnBridgeMacMappings/07-assert.yaml
+++ b/tests/kuttl/tests/ovnBridgeMacMappings/07-assert.yaml
@@ -54,10 +54,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -88,26 +88,26 @@ spec:
         datacentre: fa:16:3a:aa:aa:cc
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   hosts:
     controller-2:
       ipaddresses:
-        ctlplane: 192.168.25.102/24
+        ctlplane: 172.22.0.102/24
       ovnBridgeMacAdresses:
         datacentre: fa:16:3a:aa:aa:cc
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1
@@ -127,7 +127,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -161,8 +160,8 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
-      provisioningState: Provisioned
+        ctlplane: 172.22.0.110/24
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -199,7 +198,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.102/24
+        ctlplane: 172.22.0.102/24
       networkDataSecretName: controller-controller-2-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -213,7 +212,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -227,7 +225,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -246,12 +244,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -261,29 +259,29 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: true
         hostname: controller-0
-        ip: 192.168.25.100
+        ip: 172.22.0.100
         vip: false
       - deleted: true
         hostname: controller-1
-        ip: 192.168.25.101
+        ip: 172.22.0.101
         vip: false
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.102
+        ip: 172.22.0.102
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -293,19 +291,19 @@ status:
   reservations:
     controller-0:
       deleted: true
-      ip: 192.168.25.100
+      ip: 172.22.0.100
     controller-1:
       deleted: true
-      ip: 192.168.25.101
+      ip: 172.22.0.101
     controller-2:
       deleted: false
-      ip: 192.168.25.102
+      ip: 172.22.0.102
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 5
 ---
 apiVersion: v1

--- a/tests/kuttl/tests/ovnBridgeMacMappings/08-assert.yaml
+++ b/tests/kuttl/tests/ovnBridgeMacMappings/08-assert.yaml
@@ -54,10 +54,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -88,26 +88,26 @@ spec:
         datacentre: fa:16:3a:aa:aa:cc
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   hosts:
     controller-2:
       ipaddresses:
-        ctlplane: 192.168.25.102/24
+        ctlplane: 172.22.0.102/24
       ovnBridgeMacAdresses:
         datacentre: fa:16:3a:aa:aa:cc
     controlplane:
       ipaddresses:
-        ctlplane: 192.168.25.10/24
+        ctlplane: 172.22.0.110/24
       ovnBridgeMacAdresses: {}
     openstackclient-0:
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       ovnBridgeMacAdresses: {}
   provisioningStatus:
     attachDesiredCount: 1
@@ -127,7 +127,6 @@ metadata:
 spec:
   domainName: ostest.test.metalkube.org
   enableFencing: false
-  gitSecret: git-secret
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane
@@ -161,8 +160,8 @@ status:
       hostRef: controlplane
       hostname: controlplane
       ipaddresses:
-        ctlplane: 192.168.25.10/24
-      provisioningState: Provisioned
+        ctlplane: 172.22.0.110/24
+      provisioningState: Created
 ---
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackVMSet
@@ -199,7 +198,7 @@ status:
       hostRef: controller-2
       hostname: controller-2
       ipaddresses:
-        ctlplane: 192.168.25.102/24
+        ctlplane: 172.22.0.102/24
       networkDataSecretName: controller-controller-2-networkdata
       provisioningState: Provisioned
       userDataSecretName: controller-cloudinit
@@ -213,7 +212,6 @@ spec:
   cloudName: overcloud
   deploymentSSHSecret: osp-controlplane-ssh-keys
   domainName: ostest.test.metalkube.org
-  gitSecret: git-secret
   imageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   networks:
   - ctlplane
@@ -227,7 +225,7 @@ status:
       hostRef: openstackclient-0
       hostname: openstackclient-0
       ipaddresses:
-        ctlplane: 192.168.25.251/24
+        ctlplane: 172.22.0.251/24
       provisioningState: Provisioned
 ---
 apiVersion: osp-director.openstack.org/v1beta1
@@ -246,12 +244,12 @@ metadata:
   name: ctlplane
   namespace: openstack
 spec:
-  allocationEnd: 192.168.25.250
-  allocationStart: 192.168.25.100
+  allocationEnd: 172.22.0.250
+  allocationStart: 172.22.0.100
   attachConfiguration: br-osp
-  cidr: 192.168.25.0/24
+  cidr: 172.22.0.0/24
   domainName: ctlplane.localdomain
-  gateway: 192.168.25.1
+  gateway: 172.22.0.1
   mtu: 1500
   name: Control
   nameLower: ctlplane
@@ -261,21 +259,21 @@ spec:
       reservations:
       - deleted: false
         hostname: controlplane
-        ip: 192.168.25.10
+        ip: 172.22.0.110
         vip: true
     Controller:
       addToPredictableIPs: true
       reservations:
       - deleted: false
         hostname: controller-2
-        ip: 192.168.25.102
+        ip: 172.22.0.102
         vip: false
     OpenstackClientopenstackclient:
       addToPredictableIPs: false
       reservations:
       - deleted: false
         hostname: openstackclient-0
-        ip: 192.168.25.251
+        ip: 172.22.0.251
         vip: false
   routes: []
   vip: true
@@ -285,13 +283,13 @@ status:
   reservations:
     controller-2:
       deleted: false
-      ip: 192.168.25.102
+      ip: 172.22.0.102
     controlplane:
       deleted: false
-      ip: 192.168.25.10
+      ip: 172.22.0.110
     openstackclient-0:
       deleted: false
-      ip: 192.168.25.251
+      ip: 172.22.0.251
   reservedIpCount: 3
 ---
 apiVersion: v1

--- a/tests/kuttl/tests/ovnBridgeMacMappings/09-assert.yaml
+++ b/tests/kuttl/tests/ovnBridgeMacMappings/09-assert.yaml
@@ -50,10 +50,10 @@ spec:
     subnets:
     - attachConfiguration: br-osp
       ipv4:
-        allocationEnd: 192.168.25.250
-        allocationStart: 192.168.25.100
-        cidr: 192.168.25.0/24
-        gateway: 192.168.25.1
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
         routes: []
       ipv6:
         allocationEnd: ""
@@ -86,11 +86,11 @@ spec:
         datacentre: fa:16:3a:aa:aa:cc
     controlplane:
       ipReservations:
-        ctlplane: 192.168.25.10
+        ctlplane: 172.22.0.110
       macReservations: {}
     openstackclient-0:
       ipReservations:
-        ctlplane: 192.168.25.251
+        ctlplane: 172.22.0.251
       macReservations: {}
 status:
   provisioningStatus:

--- a/tests/kuttl/tests/unique_role_name/03-assert.yaml
+++ b/tests/kuttl/tests/unique_role_name/03-assert.yaml
@@ -36,5 +36,5 @@ status:
       hostRef: somecustomrole-0
       hostname: somecustomrole-0
       ipaddresses:
-        ctlplane: 192.168.25.100/24
+        ctlplane: 172.22.0.100/24
       provisioningState: Provisioned


### PR DESCRIPTION
Add osnetcfg and osnet labels via webhook and validations

This changes to add the osnetcfg reference label early in the
webhook of osctlplane, osbms, osclient and osvmset. It still keeps
a check if the label is there in the controller in case of when
the operator runs local.

Does the same for osnet labels to the used osnet to the CR
object.

Also adds validation to the webhook of osctlplane, osvmset, osbms
and osclient to check that for any listed subnet in the spec.Networks
there is a correspoding osnet and fail if not.

Fixes the kuttl tests match the ctlplane network change did in
dev-tools [1]. Also fixes the asserts for removed gitsecret
parameter.

[1] https://issues.redhat.com/browse/OSPK8-451
