### PR TITLE
Use cloud-admin user for local ansible task

### DIFF
--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -138,15 +138,15 @@ play() {
       register: deploy_exists
       ignore_unreachable: yes
     - set_fact:
-        deploy_exists: "{{ hostvars['localhost'].deploy_exists|default('0')|int + 1 }}"
+        deploy_exists: "{{ hostvars['undercloud'].deploy_exists|default('0')|int + 1 }}"
       when: deploy_exists.stat.exists|default(False)
-      delegate_to: localhost
+      delegate_to: undercloud
       delegate_facts: yes
     - copy:
         dest: stack_action_override.yaml
         content: |
-          stack_action: {{ 'UPDATE' if hostvars['localhost'].deploy_exists|default('0')|int > 0 else 'CREATE' }}
-      delegate_to: localhost
+          stack_action: {{ 'UPDATE' if hostvars['undercloud'].deploy_exists|default('0')|int > 0 else 'CREATE' }}
+      delegate_to: undercloud
       run_once: yes
 EOF`}}
 

--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -156,7 +156,8 @@ out_dir = oooutils.download_ansible_playbooks(client, 'overcloud', output_dir='/
 inventory = TripleoInventory(
     hclient=client,
     plan_name='overcloud',
-    ansible_ssh_user='cloud-admin')
+    ansible_ssh_user='cloud-admin',
+    username='cloud-admin')
 
 extra_vars = {
     'Standalone': {


### PR DESCRIPTION
The username was not set in the inventory for the "undercloud" host so defaulted to root.
The implicit "localhost" in the inventory also defaults to root.

As a result any files copied locally by ansible were owned by root instead of the cloud-admin user. E.g ceph-ansible and stack_action_override.yaml

This sets the correct user for the undecloud host in inventory and switches from localhost to the "undercloud" host for the stack_action_override.yaml generation.