### PR TITLE
[OSPK8-467 OSPK8-472 OSPK8-474] enhance validation for osnetcfg

### DIFF
--- a/api/shared/net.go
+++ b/api/shared/net.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import "net"
+
+// IsIPv4 checks if an IP is v4.
+func IsIPv4(ip net.IP) bool {
+	return ip.To4() != nil
+}
+
+// IsIPv6 checks if an IP is v6.
+func IsIPv6(ip net.IP) bool {
+	if IsIPv4(ip) {
+		return false
+	}
+
+	return ip.To16() != nil
+}

--- a/api/v1beta1/openstacknet_types.go
+++ b/api/v1beta1/openstacknet_types.go
@@ -63,6 +63,7 @@ type OpenStackNetSpec struct {
 	Cidr string `json:"cidr"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Maximum=4094
 	// Vlan ID of the network
 	Vlan int `json:"vlan"`
 

--- a/api/v1beta1/openstacknetconfig_types.go
+++ b/api/v1beta1/openstacknetconfig_types.go
@@ -68,6 +68,7 @@ type Subnet struct {
 	IPv6 NetDetails `json:"ipv6"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Maximum=4094
 	// Vlan ID of the network
 	Vlan int `json:"vlan"`
 

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -1877,6 +1877,7 @@ spec:
                                               type: string
                                             vlan:
                                               description: Vlan ID of the network
+                                              maximum: 4094
                                               type: integer
                                           required:
                                           - attachConfiguration
@@ -2261,6 +2262,7 @@ spec:
                                   type: boolean
                                 vlan:
                                   description: Vlan ID of the network
+                                  maximum: 4094
                                   type: integer
                               required:
                               - allocationEnd
@@ -5078,6 +5080,7 @@ spec:
                                               type: string
                                             vlan:
                                               description: Vlan ID of the network
+                                              maximum: 4094
                                               type: integer
                                           required:
                                           - attachConfiguration
@@ -5462,6 +5465,7 @@ spec:
                                   type: boolean
                                 vlan:
                                   description: Vlan ID of the network
+                                  maximum: 4094
                                   type: integer
                               required:
                               - allocationEnd

--- a/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
@@ -272,6 +272,7 @@ spec:
                             type: string
                           vlan:
                             description: Vlan ID of the network
+                            maximum: 4094
                             type: integer
                         required:
                         - attachConfiguration

--- a/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
@@ -162,6 +162,7 @@ spec:
                 type: boolean
               vlan:
                 description: Vlan ID of the network
+                maximum: 4094
                 type: integer
             required:
             - allocationEnd

--- a/pkg/common/ipam.go
+++ b/pkg/common/ipam.go
@@ -193,20 +193,6 @@ func GetIPRange(ip net.IP, ipnet net.IPNet) (net.IP, net.IP, error) {
 
 }
 
-// IsIPv4 checks if an IP is v4.
-func IsIPv4(ip net.IP) bool {
-	return ip.To4() != nil
-}
-
-// IsIPv6 checks if an IP is v6.
-func IsIPv6(ip net.IP) bool {
-	if IsIPv4(ip) {
-		return false
-	}
-
-	return ip.To16() != nil
-}
-
 func isIntIPv4(checkipint *big.Int) bool {
 	return !(len(checkipint.Bytes()) == net.IPv6len)
 }

--- a/pkg/openstackconfiggenerator/configmap.go
+++ b/pkg/openstackconfiggenerator/configmap.go
@@ -293,7 +293,7 @@ func createNetworksMap(
 					return networksMap, networkMappingList, err
 				}
 
-				if common.IsIPv4(net.ParseIP(ip)) {
+				if shared.IsIPv4(net.ParseIP(ip)) {
 					network.IPv6 = false
 					subnetDetailsV4 = netDetailsType{
 						AllocationEnd:   s.IPv4.AllocationEnd,
@@ -317,7 +317,7 @@ func createNetworksMap(
 					return networksMap, networkMappingList, err
 				}
 
-				if common.IsIPv6(net.ParseIP(ip)) {
+				if shared.IsIPv6(net.ParseIP(ip)) {
 					network.IPv6 = true
 					subnetDetailsV6 = netDetailsType{
 						AllocationEnd:   s.IPv6.AllocationEnd,
@@ -430,7 +430,7 @@ func createRolesMap(
 				}
 
 				isIPv6 := false
-				if common.IsIPv6(net.ParseIP(osnet.Spec.Cidr)) {
+				if shared.IsIPv6(net.ParseIP(osnet.Spec.Cidr)) {
 					isIPv6 = true
 				}
 
@@ -485,7 +485,7 @@ func createRolesMap(
 						}
 
 						uri := reservation.IP
-						if common.IsIPv6(net.ParseIP(reservation.IP)) {
+						if shared.IsIPv6(net.ParseIP(reservation.IP)) {
 							// IP address with brackets in case of IPv6, e.g. [2001:DB8:24::15]
 							uri = fmt.Sprintf("[%s]", uri)
 						}

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/00-prep.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/00-prep.yaml
@@ -1,0 +1,1 @@
+../../common/tests/00-prep.yaml

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/01-create_osnet_webhook_validation.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/01-create_osnet_webhook_validation.yaml
@@ -1,0 +1,32 @@
+#
+# Annotate 2 OpenStackVMSet VMs for deletion and scale OpenStackControlPlane down to 1 controller
+#
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: |
+      # blocked by webhook as there is no ctlplane network, or other network tagged as isControlPlane
+      oc apply -f ./osp-director_v1beta1_openstacknetconfig_no_ctlplane_net.yaml
+    namespaced: true
+    ignoreFailure: true
+  - command: |
+      # blocked by webhook as there is IPv4 and IPv6 network information specified in the same subnet
+      oc apply -f ./osp-director_v1beta1_openstacknetconfig_ipv4_and_ipv6_subnet.yaml
+    namespaced: true
+    ignoreFailure: true
+  - command: |
+      # blocked by webhook as there is IPv6 allocationEnd specified in IPv4 network information
+      oc apply -f ./osp-director_v1beta1_openstacknetconfig_ipv4_mix_ipv6_details.yaml
+    namespaced: true
+    ignoreFailure: true
+  - command: |
+      # blocked by webhook as there is IPv6 information specified as IPv4 network information
+      oc apply -f ./osp-director_v1beta1_openstacknetconfig_ipv6_in_ipv4.yaml
+    namespaced: true
+    ignoreFailure: true
+  - command: |
+      # blocked by webhook as the AllocationEnd does not match the IPv4 cidr information
+      oc apply -f ./osp-director_v1beta1_openstacknetconfig_ipv4_outside_range.yaml
+    namespaced: true
+    ignoreFailure: true

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/01-errors.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/01-errors.yaml
@@ -1,0 +1,30 @@
+#
+# Check for:
+#
+# - No noctlplane OpenStackNetConfig got created
+#
+
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: noctlplane
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: ipv4andipv6
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: ipv4mixipv6
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: ipv6inipv4
+---
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: allocoutsidecidr

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv4_and_ipv6_subnet.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv4_and_ipv6_subnet.yaml
@@ -1,0 +1,41 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: ipv4andipv6
+spec:
+  attachConfigurations:
+    br-osp:
+      nodeNetworkConfigurationPolicy:
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        desiredState:
+          interfaces:
+          - bridge:
+              options:
+                stp:
+                  enabled: false
+              port:
+              - name: enp7s0
+            description: Linux bridge with enp7s0 as a port
+            name: br-osp
+            state: up
+            type: linux-bridge
+            mtu: 1500
+  domainName: osptest.test.metalkube.org
+  dnsServers: ['172.22.0.1']
+  networks:
+  - name: Control
+    nameLower: ctlplane
+    subnets:
+    - name: ctlplane
+      ipv4:
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
+      ipv6:
+        cidr: 2001:db8:fd00:2000::/64
+        gateway: 2001:db8:fd00:2000::1
+        allocationEnd: 2001:db8:fd00:2000:ffff:ffff:ffff:fffe
+        allocationStart: 2001:db8:fd00:2000::100
+      attachConfiguration: br-osp

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv4_mix_ipv6_details.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv4_mix_ipv6_details.yaml
@@ -1,0 +1,36 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: ipv4mixipv6
+spec:
+  attachConfigurations:
+    br-osp:
+      nodeNetworkConfigurationPolicy:
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        desiredState:
+          interfaces:
+          - bridge:
+              options:
+                stp:
+                  enabled: false
+              port:
+              - name: enp7s0
+            description: Linux bridge with enp7s0 as a port
+            name: br-osp
+            state: up
+            type: linux-bridge
+            mtu: 1500
+  domainName: osptest.test.metalkube.org
+  dnsServers: ['172.22.0.1']
+  networks:
+  - name: Control
+    nameLower: ctlplane
+    subnets:
+    - name: ctlplane
+      ipv4:
+        allocationEnd: 2001:db8:fd00:2000:ffff:ffff:ffff:fffe
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
+      attachConfiguration: br-osp

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv4_outside_range.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv4_outside_range.yaml
@@ -1,0 +1,36 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: allocoutsidecidr
+spec:
+  attachConfigurations:
+    br-osp:
+      nodeNetworkConfigurationPolicy:
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        desiredState:
+          interfaces:
+          - bridge:
+              options:
+                stp:
+                  enabled: false
+              port:
+              - name: enp7s0
+            description: Linux bridge with enp7s0 as a port
+            name: br-osp
+            state: up
+            type: linux-bridge
+            mtu: 1500
+  domainName: osptest.test.metalkube.org
+  dnsServers: ['172.22.0.1']
+  networks:
+  - name: Control
+    nameLower: ctlplane
+    subnets:
+    - name: ctlplane
+      ipv4:
+        allocationEnd: 172.22.99.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
+      attachConfiguration: br-osp

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv6_in_ipv4.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_ipv6_in_ipv4.yaml
@@ -1,0 +1,36 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: ipv6inipv4
+spec:
+  attachConfigurations:
+    br-osp:
+      nodeNetworkConfigurationPolicy:
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        desiredState:
+          interfaces:
+          - bridge:
+              options:
+                stp:
+                  enabled: false
+              port:
+              - name: enp7s0
+            description: Linux bridge with enp7s0 as a port
+            name: br-osp
+            state: up
+            type: linux-bridge
+            mtu: 1500
+  domainName: osptest.test.metalkube.org
+  dnsServers: ['172.22.0.1']
+  networks:
+  - name: Control
+    nameLower: ctlplane
+    subnets:
+    - name: ctlplane
+      ipv4:
+        cidr: 2001:db8:fd00:2000::/64
+        gateway: 2001:db8:fd00:2000::1
+        allocationEnd: 2001:db8:fd00:2000:ffff:ffff:ffff:fffe
+        allocationStart: 2001:db8:fd00:2000::100
+      attachConfiguration: br-osp

--- a/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_no_ctlplane_net.yaml
+++ b/tests/kuttl/tests/openstacknetconfig_error_validation/osp-director_v1beta1_openstacknetconfig_no_ctlplane_net.yaml
@@ -1,0 +1,36 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackNetConfig
+metadata:
+  name: noctlplane
+spec:
+  attachConfigurations:
+    br-osp:
+      nodeNetworkConfigurationPolicy:
+        nodeSelector:
+          node-role.kubernetes.io/worker: ""
+        desiredState:
+          interfaces:
+          - bridge:
+              options:
+                stp:
+                  enabled: false
+              port:
+              - name: enp7s0
+            description: Linux bridge with enp7s0 as a port
+            name: br-osp
+            state: up
+            type: linux-bridge
+            mtu: 1500
+  domainName: osptest.test.metalkube.org
+  dnsServers: ['172.22.0.1']
+  networks:
+  - name: NoCtlplane
+    nameLower: noctlplane
+    subnets:
+    - name: noctlplane
+      ipv4:
+        allocationEnd: 172.22.0.250
+        allocationStart: 172.22.0.100
+        cidr: 172.22.0.0/24
+        gateway: 172.22.0.1
+      attachConfiguration: br-osp


### PR DESCRIPTION
Adds additional validation to check the osnetcfg:

* verifies the a network is tagged as the ctlplane network
* verifies information provided in ipv4/ipv6 section are
  actual ipv4/ipv6 information
* verifies that information in the ipv4 section is pure ipv4
* verifies ips provided for AllocationStart, AllocationEnd and
  Gateway are part of the network set via the Cidr
* verifies that in a subnet definition there is not both ipv4
  and ipv6 provided