### PR TITLE
Fixes to allow the operator to run local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ endif
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
+# Metrics bind address
+METRICS_BIND_ADDRESS ?= :8080
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -153,7 +155,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run ./main.go -metrics-bind-address ${METRICS_BIND_ADDRESS}
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.

--- a/api/v1beta1/common_openstacknet.go
+++ b/api/v1beta1/common_openstacknet.go
@@ -89,6 +89,7 @@ func AddOSNetNameLowerLabels(
 // the in the osnetcfg controller to watch this resource and reconcile
 //
 func AddOSNetConfigRefLabel(
+	c client.Client,
 	namespace string,
 	subnetName string,
 	labels map[string]string,
@@ -100,7 +101,7 @@ func AddOSNetConfigRefLabel(
 	labelSelector := map[string]string{
 		SubNetNameLabelSelector: subnetName,
 	}
-	osnet, err := GetOpenStackNetWithLabel(namespace, labelSelector)
+	osnet, err := GetOpenStackNetWithLabel(c, namespace, labelSelector)
 	if err != nil && k8s_errors.IsNotFound(err) {
 		return labels, fmt.Errorf(fmt.Sprintf("OpenStackNet %s not found reconcile again in 10 seconds", subnetName))
 	} else if err != nil {
@@ -131,6 +132,7 @@ func AddOSNetConfigRefLabel(
 
 // GetOpenStackNetsWithLabel - Return a list of all OpenStackNets in the namespace that have (optional) labels
 func GetOpenStackNetsWithLabel(
+	c client.Client,
 	namespace string,
 	labelSelector map[string]string,
 ) (*OpenStackNetList, error) {
@@ -145,7 +147,7 @@ func GetOpenStackNetsWithLabel(
 		listOpts = append(listOpts, labels)
 	}
 
-	if err := webhookClient.List(context.TODO(), osNetList, listOpts...); err != nil {
+	if err := c.List(context.TODO(), osNetList, listOpts...); err != nil {
 		return nil, err
 	}
 
@@ -154,11 +156,13 @@ func GetOpenStackNetsWithLabel(
 
 // GetOpenStackNetWithLabel - Return OpenStackNet with labels
 func GetOpenStackNetWithLabel(
+	c client.Client,
 	namespace string,
 	labelSelector map[string]string,
 ) (*OpenStackNet, error) {
 
 	osNetList, err := GetOpenStackNetsWithLabel(
+		c,
 		namespace,
 		labelSelector,
 	)
@@ -175,10 +179,12 @@ func GetOpenStackNetWithLabel(
 
 // GetOpenStackNetsMapWithLabel - Return a map[NameLower] of all OpenStackNets in the namespace that have (optional) labels
 func GetOpenStackNetsMapWithLabel(
+	c client.Client,
 	namespace string,
 	labelSelector map[string]string,
 ) (map[string]OpenStackNet, error) {
 	osNetList, err := GetOpenStackNetsWithLabel(
+		c,
 		namespace,
 		labelSelector,
 	)
@@ -196,6 +202,7 @@ func GetOpenStackNetsMapWithLabel(
 
 // CreateVIPNetworkList - return list of all networks from all VM roles which has vip flag
 func CreateVIPNetworkList(
+	c client.Client,
 	instance *OpenStackControlPlane,
 ) ([]string, error) {
 
@@ -212,6 +219,7 @@ func CreateVIPNetworkList(
 
 			// get network with name_lower label to verify if VIP needs to be requested from Spec
 			network, err := GetOpenStackNetWithLabel(
+				c,
 				instance.Namespace,
 				labelSelector,
 			)

--- a/api/v1beta1/common_webhook.go
+++ b/api/v1beta1/common_webhook.go
@@ -126,7 +126,7 @@ func validateNetworks(namespace string, networks []string) error {
 		labelSelector := map[string]string{
 			SubNetNameLabelSelector: subnetName,
 		}
-		osnet, err := GetOpenStackNetWithLabel(namespace, labelSelector)
+		osnet, err := GetOpenStackNetWithLabel(webhookClient, namespace, labelSelector)
 		if err != nil && k8s_errors.IsNotFound(err) {
 			return fmt.Errorf(fmt.Sprintf("%s %s not found, validate the object network list!", osnet.GetObjectKind().GroupVersionKind().Kind, subnetName))
 		} else if err != nil {

--- a/api/v1beta1/openstackbaremetalset_webhook.go
+++ b/api/v1beta1/openstackbaremetalset_webhook.go
@@ -114,6 +114,7 @@ func (r *OpenStackBaremetalSet) Default() {
 	//
 	if _, ok := r.GetLabels()[OpenStackNetConfigReconcileLabel]; !ok {
 		labels, err := AddOSNetConfigRefLabel(
+			webhookClient,
 			r.Namespace,
 			r.Spec.Networks[0],
 			r.DeepCopy().GetLabels(),

--- a/api/v1beta1/openstackclient_webhook.go
+++ b/api/v1beta1/openstackclient_webhook.go
@@ -64,6 +64,7 @@ func (r *OpenStackClient) Default() {
 	//
 	if _, ok := r.GetLabels()[OpenStackNetConfigReconcileLabel]; !ok {
 		labels, err := AddOSNetConfigRefLabel(
+			webhookClient,
 			r.Namespace,
 			r.Spec.Networks[0],
 			r.DeepCopy().GetLabels(),

--- a/api/v1beta1/openstackcontrolplane_webhook.go
+++ b/api/v1beta1/openstackcontrolplane_webhook.go
@@ -198,6 +198,7 @@ func (r *OpenStackControlPlane) Default() {
 		}
 
 		labels, err := AddOSNetConfigRefLabel(
+			webhookClient,
 			r.Namespace,
 			subnetName,
 			r.DeepCopy().GetLabels(),
@@ -213,7 +214,7 @@ func (r *OpenStackControlPlane) Default() {
 	//
 	// add labels of all networks used by this CR
 	//
-	vipNetList, err := CreateVIPNetworkList(r)
+	vipNetList, err := CreateVIPNetworkList(webhookClient, r)
 	if err != nil {
 		controlplanelog.Error(err, fmt.Sprintf("error creating VIP network list: %s", err))
 	}

--- a/api/v1beta1/openstackipset_webhook.go
+++ b/api/v1beta1/openstackipset_webhook.go
@@ -54,6 +54,7 @@ func (r *OpenStackIPSet) Default() {
 	//
 	if _, ok := r.GetLabels()[OpenStackNetConfigReconcileLabel]; !ok {
 		labels, err := AddOSNetConfigRefLabel(
+			webhookClient,
 			r.Namespace,
 			r.Spec.Networks[0],
 			r.GetLabels(),

--- a/api/v1beta1/openstackvmset_webhook.go
+++ b/api/v1beta1/openstackvmset_webhook.go
@@ -113,6 +113,7 @@ func (r *OpenStackVMSet) Default() {
 	//
 	if _, ok := r.GetLabels()[OpenStackNetConfigReconcileLabel]; !ok {
 		labels, err := AddOSNetConfigRefLabel(
+			webhookClient,
 			r.Namespace,
 			r.Spec.Networks[0],
 			r.DeepCopy().GetLabels(),

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -241,6 +241,7 @@ func (r *OpenStackBaremetalSetReconciler) Reconcile(ctx context.Context, req ctr
 	if _, ok := currentLabels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]; !ok {
 		common.LogForObject(r, "osnetcfg reference label not added by webhook, adding it!", instance)
 		instance.Labels, err = ospdirectorv1beta1.AddOSNetConfigRefLabel(
+			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
 			currentLabels,
@@ -955,6 +956,7 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(
 
 	// get ctlplane network
 	ctlPlaneNetwork, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
+		r.Client,
 		instance.Namespace,
 		labelSelector,
 	)

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -153,6 +153,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if _, ok := currentLabels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]; !ok {
 		common.LogForObject(r, "osnetcfg reference label not added by webhook, adding it!", instance)
 		instance.Labels, err = ospdirectorv1beta1.AddOSNetConfigRefLabel(
+			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
 			currentLabels,
@@ -484,6 +485,7 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 
 		// get network with name_lower label
 		network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
+			r.Client,
 			instance.Namespace,
 			labelSelector,
 		)
@@ -676,6 +678,7 @@ func (r *OpenStackClientReconciler) verifyNetworkAttachments(
 
 		// get network with name_lower label
 		network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
+			r.Client,
 			instance.Namespace,
 			map[string]string{
 				ospdirectorv1beta1.SubNetNameLabelSelector: netNameLower,

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -779,7 +779,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 	//
 
 	// create list of networks where Spec.VIP == True
-	vipNetworksList, err := ospdirectorv1beta1.CreateVIPNetworkList(instance)
+	vipNetworksList, err := ospdirectorv1beta1.CreateVIPNetworkList(r.Client, instance)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -795,6 +795,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 	if _, ok := currentLabels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]; !ok {
 		common.LogForObject(r, "osnetcfg reference label not added by webhook, adding it!", instance)
 		instance.Labels, err = ospdirectorv1beta1.AddOSNetConfigRefLabel(
+			r.Client,
 			instance.Namespace,
 			vipNetworksList[0],
 			currentLabels,

--- a/controllers/openstackipset_controller.go
+++ b/controllers/openstackipset_controller.go
@@ -145,6 +145,7 @@ func (r *OpenStackIPSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if _, ok := currentLabels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]; !ok {
 		common.LogForObject(r, "osnetcfg reference label not added by webhook, adding it!", instance)
 		instance.Labels, err = ospdirectorv1beta1.AddOSNetConfigRefLabel(
+			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
 			currentLabels,

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -240,6 +240,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if _, ok := currentLabels[ospdirectorv1beta1.OpenStackNetConfigReconcileLabel]; !ok {
 		common.LogForObject(r, "osnetcfg reference label not added by webhook, adding it!", instance)
 		instance.Labels, err = ospdirectorv1beta1.AddOSNetConfigRefLabel(
+			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
 			currentLabels,
@@ -627,6 +628,7 @@ func (r *OpenStackVMSetReconciler) generateVirtualMachineNetworkData(
 
 	// get ctlplane network
 	network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
+		r.Client,
 		instance.Namespace,
 		labelSelector,
 	)
@@ -949,6 +951,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 				ospdirectorv1beta1.SubNetNameLabelSelector: netNameLower,
 			}
 			network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
+				r.Client,
 				instance.Namespace,
 				labelSelector,
 			)
@@ -1142,6 +1145,7 @@ func (r *OpenStackVMSetReconciler) verifyNetworkAttachments(
 
 		// get network with name_lower label
 		network, err := ospdirectorv1beta1.GetOpenStackNetWithLabel(
+			r.Client,
 			instance.Namespace,
 			map[string]string{
 				ospdirectorv1beta1.SubNetNameLabelSelector: netNameLower,

--- a/pkg/openstacknet/funcs.go
+++ b/pkg/openstacknet/funcs.go
@@ -19,7 +19,7 @@ func GetOpenStackNetsBindingMap(
 	//
 	// Acquire a list and map of all OpenStackNetworks available in this namespace
 	//
-	osNetList, err := ospdirectorv1beta1.GetOpenStackNetsWithLabel(namespace, map[string]string{})
+	osNetList, err := ospdirectorv1beta1.GetOpenStackNetsWithLabel(r.GetClient(), namespace, map[string]string{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Don't rely on webhookClient in common functions to run local
  
Right now the webclient is used in a couple of places, which works fine if the operator is deployed in the env, but fails
when running local with webhooks disabled. This changes the functions which uses them and instead pass the client.Client from the caller.

- Add METRICS_BIND_ADDRESS to Makefile allows operator to run local
  
If port 8080 is already in use to run the operator local it is required to specify a different ports for metrics to bind on. This adds METRICS_BIND_ADDRESS env var to control the address/port metrics to bind to. This allows the operator to be run local like:

`WATCH_NAMESPACE=openstack,openshift-machine-api,openshift-sriov-network-operator ENABLE_WEBHOOKS=false METRICS_BIND_ADDRESS=:8085 make run`