### PR TITLE
Support creating bundle and index image for 16.2 and 17.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ kuttl-test.json
 !vendor/**/zz_generated.*
 /bundle/
 config/manager/kustomization.yaml
+config/default/manager_default_images.yaml
 
 # editor and IDE paraphernalia
 .idea

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
 
+OSP_RELEASE ?= 16.2
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -223,10 +225,12 @@ $(ENVTEST): $(LOCALBIN)
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	cp -f config/default/manager_default_images_${OSP_RELEASE}.yaml config/default/manager_default_images.yaml
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
+	rm -f config/default/manager_default_images.yaml
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=osp-director-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.23.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/config/default/manager_default_images_16.2.yaml
+++ b/config/default/manager_default_images_16.2.yaml
@@ -1,0 +1,31 @@
+# This patch inject custom ENV settings to the manager container
+# Used to set our default image locations
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: OPENSTACKCLIENT_IMAGE_URL_DEFAULT
+          value: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
+        - name: HEAT_API_IMAGE_URL_DEFAULT
+          value: registry.redhat.io/rhosp-rhel8/openstack-heat-api:16.2
+        - name: HEAT_ENGINE_IMAGE_URL_DEFAULT
+          value: registry.redhat.io/rhosp-rhel8/openstack-heat-engine:16.2
+        - name: MARIADB_IMAGE_URL_DEFAULT
+          value: registry.redhat.io/rhosp-rhel8/openstack-mariadb:16.2
+        - name: RABBITMQ_IMAGE_URL_DEFAULT
+          value: registry.redhat.io/rhosp-rhel8/openstack-rabbitmq:16.2
+        - name: DOWNLOADER_IMAGE_URL_DEFAULT
+          value: registry.redhat.io/rhosp-rhel8/osp-director-downloader:1.3.0
+        - name: AGENT_IMAGE_URL_DEFAULT
+          value: registry.rehat.io/rhosp-rhel8/osp-director-agent:1.3.0
+        - name: APACHE_IMAGE_URL_DEFAULT
+          value: registry.redhat.io/rhel8/httpd-24:latest
+        - name: OPENSTACK_RELEASE_DEFAULT
+          value: "16.2"

--- a/config/default/manager_default_images_17.0.yaml
+++ b/config/default/manager_default_images_17.0.yaml
@@ -12,20 +12,20 @@ spec:
       - name: manager
         env:
         - name: OPENSTACKCLIENT_IMAGE_URL_DEFAULT
-          value: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
+          value: registry.redhat.io/rhosp-rhel9/openstack-tripleoclient:17.0
         - name: HEAT_API_IMAGE_URL_DEFAULT
-          value: registry.redhat.io/rhosp-rhel8/openstack-heat-api:16.2
+          value: registry.redhat.io/rhosp-rhel9/openstack-heat-api:17.0
         - name: HEAT_ENGINE_IMAGE_URL_DEFAULT
-          value: registry.redhat.io/rhosp-rhel8/openstack-heat-engine:16.2
+          value: registry.redhat.io/rhosp-rhel9/openstack-heat-engine:17.0
         - name: MARIADB_IMAGE_URL_DEFAULT
-          value: registry.redhat.io/rhosp-rhel8/openstack-mariadb:16.2
+          value: registry.redhat.io/rhosp-rhel9/openstack-mariadb:17.0
         - name: RABBITMQ_IMAGE_URL_DEFAULT
-          value: registry.redhat.io/rhosp-rhel8/openstack-rabbitmq:16.2
+          value: registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
         - name: DOWNLOADER_IMAGE_URL_DEFAULT
-          value: registry.redhat.io/rhosp-rhel8-tech-preview/osp-director-downloader:1.0
+          value: registry.redhat.io/rhosp-rhel8/osp-director-downloader:1.3.0
         - name: AGENT_IMAGE_URL_DEFAULT
-          value: quay.io/openstack-k8s-operators/osp-director-agent:0.0.1
+          value: registry.rehat.io/rhosp-rhel8/osp-director-agent:1.3.0
         - name: APACHE_IMAGE_URL_DEFAULT
           value: registry.redhat.io/rhel8/httpd-24:latest
         - name: OPENSTACK_RELEASE_DEFAULT
