### PR TITLE
[OSPK8-600] Don't delete role reservations with PreserveReservations true

### DIFF
--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -1250,10 +1250,12 @@ func (r *OpenStackNetConfigReconciler) ensureIPReservation(
 	}
 
 	//
-	// cleanup reservations from deleted roles
+	// cleanup reservations from osnet RoleReservations if
+	// * role is not in allRoles (ipset deleted)
+	// * and PreserveReservations is not set
 	//
 	for role := range osNet.Spec.RoleReservations {
-		if _, ok := allRoles[role]; !ok {
+		if _, ok := allRoles[role]; !ok && !*instance.Spec.PreserveReservations {
 			delete(osNet.Spec.RoleReservations, role)
 		}
 	}


### PR DESCRIPTION
In master of the osp-director-operator OSIPSet got introduced.
During the update from 1.2.x to latest the OSIPSets get created.
The OSNetConfig depends on the OSIPSet to identify which
reservations could be deleted. If an OSIPSet is gone the OSNetConfig
expects that the reservations for the whole role could be delted.

This conflicts during the update as there is no OSIPSet and therefore
the OSNetConfig will delete all reservations, only the nodes which
have static reservations are save to keep their current IPs.

This changes the OSNetConfig behaviour to not delete reservations
for deleted roles if Spec.PreserveReservations is set to true,
which is the default behaviour.