### PR TITLE
Fix multi subnet routes ... again

### DIFF
--- a/templates/openstackconfiggenerator/config/16.2/nic/net-config-multi-nic.role.j2.yaml
+++ b/templates/openstackconfiggenerator/config/16.2/nic/net-config-multi-nic.role.j2.yaml
@@ -73,6 +73,14 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  {{`{{network.name}}`}}Routes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
 {%- endfor %}
 {% for network in networks if network.name == "External" and 'external_bridge' in role.tags and not network.name in _role_networks %}
   {{`{{network.name}}`}}Mtu:
@@ -155,6 +163,7 @@ resources:
                     get_param: {{`{{network.name}}`}}IpSubnet
                 routes:
                   list_concat_unique:
+                    - get_param: {{`{{network.name}}`}}Routes
                     - get_param: {{`{{network.name}}`}}InterfaceRoutes
 {%-             if network.name in role.default_route_networks %}
                     - - default: true
@@ -181,6 +190,7 @@ resources:
                     get_param: {{`{{network.name}}`}}IpSubnet
                 routes:
                   list_concat_unique:
+                    - get_param: {{`{{network.name}}`}}Routes
                     - get_param: {{`{{network.name}}`}}InterfaceRoutes
 {%-             if network.name in role.default_route_networks %}
                     - - default: true


### PR DESCRIPTION
This was missed when we switched to role nic template a while ago.

As mentioned in [1]:
The OSP 16.2 tripleo nic templates have the <netName>InterfaceRoutes parameter
per default included. The routes parameter rendered in
environments/network-environment.yaml which are named <netName>Routes get
usually set on the neutron network host_routes property and get added to the
role <netName>InterfaceRoutes parameter.

[1] https://github.com/openstack-k8s-operators/osp-director-operator/pull/529