### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  ignore:
+    - dependency-name: "github.com/coreos/ignition"


### PR DESCRIPTION
Initial dependabot config setup to ignore github.com/coreos/ignition
which we don't use directly.