### PR TITLE
BLS entries in cloud-init for osbms and osvmset

### DIFF
--- a/templates/baremetalset/cloudinit/userdata
+++ b/templates/baremetalset/cloudinit/userdata
@@ -12,3 +12,6 @@ chpasswd:
     root:{{ .NodeRootPassword }}
   expire: False
 {{- end }}
+bootcmd:
+  # fix BLS entries
+  - set -x; if [ -e /boot/loader/entries/ffffffffffffffffffffffffffffffff-* ]; then MACHINEID=$(cat /etc/machine-id) && rename "ffffffffffffffffffffffffffffffff" "$MACHINEID" /boot/loader/entries/ffffffffffffffffffffffffffffffff-* ; fi

--- a/templates/vmset/cloudinit/userdata
+++ b/templates/vmset/cloudinit/userdata
@@ -15,6 +15,8 @@ chpasswd:
 {{/* if the VM is _NOT_ part of a tripleo role, keep them as clean as possible and do _NOT_ run the following modifications */}}
 {{- if .IsTripleoRole }}
 bootcmd:
+  # fix BLS entries
+  - set -x; if [ -e /boot/loader/entries/ffffffffffffffffffffffffffffffff-* ]; then MACHINEID=$(cat /etc/machine-id) && rename "ffffffffffffffffffffffffffffffff" "$MACHINEID" /boot/loader/entries/ffffffffffffffffffffffffffffffff-* ; fi
   - "mkdir -p /mnt/kubeconfig"
   - "mkdir -p /root/kubeconfig"
   - "mount /dev/disk/by-id/virtio-fencingdisk /mnt/kubeconfig"


### PR DESCRIPTION
Per default for the rhel guest image the BLS entries are for machine-id fffffffffffffffffffffffffffffff . When this id does not match the real machine-id from /etc/machine-id updating via grub2-mkconfig won't get set correct.
This updates the entries for /boot/loader/entries/ffffffffffffffffffffffffffffffff-* to match the current machine-id.