### PR TITLE
Enable dependabot for branch v1.3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     interval: "daily"
   ignore:
     - dependency-name: "github.com/coreos/ignition"
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "v1.3.x"
+  ignore:
+    - dependency-name: "github.com/coreos/ignition"


### PR DESCRIPTION
Instead of cherry-pick dependabot PRs to v1.3.x branch, which can fail due to inconsitency of go.sum between the branches, enable dependabot for v1.3.x branch.