### PR TITLE
[v1.3.x backport] Change RunStrategy of VMs to manual

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -823,6 +823,12 @@ rules:
   verbs:
   - use
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachines/start
+  verbs:
+  - update
+- apiGroups:
   - template.openshift.io
   resourceNames:
   - privileged


### PR DESCRIPTION
Fencing can fail with current RunStrategy RerunOnFailure because fencing is not a graceful shutdown and kubevirt will jump in and restart immediately the VM, but fence_kubevirt is waiting for the successful shutdown state of the VM befor triggering the start.

This changes the RunStrategy to manual and only triggers a start of the VM once when the VM CR got created. After that its the responsibility if the end user, or pacemaker to manage the power state of the VMs.

(cherry picked from commit 4c7baead51b196363614bf3e7a682aa33b041162)