### PR TITLE
Move EnableFencing to OpenStackConfigGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ Create a base RHEL data volume prior to deploying OpenStack.  This will be used 
       name: default
       namespace: openstack
     spec:
+      enableFencing: False
       imageURL: quay.io/openstack-k8s-operators/rhosp16-openstack-tripleoclient:16.2_20210713.1
       gitSecret: git-secret
       heatEnvConfigMap: heat-env-config
@@ -1364,7 +1365,6 @@ spec:
         storageClass: host-nfs-storageclass
         storageAccessMode: ReadWriteMany
         storageVolumeMode: Filesystem
-  enableFencing: False
 ```
 
 ### Create the computes for the leafs

--- a/api/v1beta1/openstackconfiggenerator_types.go
+++ b/api/v1beta1/openstackconfiggenerator_types.go
@@ -45,6 +45,11 @@ type OpenStackConfigGeneratorSpec struct {
 	// +kubebuilder:default={}
 	// Optional. List of Roles used to limit which roles have network information injected during playbook generation. By default the list is empty and all Roles are included for Baremetal/Vmsets within the project.
 	Roles []string `json:"roles,omitempty"`
+	// EnableFencing allows the automatic creation of required heat environment files to enable fencing.
+	// Note:
+	// - Production OSP environments MUST have fencing enabled.
+	// - Requires the fence-agents-kubevirt package to be installed in the virtual machines for the roles running pacemaker.
+	EnableFencing bool `json:"enableFencing"`
 }
 
 // OpenStackConfigGeneratorStatus defines the observed state of OpenStackConfigGenerator

--- a/api/v1beta2/openstackcontrolplane_types.go
+++ b/api/v1beta2/openstackcontrolplane_types.go
@@ -38,11 +38,6 @@ type OpenStackControlPlaneSpec struct {
 	// OpenStackClientNetworks the name(s) of the OpenStackClientNetworks used to attach the openstackclient to
 	OpenStackClientNetworks []string `json:"openStackClientNetworks"`
 
-	// +kubebuilder:default=false
-	// EnableFencing is provided so that users have the option to disable fencing if desired
-	// FIXME: Defaulting to false until Kubevirt agent merged into RHEL overcloud image
-	EnableFencing bool `json:"enableFencing"`
-
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum={"train","wallaby","16.2","17.0"}
 	// OpenStackRelease to overwrite OSPrelease auto detection from tripleoclient container image

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -3832,13 +3832,6 @@ spec:
                                   description: Name of the config map containing custom
                                     CA certificates to trust
                                   type: string
-                                enableFencing:
-                                  default: false
-                                  description: 'EnableFencing is provided so that
-                                    users have the option to disable fencing if desired
-                                    FIXME: Defaulting to false until Kubevirt agent
-                                    merged into RHEL overcloud image'
-                                  type: boolean
                                 idmSecret:
                                   description: Idm secret used to register openstack
                                     client in IPA
@@ -4145,7 +4138,6 @@ spec:
                                   description: List of VirtualMachine roles
                                   type: object
                               required:
-                              - enableFencing
                               - virtualMachineRoles
                               type: object
                             status:

--- a/config/crd/bases/osp-director.openstack.org_openstackconfiggenerators.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackconfiggenerators.yaml
@@ -46,6 +46,13 @@ spec:
             description: OpenStackConfigGeneratorSpec defines the desired state of
               OpenStackConfigGenerator
             properties:
+              enableFencing:
+                description: 'EnableFencing allows the automatic creation of required
+                  heat environment files to enable fencing. Note: - Production OSP
+                  environments MUST have fencing enabled. - Requires the fence-agents-kubevirt
+                  package to be installed in the virtual machines for the roles running
+                  pacemaker.'
+                type: boolean
               ephemeralHeatSettings:
                 description: Advanced Heat Settings can be used to increase the Heat
                   Engine replicas or customize container images used during config
@@ -119,6 +126,7 @@ spec:
                   Heat template tarball which will be extracted prior to config generation
                 type: string
             required:
+            - enableFencing
             - gitSecret
             - heatEnvConfigMap
             type: object

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -361,12 +361,6 @@ spec:
                 description: Name of the config map containing custom CA certificates
                   to trust
                 type: string
-              enableFencing:
-                default: false
-                description: 'EnableFencing is provided so that users have the option
-                  to disable fencing if desired FIXME: Defaulting to false until Kubevirt
-                  agent merged into RHEL overcloud image'
-                type: boolean
               idmSecret:
                 description: Idm secret used to register openstack client in IPA
                 type: string
@@ -632,7 +626,6 @@ spec:
                 description: List of VirtualMachine roles
                 type: object
             required:
-            - enableFencing
             - virtualMachineRoles
             type: object
           status:

--- a/config/samples/osp-director_v1beta1_openstackconfiggenerator.yaml
+++ b/config/samples/osp-director_v1beta1_openstackconfiggenerator.yaml
@@ -3,6 +3,7 @@ kind: OpenStackConfigGenerator
 metadata:
   name: default
 spec:
+  enableFencing: false
   gitSecret: git-secret
   heatEnvConfigMap: heat-env-config
   tarballConfigMap: tripleo-tarball-config

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: openstack
 spec:
   domainName: ostest.test.metalkube.org
-  enableFencing: false
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane

--- a/config/samples/osp-director_v1beta1_openstackcontrolplane_single_net.yaml
+++ b/config/samples/osp-director_v1beta1_openstackcontrolplane_single_net.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: openstack
 spec:
   domainName: ostest.test.metalkube.org
-  enableFencing: false
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane

--- a/config/samples/osp-director_v1beta2_openstackcontrolplane.yaml
+++ b/config/samples/osp-director_v1beta2_openstackcontrolplane.yaml
@@ -4,7 +4,6 @@ metadata:
   name: overcloud
   namespace: openstack
 spec:
-  enableFencing: false
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane

--- a/config/samples/osp-director_v1beta2_openstackcontrolplane_single_net.yaml
+++ b/config/samples/osp-director_v1beta2_openstackcontrolplane_single_net.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: openstack
 spec:
   domainName: ostest.test.metalkube.org
-  enableFencing: false
   openStackClientImageURL: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
   openStackClientNetworks:
   - ctlplane

--- a/controllers/openstackconfiggenerator_controller.go
+++ b/controllers/openstackconfiggenerator_controller.go
@@ -720,7 +720,7 @@ func (r *OpenStackConfigGeneratorReconciler) createFencingEnvironmentFiles(
 	//
 	templateParameters["EnableFencing"] = false
 
-	if controlPlane.Spec.EnableFencing {
+	if instance.Spec.EnableFencing {
 		fencingRoles := common.GetFencingRoles()
 
 		// First check if custom roles were included that require fencing


### PR DESCRIPTION
The EnableFencing parameter is only used in the ConfigGenerator to auto create templates to enable fencing. Therefore it makes sense to have this parameter in the ConfigGenerator CRD instead of the ControlPlane.

Also as it is a required parameter lets not specify a default and have the user to explicitely either enable or disable it so that the user is being forced to set either state.