### PR TITLE
Allow updating password secret with new/missing passwords

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog v1.0.0 // indirect


### PR DESCRIPTION
Right now the tripleo password secret only gets created once if it does not exist. If a new operator version introduces a new password, this would not get added to the password secret of an existing environment.

This change validates if the password list is missing any entry on the top level. If there is one missing it merges the new password map[string]interface{} into the existing. It only validates if the password list is complete, using the highest level password keys.