-          value: "16.2"
+          value: "17.0"

--- a/scripts/build_and_push_images.sh
+++ b/scripts/build_and_push_images.sh
@@ -15,11 +15,10 @@ fi
 VERSION=${1:-"17.0.1"}
 REPO=${2:-"quay.io/openstack-k8s-operators"}
 OP_NAME=${3:-"osp-director-operator"}
+OSP_RELEASES="16.2 17.0"
 IMG="$REPO/$OP_NAME":$VERSION
 IMAGE_TAG_BASE="$REPO/$OP_NAME"
-INDEX_IMG="$REPO/$OP_NAME-index:$VERSION"
 
-BUNDLE_IMG="$REPO/$OP_NAME-bundle:$VERSION"
 
 AGENT_IMAGE="$OP_NAME-agent"
 AGENT_IMG_BASE="$REPO/$AGENT_IMAGE"
@@ -43,54 +42,60 @@ make IMG=${AGENT_IMG} osp-director-operator-agent-image-build docker-push
 # Downloader image
 make IMG=${DOWNLOADER_IMG} osp-director-downloader-image-build docker-push
 
-rm -Rf bundle
-rm -Rf bundle.Dockerfile
+for OSP_RELEASE in ${OSP_RELEASES}; do
+  VERSION_RELEASE="${VERSION}-${OSP_RELEASE}"
+  BUNDLE_IMG="$REPO/$OP_NAME-bundle:$VERSION_RELEASE"
+  INDEX_IMG="$REPO/$OP_NAME-index:$VERSION_RELEASE"
 
-# Generate bundle manifests
-VERSION=${VERSION} IMG=${IMG} make bundle
+  rm -Rf bundle
+  rm -Rf bundle.Dockerfile
 
