### PR TITLE
[OSPK8-601] fix ansible-inventory jq query

### DIFF
--- a/templates/openstackclient/bin/ansible-inventory
+++ b/templates/openstackclient/bin/ansible-inventory
@@ -8,7 +8,7 @@ NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
 TOKEN=$(cat ${SERVICEACCOUNT}/token)
 CACERT=${SERVICEACCOUNT}/ca.crt
 
-ROLE_RESERVATIONS=$(curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/apis/osp-director.openstack.org/v1beta1/namespaces/$NAMESPACE/openstacknets/ctlplane | jq .spec.roleReservations | jq -r "to_entries | map(select(.value.addToPredictableIPs == true and .value.reservations[].vip == false and .value.reservations[].deleted == false)) | unique[]")
+ROLE_RESERVATIONS=$(curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/apis/osp-director.openstack.org/v1beta1/namespaces/$NAMESPACE/openstacknets/ctlplane | jq .spec.roleReservations | jq -r "to_entries | map(select(.value.addToPredictableIPs == true and .value.reservations[].vip == false)) | del(.[] | .value.reservations[] | select(.deleted? == true))| unique[]")
 
 ROLES=$(echo $ROLE_RESERVATIONS | jq -re '.key')
 


### PR DESCRIPTION
The current jq query does not filter deleted hosts correct. Instead
it checks if any node is not deleted and then adds all of the nodes
in a role. This changes the query to delete the deleted marked nodes
from the result.