### PR TITLE
Change RunStrategy of VMs to manual

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=osp-director-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.23.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -823,6 +823,12 @@ rules:
   verbs:
   - use
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachines/start
+  verbs:
+  - update
+- apiGroups:
   - template.openshift.io
   resourceNames:
   - privileged

--- a/pkg/common/job_util.go
+++ b/pkg/common/job_util.go
@@ -76,8 +76,8 @@ func WaitOnJob(
 	if foundJob.Status.Active > 0 {
 		log.Info("Job Status Active... requeuing")
 		return true, err
-        } else if foundJob.Status.Succeeded > 0 {
-                log.Info("Job Status Successful")
+	} else if foundJob.Status.Succeeded > 0 {
+		log.Info("Job Status Successful")
 	} else if foundJob.Status.Failed > 0 {
 		log.Info("Job Status Failed")
 		return true, k8s_errors.NewInternalError(errors.New("Job Failed. Check job logs"))


### PR DESCRIPTION
Fencing can fail with current RunStrategy RerunOnFailure because
fencing is not a graceful shutdown and kubevirt will jump in and
restart immediately the VM, but fence_kubevirt is waiting for
the successful shutdown state of the VM befor triggering the start.

This changes the RunStrategy to manual and only triggers a start
of the VM once when the VM CR got created. After that its the
responsibility if the end user, or pacemaker to manage the power
state of the VMs.

Resolves: rhbz#2126727