### PR TITLE
Fix IsReady cond reason

### DIFF
--- a/api/v1beta2/openstackvmset_types.go
+++ b/api/v1beta2/openstackvmset_types.go
@@ -146,7 +146,7 @@ type Host struct {
 func (instance *OpenStackVMSet) IsReady() bool {
 	cond := instance.Status.Conditions.InitCondition()
 
-	return cond.Reason == shared.VMSetCondReasonProvisioned || cond.Reason == shared.VMSetCondReasonVirtualMachineCountZero
+	return cond.Reason == shared.VMSetCondReasonVirtualMachineProvisioned || cond.Reason == shared.VMSetCondReasonVirtualMachineCountZero
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
Creating a backup is stuck in quiescing because IsReady() from OSVMSet is using OpenStackVMSetProvisioned instead of VMSetCondReasonVirtualMachineProvisioned as set in the controller at
https://github.com/openstack-k8s-operators/osp-director-operator/blob/v1.3.x/controllers/openstackvmset_controller.go#L1703

This alligns IsReady to use VMSetCondReasonVirtualMachineProvisioned.