### PR TITLE
[OSPK8-460] Replicate StackAction behaviour for 16.2

### DIFF
--- a/containers/agent/deploy.go
+++ b/containers/agent/deploy.go
@@ -48,6 +48,7 @@ var (
 		limit          string
 		tags           string
 		skipTags       string
+		ospVersion     string
 	}
 
 	openstackConfigVersionGVR = schema.GroupVersionResource{
@@ -78,6 +79,7 @@ func init() {
 	deployCmd.PersistentFlags().StringVar(&deployOpts.playbook, "limit", "", "Playbook inventory limit")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.playbook, "tags", "", "Playbook include tags")
 	deployCmd.PersistentFlags().StringVar(&deployOpts.playbook, "skipTags", "", "Playbook exclude tags")
+	deployCmd.PersistentFlags().StringVar(&deployOpts.ospVersion, "ospVersion", "", "OSP release version")
 }
 
 // GetConfigMap for our exports Heat environment
@@ -335,6 +337,13 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 		}
 		deployOpts.deployName = deployName
 	}
+	if deployOpts.ospVersion == "" {
+		ospVersion, ok := os.LookupEnv("OSP_VERSION")
+		if !ok || ospVersion == "" {
+			glog.Fatalf("ospVersion is required")
+		}
+		deployOpts.ospVersion = ospVersion
+	}
 
 	if deployOpts.gitURL == "" {
 		gitURL, ok := os.LookupEnv("GIT_URL")
@@ -416,6 +425,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 					"LIMIT='"+deployOpts.limit+"' "+
 					"TAGS='"+deployOpts.tags+"' "+
 					"SKIP_TAGS='"+deployOpts.skipTags+"' "+
+					"OSP_VERSION='"+deployOpts.ospVersion+"' "+
 					"/usr/local/bin/tripleo-deploy-term.sh")
 			if execErr != nil {
 				panic(execErr.Error())
@@ -434,6 +444,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 			"LIMIT='"+deployOpts.limit+"' "+
 			"TAGS='"+deployOpts.tags+"' "+
 			"SKIP_TAGS='"+deployOpts.skipTags+"' "+
+			"OSP_VERSION='"+deployOpts.ospVersion+"' "+
 			"/usr/local/bin/tripleo-deploy.sh")
 	if execErr != nil {
 		panic(execErr.Error())

--- a/pkg/openstackdeploy/job.go
+++ b/pkg/openstackdeploy/job.go
@@ -33,6 +33,7 @@ func DeployJob(
 	configVersion string,
 	gitSecret string,
 	advancedSettings *ospdirectorv1beta1.OpenStackDeployAdvancedSettingsSpec,
+	ospVersion ospdirectorv1beta1.OSPVersion,
 ) *batchv1.Job {
 
 	runAsUser := int64(openstackclient.CloudAdminUID)
@@ -84,6 +85,10 @@ func DeployJob(
 					{
 						Name:  "OPENSTACKCLIENT_POD",
 						Value: openstackClientPod,
+					},
+					{
+						Name:  "OSP_VERSION",
+						Value: string(ospVersion),
 					},
 					{
 						Name: "GIT_URL",


### PR DESCRIPTION
Pacemaker restart, Octavia, and tripleo-network-config rely on the
stack_action (CREATE or UPDATE) ansible fact or hieradata.
To ensure this works correctly with director operator's ephemeral
heat we need to replicate the tripleoclient logic.
As we do not have the existance of a heat stack to rely on we need a
different approach.
Instead the existance of /var/lib/tripleo-config on any overcloud node
is used to determine the appropriate stack_action setting. This is
passed on the ansible-playbook command line to override the default
stack_action in global_vars (which is always CREATE). The resulting
hieradata is also updated.