### PR TITLE
Add default services to 17.0 or wallaby

### DIFF
--- a/api/v1beta2/openstackcontrolplane_webhook.go
+++ b/api/v1beta2/openstackcontrolplane_webhook.go
@@ -76,7 +76,7 @@ func (r *OpenStackControlPlane) Default() {
 	// set default for AdditionalServiceVIPs if non provided in ctlplane spec
 	// https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/deployment/network_v2.html#service-virtual-ips
 	//
-	if r.Status.OSPVersion == shared.TemplateVersion17_0 && r.Spec.AdditionalServiceVIPs == nil {
+	if (r.Status.OSPVersion == shared.TemplateVersion17_0 || r.Status.OSPVersion == shared.TemplateVersionWallaby) && r.Spec.AdditionalServiceVIPs == nil {
 		r.Spec.AdditionalServiceVIPs = map[string]string{
 			"Redis":  "internal_api",
 			"OVNDBs": "internal_api",


### PR DESCRIPTION
Right now the webhook only adds the default service list to
OSPVersion 17.0, but also need to be added for upstream wallaby.