### PR TITLE
Use Makefile targets for golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,17 +13,12 @@ jobs:
           go-version: 1.17.8
       - name: Checkout project code
         uses: actions/checkout@v2
-      - name: Checkout openstack-k8s-operators-ci project
-        uses: actions/checkout@v2
-        with:
-          repository: openstack-k8s-operators/openstack-k8s-operators-ci
-          path: ./openstack-k8s-operators-ci
       - name: Run govet.sh
-        run: ./openstack-k8s-operators-ci/test-runner/govet.sh
+        run: make govet
       - name: Run golint.sh
-        run: ./openstack-k8s-operators-ci/test-runner/golint.sh
+        run: make golint
       - name: Run gotest.sh
-        run: ./openstack-k8s-operators-ci/test-runner/gotest.sh
+        run: make gotest
 
   golangci:
     name: github (golangci)
@@ -36,6 +31,4 @@ jobs:
       - name: Checkout project code
         uses: actions/checkout@v2
       - name: Run golangci lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          args: --timeout 5m
+        run: make golangci

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ gotest: get-ci-tools
 
 # Run golangci-lint test against code
 golangci: get-ci-tools
-	$(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh
+	$(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh "." 10
 
 # Run go lint against code
 golint: get-ci-tools


### PR DESCRIPTION
Lets use the same approach like when running local and use the Makefile
targets.