### PR TITLE
DNM Test: Debug golangci failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package main
 
+hello hello this is a test
+
 import (
 	"flag"
 	"fmt"


### PR DESCRIPTION
HItting this failure in MariaDB, checking if same issue on osp-director-operator

https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/30638/rehearse-30638-pull-ci-openstack-k8s-operators-mariadb-operator-master-golangci/1551583824574418944/build-log.txt

~~~
+ echoerr golangci/golangci-lint crit 'unable to find '\'''\'' - use '\''latest'\'' or see https://github.com/golangci/golangci-lint/releases for details'
+ echo golangci/golangci-lint crit 'unable to find '\'''\'' - use '\''latest'\'' or see https://github.com/golangci/golangci-lint/releases for details'
golangci/golangci-lint crit unable to find '' - use 'latest' or see https://github.com/golangci/golangci-lint/releases for details
+ exit 1
~~~