### PR TITLE
Align kube-rbac-proxy versions

### DIFF
--- a/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/osp-director-operator.clusterserviceversion.yaml
@@ -177,6 +177,6 @@ spec:
     name: osp-director-operator
   - image: registry.redhat.io/rhel8/httpd-24:latest
     name: apache
-  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
     name: kube-rbac-proxy
   version: 0.0.0


### PR DESCRIPTION
This updates the relatedImages version to match the one we use in config/default/manager_auth_proxy_patch.yaml.

TODO: look into adding a common ENV variable for these