### PR TITLE
Fix compute/osbms hostname to be FQDN

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -921,6 +921,7 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(
 	templateParameters := make(map[string]interface{})
 	templateParameters["AuthorizedKeys"] = sshSecret
 	templateParameters["Hostname"] = bmhStatus.Hostname
+	templateParameters["DomainName"] = osNetCfg.Spec.DomainName
 
 	//
 	// use same NodeRootPassword paremater as tripleo have
@@ -981,7 +982,6 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(
 	templateParameters["CtlplaneInterface"] = instance.Spec.CtlplaneInterface
 	templateParameters["CtlplaneGateway"] = ctlPlaneNetwork.Spec.Gateway
 	templateParameters["CtlplaneNetmask"] = fmt.Sprintf("%d.%d.%d.%d", netMask[0], netMask[1], netMask[2], netMask[3])
-	templateParameters["DomainName"] = osNetCfg.Spec.DomainName
 	if len(instance.Spec.BootstrapDNS) > 0 {
 		templateParameters["CtlplaneDns"] = instance.Spec.BootstrapDNS
 	} else {


### PR DESCRIPTION
DomainName was not correct to render the osbms userdata. Therefore
the DomainName was always empty and not set, which resulted in
osbms nodes to default to short hostname:

```
[root@computehci-1 ~]# hostname
computehci-1
[root@computehci-1 ~]# hostname --short
computehci-1
[root@computehci-1 ~]# hostname --long
computehci-1.osptest.test.metalkube.org
```

And osvmset nodes to fqdn:
```
[root@controller-0 ~]# hostname
controller-0.osptest.test.metalkube.org
[root@controller-0 ~]# hostname --short
controller-0
[root@controller-0 ~]# hostname --long
controller-0.osptest.test.metalkube.org
```

This sets the DomainName correct for the templateParameters that
the osbms cloud-init userdata has the DomainName information set.