### PR TITLE
[OSPK8-602] OSP 17.0 fixes due to ooo changes

### DIFF
--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -90,8 +90,13 @@ HEAT_ENVIRONMENT_FILES="
     -e $TEMPLATES_DIR/tripleo-overcloud-images.yaml \
     -e $TEMPLATES_DIR/environments/deployed-server-environment.yaml \
     -e $TEMPLATES_DIR/environments/docker-ha.yaml \
+{{- if eq .OSPVersion "16.2" }}
     -e $TEMPLATES_DIR/environments/network-isolation.yaml \
     -e $TEMPLATES_DIR/environments/network-environment.yaml \
+{{- end }}
+{{- if eq .OSPVersion "17.0" }}
+    -e $TEMPLATES_DIR/environments/deployed-network-environment.yaml \
+{{- end }}
 {{- range $i, $value := .TripleoEnvironmentFiles }}
     -e $TEMPLATES_DIR/{{ $value }} \
 {{- end }}

--- a/templates/openstackconfiggenerator/config/17.0/rendered-tripleo-config.yaml
+++ b/templates/openstackconfiggenerator/config/17.0/rendered-tripleo-config.yaml
@@ -2,22 +2,6 @@
 # Resource Registry
 resource_registry:
   OS::TripleO::Server: deployed-server/deployed-server.yaml
-  OS::TripleO::Network: network/deployed_networks.yaml
-  OS::TripleO::DeployedServer::ControlPlanePort: deployed-server/deployed-neutron-port.yaml
-  OS::TripleO::Network::Ports::ControlPlaneVipPort: network/ports/deployed_vip_ctlplane.yaml
-  OS::TripleO::Network::Ports::ExternalVipPort: network/ports/deployed_vip_external.yaml
-  OS::TripleO::Network::Ports::InternalApiVipPort: network/ports/deployed_vip_internal_api.yaml
-  OS::TripleO::Network::Ports::StorageMgmtVipPort: network/ports/deployed_vip_storage_mgmt.yaml
-  OS::TripleO::Network::Ports::StorageVipPort: network/ports/deployed_vip_storage.yaml
-{{- range $roleid, $role := .RolesMap }}
-{{- if not $role.IsControlPlane }}
-{{- range $netid, $net := $role.Networks }}
-{{- if not $net.IsControlPlane }}
-  OS::TripleO::{{ $role.Name }}::Ports::{{ $net.Name }}Port: network/ports/deployed_{{ $net.NameLower }}.yaml
-{{- end}}
-{{- end }}
-{{- end }}
-{{- end }}
 
 # Parameter Defaults
 parameter_defaults:
@@ -149,92 +133,6 @@ parameter_defaults:
 {{- end }}
 {{- end }}
 {{- end }}
-  #
-  # DeployedNetworkEnvironment
-  DeployedNetworkEnvironment:
-    {{- /* net_attributes_map start */}}
-    net_attributes_map:
-      {{- $net_idx := 0 }}
-      {{- range $netname, $net := .NetworksMap }}
-      {{- if not $net.IsControlPlane }}
-      {{ $net.NameLower }}:
-        network:
-          dns_domain: {{ $net.DomainName }}.
-          mtu: {{ $net.MTU }}
-          name: {{ $net.NameLower }}
-          tags:
-          - tripleo_network_name={{$net.Name }}
-          - tripleo_net_idx={{ $net_idx }}
-          {{- $net_idx = add $net_idx 1 }}
-          - tripleo_vip={{ $net.VIP }}
-        {{- /* subnets start */}}
-        subnets:
-        {{- range $subnetname, $subnet := $net.Subnets }}
-          {{ $subnetname }}_subnet:
-          {{- /* IPv4 subnet start */ -}}
-          {{- if ne $subnet.IPv4.Cidr "" }}
-            cidr: '{{ $subnet.IPv4.Cidr }}'
-            dns_nameservers: []
-            gateway_ip: {{ $subnet.IPv4.Gateway }}
-            host_routes: {{ if eq (len $subnet.IPv4.Routes) 0 }}[]{{ else }}
-              {{- range $netname, $route := $subnet.IPv4.Routes }}
-              - destination: '{{ $route.Destination }}'
-                nexthop: '{{ $route.Nexthop }}'
-              {{- end }}
-              {{- end }}
-            ip_version: 4
-            name: {{ $subnetname }}
-            tags: {{ if eq $subnet.Vlan 0 }}[]{{ else }}
-              - tripleo_vlan_id={{ $subnet.Vlan }}
-            {{- end }}
-          {{- end }}
-          {{- /* IPv4 subnet end */}}
-          {{- /* IPv6 subnet start */ -}}
-          {{- if ne $subnet.IPv6.Cidr "" }}
-            cidr: '{{ $subnet.IPv6.Cidr }}'
-            dns_nameservers: []
-            gateway_ip: {{ $subnet.IPv6.Gateway }}
-            host_routes: {{ if eq (len $subnet.IPv6.Routes) 0 }}[]{{ else }}
-              {{- range $netname, $route := $subnet.IPv6.Routes }}
-              - destination: '{{ $route.Destination }}'
-                nexthop: '{{ $route.Nexthop }}'
-              {{- end }}
-              {{- end }}
-            ip_version: 6
-            name: {{ $subnetname }}
-            tags: {{ if eq $subnet.Vlan 0 }}[]{{ else }}
-              - tripleo_vlan_id={{ $subnet.Vlan }}
-            {{- end }}
-          {{- end }}
-          {{- /* IPv6 subnet end */ -}}
-        {{- end }}
-        {{- /* subnets end */ -}}
-      {{- end }}
-      {{- end }}
-    {{- /* net_attributes_map end */ -}}
-    {{- /* net_cidr_map start */}}
-    net_cidr_map:
-      {{- range $netname, $net := .NetworksMap }}
-      {{- if not $net.IsControlPlane }}
-      {{ $net.NameLower }}:
-      {{- range $subnetname, $subnet := $net.Subnets }}
-      {{- if $net.IPv6 }}
-      - '{{ $subnet.IPv6.Cidr }}'
-      {{-  else }}
-      - '{{ $subnet.IPv4.Cidr }}'
-      {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- end }}
-    {{- /* net_cidr_map end */ -}}
-    {{- /* net_ip_version_map start */}}
-    net_ip_version_map:
-      {{- range $netname, $net := .NetworksMap }}
-      {{- if not $net.IsControlPlane }}
-      {{ $net.NameLower }}: {{ if $net.IPv6 }}6{{ else }}4{{ end }}
-      {{- end }}
-      {{- end }}
-    {{- /* net_ip_version_map end */}}
   #
   # CtlplaneNetworkAttributes
   CtlplaneNetworkAttributes:


### PR DESCRIPTION
* [1] removed environments/network-isolation.yaml file in wallaby
* [2] introduced the environments/deployed-network-environment.j2.yaml to
created the DeployedNetworkEnvironment + register required resources for
deployed network scenario.

Therefore we remove environments/network-isolation.yaml and
environments/network-environment.yaml from the OSP17.0 stack create
command, remove the rendering of DeployedNetworkEnvironment via the operator
and add instead `-e environments/deployed-network-environment.yaml` for OSP17.

[1] https://github.com/openstack/tripleo-heat-templates/commit/5f97b4136041c2b4fbbf0f5aa407941c3ec61f23
[2] https://github.com/openstack/tripleo-heat-templates/commit/8550b8482fab548d24304f2f7014bd277560eb1c