### PR TITLE
allign heat tunings with traditional undercloud

### DIFF
--- a/templates/openstackephemeralheat/bin/heat.conf
+++ b/templates/openstackephemeralheat/bin/heat.conf
@@ -9,6 +9,11 @@ deferred_auth_method=password
 max_nested_stack_depth=10
 max_json_body_size=8388608
 default_deployment_signal_transport=HEAT_SIGNAL
+max_resources_per_stack=-1
+convergence_engine=True
+max_nested_stack_depth=7
+num_engine_workers=4
+rpc_response_timeout=600
 [database]
 connection=mysql+pymysql://heat:{{.MariaDBPassword}}@{{.MariaDBHost}}/heat
 max_retries=-1
@@ -21,3 +26,7 @@ memory_quota=900000
 limit_iterators=9000
 [noauth]
 token_response=/etc/heat/token.json
+[oslo_messaging_rabbit]
+heartbeat_timeout_threshold=60
+[oslo_middleware]
+enable_proxy_headers_parsing=True


### PR DESCRIPTION
Current config version made playbook create to fail on slower/busy ocp cluster.
With these changes taken from a 16.2 traditional undercloud it worked fine.