### PR TITLE
ServiceVIP to be optional in IP reservation

### DIFF
--- a/api/v1beta1/openstacknet_types.go
+++ b/api/v1beta1/openstacknet_types.go
@@ -26,7 +26,7 @@ type IPReservation struct {
 	IP         string `json:"ip"`
 	Hostname   string `json:"hostname"`
 	VIP        bool   `json:"vip"`
-	ServiceVIP bool   `json:"serviceVIP"`
+	ServiceVIP bool   `json:"serviceVIP,omitempty"`
 	Deleted    bool   `json:"deleted"`
 }
 

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -2228,7 +2228,6 @@ spec:
                                           - deleted
                                           - hostname
                                           - ip
-                                          - serviceVIP
                                           - vip
                                           type: object
                                         type: array
@@ -5437,7 +5436,6 @@ spec:
                                           - deleted
                                           - hostname
                                           - ip
-                                          - serviceVIP
                                           - vip
                                           type: object
                                         type: array

--- a/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
@@ -129,7 +129,6 @@ spec:
                         - deleted
                         - hostname
                         - ip
-                        - serviceVIP
                         - vip
                         type: object
                       type: array


### PR DESCRIPTION
ServiceVIP is right now a required parameter in the IPReservation
type. This prevents update the operator in existing environments
from v1.2.x to later version as there is a validation if existing
object meet the requirements.
ServiceVIP is only used in OSP17 [1] environments and therefore
can be set to optional.

[1] https://github.com/openstack-k8s-operators/osp-director-operator/blob/master/controllers/openstackcontrolplane_controller.go#L885