### PR TITLE
dependabot optimization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     interval: "daily"
   ignore:
     - dependency-name: "github.com/coreos/ignition"
+    - dependency-name: "kubevirt.io/api"
+    - dependency-name: "kubevirt.io/client-go"
+    - dependency-name: "kubevirt.io/containerized-data-importer-api"
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
@@ -13,3 +16,9 @@ updates:
   target-branch: "v1.3.x"
   ignore:
     - dependency-name: "github.com/coreos/ignition"
+    - dependency-name: "kubevirt.io/api"
+    - dependency-name: "kubevirt.io/client-go"
+    - dependency-name: "kubevirt.io/containerized-data-importer-api"
+  commit-message:
+    # Prefix all commit messages with "[v1.3.x]"
+    prefix: "[v1.3.x]"


### PR DESCRIPTION
* prefix all v1.3.x target PRs with [v1.3.x]
* exclude kubevirt from being updated
    - dependency-name: "kubevirt.io/api"
    - dependency-name: "kubevirt.io/client-go"
    - dependency-name: "kubevirt.io/containerized-data-importer-api"