### PR TITLE
[v1.2.x-backports][OSPK8-447] Fix multi subnet network identification and routes rendering/template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,30 @@ Update the `tarballConfigMap` configmap to add the `roles_data.yaml` file to the
 
 ## Create NIC templates for the new roles
 
+### Default network routes
+The OSP 16.2 tripleo nic templates have the <netName>InterfaceRoutes parameter per default included. The routes parameter rendered in environments/network-environment.yaml which are named <netName>Routes get usually set on the neutron network host_routes property and get added to the role <netName>InterfaceRoutes parameter. Since there is no neutron it is required to add the {{network.name}}Routes to the nic template where needed and concat the two lists:
+
+~~~
+parameters:
+  ...
+  {{ $net.Name }}Routes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ...
+              - type: interface
+                ...
+                routes:
+                  list_concat_unique:
+                    - get_param: {{ $net.Name }}Routes
+                    - get_param: {{ $net.Name }}InterfaceRoutes
+~~~
+
+### Subnet routes
 Routes subnet information gets auto rendered to the tripleo environment file `environments/network-environment.yaml` which is used in the script rendering the ansible playbooks. In the NIC templates therefore use <NetName>Routes_<subnet_name>, e.g. StorageRoutes_storage_leaf1 to set the correct routing on the host.
 
 ### OSP16.2/train NIC templates modification

--- a/templates/openstackconfiggenerator/config/16.2/network_data.yaml
+++ b/templates/openstackconfiggenerator/config/16.2/network_data.yaml
@@ -77,7 +77,7 @@
       gateway_ipv6: '{{ $subnet.IPv6.Gateway }}'
 {{- end }}
 {{- if not (eq (len $subnet.IPv6.Routes) 0) }}
-      routes:
+      routes_ipv6:
 {{- range $netname, $route := $subnet.IPv6.Routes }}
       - destination: '{{ $route.Destination }}'
         nexthop: '{{ $route.Nexthop }}'

--- a/templates/openstackconfiggenerator/config/16.2/nic/net-config-multi-nic.yaml
+++ b/templates/openstackconfiggenerator/config/16.2/nic/net-config-multi-nic.yaml
@@ -60,6 +60,14 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  {{ $net.Name }}Routes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
 {{- end }}
 {{- end }}
   DnsServers: # Override this via parameter_defaults
@@ -128,6 +136,7 @@ resources:
                     get_param: {{ $net.Name }}IpSubnet
                 routes:
                   list_concat_unique:
+                    - get_param: {{ $net.Name }}Routes
                     - get_param: {{ $net.Name }}InterfaceRoutes
 {{- else if ne $net.NameLower "ctlplane" }}
 {{- $nic_counter = add $nic_counter 1 }}
@@ -147,6 +156,7 @@ resources:
                     get_param: {{ $net.Name }}IpSubnet
                 routes:
                   list_concat_unique:
+                    - get_param: {{ $net.Name }}Routes
                     - get_param: {{ $net.Name }}InterfaceRoutes
                     - - default: true
                         next_hop:

--- a/templates/openstackconfiggenerator/config/17.0/network_data.yaml
+++ b/templates/openstackconfiggenerator/config/17.0/network_data.yaml
@@ -38,7 +38,7 @@
       gateway_ipv6: '{{ $subnet.IPv6.Gateway }}'
 {{- end }}
 {{- if not (eq (len $subnet.IPv6.Routes) 0) }}
-      routes:
+      routes_ipv6:
 {{- range $netname, $route := $subnet.IPv6.Routes }}
       - destination: '{{ $route.Destination }}'
         nexthop: '{{ $route.Nexthop }}'


### PR DESCRIPTION
- Use subnetName instead of networkNameLower to identify network

The correct way to identify the network is the subnetName because the networkNameLower can return multiple networks when multiple subnets are used.

- [OSPK8-447] fix network routes for IPv6 multi subnet
The routes parameter of the subnet in `network_data.yaml`, rendered by the operator, use `routes` instead of the expected `routes_ipv6`.

Also the routes parameter rendered in environments/network-environment.yaml which are named <netName>Routes get usually set on the neutron network host_routes property.

```
      {{network.name}}Routes:
          Routes for the {{network.name_lower}} network traffic.
          JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
          Routes are added to the host_routes property on the subnet in neutron
          when the network and subnet is created.

```

Since there is no neutron we add the {{network.name}}Routes to the nic template and concat the two lists:
```
      routes:
        list_concat_unique:
          - get_param: {{ $net.Name }}Routes
          - get_param: {{ $net.Name }}InterfaceRoutes
```