### PR TITLE
Fix agent and downloader image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,3 +272,11 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+.PHONY: osp-director-operator-agent-image-build
+osp-director-operator-agent-image-build: test ## Build osp-director-operator-agent.
+	podman build -t ${IMG} -f Dockerfile.agent
+
+.PHONY: osp-director-downloader-image-build
+osp-director-downloader-image-build: test ## Build osp-director-downloader image.
+	podman build -t ${IMG} -f containers/image_downloader/Dockerfile containers/image_downloader

--- a/scripts/build_and_push_images.sh
+++ b/scripts/build_and_push_images.sh
@@ -38,10 +38,10 @@ make generate
 make IMG=${IMG} docker-build docker-push
 
 # Agent image
-make IMG=${AGENT_IMG} DOCKERFILE="Dockerfile.agent" docker-build docker-push
+make IMG=${AGENT_IMG} osp-director-operator-agent-image-build docker-push
 
 # Downloader image
-make IMG=${DOWNLOADER_IMG} DOCKERFILE="containers/image_downloader/Dockerfile" DOCKER_BUILD_DIR="containers/image_downloader" docker-build docker-push
+make IMG=${DOWNLOADER_IMG} osp-director-downloader-image-build docker-push
 
 rm -Rf bundle
 rm -Rf bundle.Dockerfile


### PR DESCRIPTION
[1] removed the DOCKERFILE and DOCKER_BUILD_DIR env variables
from the docker-build target. As a result for the anget and
the downloader image also the operator image got build and
pushed.
To keep the Makefile as default as possible, this adds new
specific targets, osp-director-operator-agent-image-build and
osp-director-downloader-image-build to build these images.

[1] https://github.com/openstack-k8s-operators/osp-director-operator/commit/efc90f909d9d62928acd33dcf57163d895525869#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R135