### PR TITLE
Add MysqlMariabackupPassword to generate password list

### DIFF
--- a/pkg/bindata_util/render.go
+++ b/pkg/bindata_util/render.go
@@ -3,7 +3,6 @@ package bindatautil
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +74,7 @@ func RenderTemplate(path string, d *RenderData) ([]*unstructured.Unstructured, e
 	tmpl.Funcs(template.FuncMap{"getOr": common.GetOr, "isSet": common.IsSet})
 	tmpl.Funcs(sprig.TxtFuncMap())
 
-	source, err := ioutil.ReadFile(path)
+	source, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read manifest %s", path)
 	}

--- a/pkg/common/fencing.go
+++ b/pkg/common/fencing.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/tidwall/gjson"
 	"sigs.k8s.io/yaml"
@@ -60,7 +59,7 @@ func GetCustomFencingRoles(customBinaryData map[string][]byte) ([]string, error)
 			switch header.Typeflag {
 			case tar.TypeReg:
 				if header.Name == TripleORolesDataFile {
-					buf, err := ioutil.ReadAll(tarReader)
+					buf, err := io.ReadAll(tarReader)
 
 					if err != nil {
 						return nil, err

--- a/pkg/common/passwords.go
+++ b/pkg/common/passwords.go
@@ -71,6 +71,7 @@ func passwordNames() []string {
 		"ManilaPassword",
 		"MistralPassword",
 		"MysqlClustercheckPassword",
+		"MysqlMariabackupPassword",
 		"MysqlRootPassword",
 		"NeutronMetadataProxySharedSecret",
 		"NeutronPassword",

--- a/pkg/common/template_util.go
+++ b/pkg/common/template_util.go
@@ -3,7 +3,6 @@ package common
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -96,7 +95,7 @@ func GetAllTemplates(path string, kind string, templateType string, version stri
 // execute it with the specified data
 func ExecuteTemplate(templateFile string, data interface{}) (string, error) {
 
-	b, err := ioutil.ReadFile(templateFile)
+	b, err := os.ReadFile(templateFile)
 	if err != nil {
 		return "", err
 	}
@@ -156,7 +155,7 @@ func ExecuteTemplateFile(filename string, data interface{}) (string, error) {
 		filepath = path.Join(templates + filename)
 	}
 
-	b, err := ioutil.ReadFile(filepath)
+	b, err := os.ReadFile(filepath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Upstream wallaby deployment fail right now with:
```
2022-08-10T14:00:34.772309024Z 2022-08-10 14:00:30Z [overcloud.ControllerServiceChain]: CREATE_FAILED  resources.ServiceChain: resources.ControllerServiceChain.Property error: resources[88].properties: Property MysqlMariabackupPassword not assigned
2022-08-10T14:00:34.772309024Z 2022-08-10 14:00:30Z [overcloud]: CREATE_FAILED  Resource CREATE failed: resources.ServiceChain: resources.ControllerServiceChain.Property error: resources[88].properties: Property MysqlMariabackupPassword not assigned
```

This is due to this change:

releasenotes/notes/galera-sst-mariabackup-5a667eed1787353f.yaml
features:
  - |
    When deploying a new HA overcloud, the mysql/galera service can now be
    configured to use mariabackup for State Snapshot Transfers (SST) by
    configuring the new Heat parameter `MysqlGaleraSSTMethod`. Mariabackup
    SST uses a dedicated SQL user with the appropriate grants to transfer
    the database content across nodes. The user credentials can be
    configured via two additional Heat parameters `MysqlMariabackupUser`
    and `MysqlMariabackupPassword`.

upgrade:
  - |
    The new support for mariabackup SST for the mysql/galera service is
    currently limited to new overcloud deployments. Doing a stack update
    to change SST method from rsync to mariabackup or the other way around
    is currently not supported.