### PR TITLE
Really use cloud-admin user for local ansible task

### DIFF
--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -132,6 +132,7 @@ play() {
 - hosts: overcloud
   name: Determine the correct stack action for 16.2 deployments
   gather_facts: false
+  become: false
   tasks:
     - stat:
         path: /var/lib/tripleo-config


### PR DESCRIPTION
This appeared to be working when I manually tested it but is not. Turns out the reason root owns the files is tripleo-deploy.sh sets ANSIBLE_BECOME="True". We have to expliciltly disable it if we want the current user.

Fix this for the stack_action_playbook generation. Other cases that hit this such as ceph-ansible will need to be fixed in upstream t-h-t.