### PR TITLE
Add missing sdk upgrade changes

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=osp-director-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
* Add annotation to specify the default container [1]
* Reduce debug log level for the sidecar container kube-rbac-proxy from 10 to 0

[1] https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.16.0/#add-annotation-to-specify-the-default-container
[2] https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.17.0/#reduce-debug-log-level-for-the-sidecar-container-kube-rbac-proxy-from-10-to-0