### PR TITLE
[OSPK8-617] Set storage class when creating VMSet DVs

### DIFF
--- a/pkg/vmset/virtualmachine.go
+++ b/pkg/vmset/virtualmachine.go
@@ -171,6 +171,7 @@ func DataVolume(
 		dataVolume.Spec.PVC.AccessModes = []corev1.PersistentVolumeAccessMode{
 			corev1.PersistentVolumeAccessMode(pvAccessMode),
 		}
+		dataVolume.Spec.PVC.StorageClassName = &storageClass
 
 		dataVolume.Spec.PVC.Resources = corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{


### PR DESCRIPTION
We forgot to set the `storageClass` on the PVC for any DataVolumes we create for the OSP VM controllers