### PR TITLE
Fix default route handling in VM nic template

### DIFF
--- a/controllers/openstackconfiggenerator_controller.go
+++ b/controllers/openstackconfiggenerator_controller.go
@@ -971,7 +971,7 @@ func (r *OpenStackConfigGeneratorReconciler) createVMRoleNicTemplates(
 			file := ""
 			nicTemplate := ""
 			if ospVersion == shared.OSPVersion(shared.TemplateVersion16_2) {
-				file = fmt.Sprintf("%s-%s", role.NameLower, openstackconfiggenerator.RenderedNicFileTrain)
+				file = openstackconfiggenerator.RenderedNicFileTrain
 				nicTemplate = fmt.Sprintf("/openstackconfiggenerator/config/%s/nic/%s", ospVersion, openstackconfiggenerator.NicTemplateTrain)
 			}
 			if ospVersion == shared.OSPVersion(shared.TemplateVersion17_0) {

--- a/pkg/openstackconfiggenerator/const.go
+++ b/pkg/openstackconfiggenerator/const.go
@@ -21,10 +21,10 @@ const (
 	AppLabel = "osp-openstackconfiggenerator"
 
 	// NicTemplateTrain - nic template file for train/16.2
-	NicTemplateTrain = "net-config-multi-nic.yaml"
+	NicTemplateTrain = "net-config-multi-nic.role.j2.yaml"
 
 	// RenderedNicFileTrain - suffix of the renered train/16.2 file
-	RenderedNicFileTrain = "nic-template.yaml"
+	RenderedNicFileTrain = "nic-template.role.j2.yaml"
 
 	// NicTemplateWallaby - nic template file for wallaby/17.0 and later
 	NicTemplateWallaby = "multiple_nics_dvr.j2"

--- a/templates/openstackconfiggenerator/config/16.2/nic/net-config-multi-nic.role.j2.yaml
+++ b/templates/openstackconfiggenerator/config/16.2/nic/net-config-multi-nic.role.j2.yaml
@@ -119,9 +119,11 @@ resources:
                 routes:
                   list_concat_unique:
                     - get_param: ControlPlaneStaticRoutes
+{{`{%- if role.default_route_networks is not defined or 'ControlPlane' in role.default_route_networks %}`}}
                     - - default: true
                         next_hop:
                           get_param: ControlPlaneDefaultRoute
+{{`{%- endif %}`}}
 {{- $nic_counter := 2 }}
 {{- range $netid, $net := .Role.Networks }}
 {{- if and (ne $net.Name "External") (ne $net.Name "Tenant") (ne $net.NameLower "ctlplane") }}
@@ -138,6 +140,11 @@ resources:
                   list_concat_unique:
                     - get_param: {{ $net.Name }}Routes
                     - get_param: {{ $net.Name }}InterfaceRoutes
+{{`{%- if '`}}{{ $net.Name }}{{`' in role.default_route_networks %}`}}
+                    - - default: true
+                        next_hop:
+                          get_param: {{ $net.Name }}InterfaceDefaultRoute
+{{`{%- endif %}`}}
 {{- else if ne $net.NameLower "ctlplane" }}
 {{- $nic_counter = add $nic_counter 1 }}
               - type: ovs_bridge
@@ -158,9 +165,11 @@ resources:
                   list_concat_unique:
                     - get_param: {{ $net.Name }}Routes
                     - get_param: {{ $net.Name }}InterfaceRoutes
+{{`{%- if '`}}{{ $net.Name }}{{`' in role.default_route_networks %}`}}
                     - - default: true
                         next_hop:
                           get_param: {{ $net.Name }}InterfaceDefaultRoute
+{{`{%- endif %}`}}
                 members:
                 - type: interface
                   name: nic{{ $nic_counter }}


### PR DESCRIPTION
Change the VM nic config template to a tripleo role template as it
needs to get the default_route_networks value from roles_data.yaml.

Update the template to only set default routes on the specified
interfaces.