### PR TITLE
Set BootOrder: 1 on rootdisk

### DIFF
--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -997,6 +997,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 			instance.Namespace,
 		)
 
+		bootDevice := uint(1)
 		vm.Spec.Template.Spec.Domain.Devices.Disks = vmset.MergeVMDisks(
 			vm.Spec.Template.Spec.Domain.Devices.Disks,
 			vmset.DiskSetterMap{
@@ -1005,18 +1006,21 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 					"virtio",
 					"",
 					instance.Spec.RootDisk.DedicatedIOThread,
+					&bootDevice,
 				),
 				"cloudinitdisk": vmset.Disk(
 					"cloudinitdisk",
 					"virtio",
 					"",
 					false,
+					nil,
 				),
 				"fencingdisk": vmset.Disk(
 					"fencingdisk",
 					"virtio",
 					"fencingdisk",
 					false,
+					nil,
 				),
 			},
 		)
@@ -1068,6 +1072,7 @@ func (r *OpenStackVMSetReconciler) vmCreateInstance(
 						"virtio",
 						"",
 						disk.DedicatedIOThread,
+						nil,
 					),
 				},
 			)

--- a/pkg/vmset/virtualmachine.go
+++ b/pkg/vmset/virtualmachine.go
@@ -39,6 +39,7 @@ func Disk(
 	bus string,
 	serial string,
 	dedicatedIOThread bool,
+	bootOrder *uint,
 ) DiskSetter {
 	return func(disk *virtv1.Disk) {
 		disk.Name = diskName
@@ -48,6 +49,9 @@ func Disk(
 		disk.DiskDevice.Disk = &virtv1.DiskTarget{}
 		disk.DiskDevice.Disk.Bus = bus
 		disk.DedicatedIOThread = &dedicatedIOThread
+		if bootOrder != nil {
+			disk.BootOrder = bootOrder
+		}
 	}
 }
 


### PR DESCRIPTION
To prevent an issue when the rootdisk is not the first
disk in the disk list, set BootOrder: 1 [1] on the rootdisk
as this is always the disk the VM should boot from.

[1] https://pkg.go.dev/kubevirt.io/api@v0.51.0/core/v1#Disk