-# Replace AGENT_IMAGE_URL_DEFAULT in CSV
-AGENT_IMG_WITH_DIGEST="${AGENT_IMG_BASE}@"$(skopeo inspect docker://${AGENT_IMG} | jq '.Digest' -r)
-sed -z -e 's!\(AGENT_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${AGENT_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
+  # Generate bundle manifests
+  OSP_RELEASE=${OSP_RELEASE} VERSION=${VERSION_RELEASE} IMG=${IMG} make bundle
 
-# Replace DOWNLOADER_IMAGE_URL_DEFAULT in CSV
-DOWNLOADER_IMG_WITH_DIGEST="${DOWNLOADER_IMG_BASE}@"$(skopeo inspect docker://${DOWNLOADER_IMG} | jq '.Digest' -r)
-sed -z -e 's!\(DOWNLOADER_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${DOWNLOADER_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
+  # Replace AGENT_IMAGE_URL_DEFAULT in CSV
+  AGENT_IMG_WITH_DIGEST="${AGENT_IMG_BASE}@"$(skopeo inspect docker://${AGENT_IMG} | jq '.Digest' -r)
+  sed -z -e 's!\(AGENT_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${AGENT_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
 
-# HACKs for webhook deployment to work around: https://bugzilla.redhat.com/show_bug.cgi?id=1921000
-# TODO: Figure out how to do this via Kustomize so that it's automatically rolled into the make
-#       commands above
-sed -i '/^    webhookPath:.*/a #added\n    containerPort: 4343\n    targetPort: 4343' ${CLUSTER_BUNDLE_FILE}
-sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controller-manager/g' ${CLUSTER_BUNDLE_FILE}
+  # Replace DOWNLOADER_IMAGE_URL_DEFAULT in CSV
+  DOWNLOADER_IMG_WITH_DIGEST="${DOWNLOADER_IMG_BASE}@"$(skopeo inspect docker://${DOWNLOADER_IMG} | jq '.Digest' -r)
+  sed -z -e 's!\(DOWNLOADER_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${DOWNLOADER_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
 
-# Convert any tags to digests within the CSV (for offline/air gapped environments)
-for csv_image in $(cat ${CLUSTER_BUNDLE_FILE} | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-  base_image=$(echo $csv_image | cut -f 1 -d':')
-  tag_image=$(echo $csv_image | cut -f 2 -d':')
-  if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-    sed -e "s|$base_image:$tag_image|$IMG|g" -i ${CLUSTER_BUNDLE_FILE}
-  elif [[ "$base_image" == */"${AGENT_IMAGE}" ]]; then
-    sed -e "s|$base_image:$tag_image|$AGENT_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-  elif [[ "$base_image" == */"${DOWNLOADER_IMAGE}" ]]; then
-    sed -e "s|$base_image:$tag_image|$DOWNLOADER_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-  else
-    digest_image=$(skopeo inspect docker://$base_image:$tag_image | jq '.Digest' -r)
-    if [[ "$digest_image" == "" ]]; then
-	echo "Failed to get image digest for docker://$base_image:$tag_image"
+  # HACKs for webhook deployment to work around: https://bugzilla.redhat.com/show_bug.cgi?id=1921000
+  # TODO: Figure out how to do this via Kustomize so that it's automatically rolled into the make
+  #       commands above
+  sed -i '/^    webhookPath:.*/a #added\n    containerPort: 4343\n    targetPort: 4343' ${CLUSTER_BUNDLE_FILE}
+  sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controller-manager/g' ${CLUSTER_BUNDLE_FILE}
+
+  # Convert any tags to digests within the CSV (for offline/air gapped environments)
+  for csv_image in $(cat ${CLUSTER_BUNDLE_FILE} | grep "image:" | sed -e "s|.*image:||" | sort -u); do
+    base_image=$(echo $csv_image | cut -f 1 -d':')
+    tag_image=$(echo $csv_image | cut -f 2 -d':')
+    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
+      sed -e "s|$base_image:$tag_image|$IMG|g" -i ${CLUSTER_BUNDLE_FILE}
+    elif [[ "$base_image" == */"${AGENT_IMAGE}" ]]; then
+      sed -e "s|$base_image:$tag_image|$AGENT_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
+    elif [[ "$base_image" == */"${DOWNLOADER_IMAGE}" ]]; then
+      sed -e "s|$base_image:$tag_image|$DOWNLOADER_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
     else
-        echo "$base_image:$tag_image becomes $base_image@$digest_image."
-        sed -e "s|$base_image:$tag_image|$base_image@$digest_image|g" -i ${CLUSTER_BUNDLE_FILE}
+      digest_image=$(skopeo inspect docker://$base_image:$tag_image | jq '.Digest' -r)
+      if [[ "$digest_image" == "" ]]; then
+        echo "Failed to get image digest for docker://$base_image:$tag_image"
+      else
+          echo "$base_image:$tag_image becomes $base_image@$digest_image."
+          sed -e "s|$base_image:$tag_image|$base_image@$digest_image|g" -i ${CLUSTER_BUNDLE_FILE}
+      fi
     fi
-  fi
+  done
+
+  # Build bundle image
+  VERSION=${VERSION_RELEASE} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} make bundle-build
+
+  # Push bundle image
+  VERSION=${VERSION_RELEASE} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} make bundle-push
+  #opm alpha bundle validate --tag ${BUNDLE_IMG} -b podman
+
+  # Index image
+  opm index add --bundles ${BUNDLE_IMG} --tag ${INDEX_IMG} -u podman --pull-tool podman
+  podman push ${INDEX_IMG}
 done
-
-# Build bundle image
-VERSION=${VERSION} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} make bundle-build
-
-# Push bundle image
-VERSION=${VERSION} IMAGE_TAG_BASE=${IMAGE_TAG_BASE} make bundle-push
-#opm alpha bundle validate --tag ${BUNDLE_IMG} -b podman
-
-# Index image
-opm index add --bundles ${BUNDLE_IMG} --tag ${INDEX_IMG} -u podman --pull-tool podman
-podman push ${INDEX_IMG}


### PR DESCRIPTION
This updates the bundle build process to support having default images for 16.2 and 17.0. Right now tested with
scripts/build_and_push_images.sh . The bundle/index images are now tagged with VERSION-OSP_RELEASE, e.g. 17.0.33-16.2 / 17.0.33-17.0.

In a follow up we have to update the github actions scripts to follow the same and call the latest images latest-16.2/latest-17.0 and v1.3.x-latest-16.2 / v1.3.x-latest-17.0.