### PR TITLE
Implement ceph data export

### DIFF
--- a/pkg/openstackclient/volumes.go
+++ b/pkg/openstackclient/volumes.go
@@ -58,6 +58,12 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volu
 		},
 		{
 			Name:      "openstackclient-scripts",
+			MountPath: "/usr/local/bin/tripleo-export-ceph",
+			SubPath:   "tripleo-export-ceph",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "openstackclient-scripts",
 			MountPath: "/home/cloud-admin/ctlplane-ansible-inventory",
 			SubPath:   "ansible-inventory",
 			ReadOnly:  true,
@@ -184,6 +190,10 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackClient) []corev1.Volume {
 						{
 							Key:  "tripleo-deploy-term.sh",
 							Path: "tripleo-deploy-term.sh",
+						},
+						{
+							Key:  "tripleo-export-ceph",
+							Path: "tripleo-export-ceph",
 						},
 						{
 							Key:  "init.sh",

--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -173,6 +173,8 @@ EOF`}}
     sudo chown cloud-admin: ~/.config/openstack/clouds.yaml
   fi
 
+  sudo /usr/local/bin/tripleo-export-ceph "${WORKDIR}"
+
   popd > /dev/null
 
 }

--- a/templates/openstackclient/bin/tripleo-export-ceph
+++ b/templates/openstackclient/bin/tripleo-export-ceph
@@ -1,0 +1,62 @@
+#! /usr/bin/env python3
+
+import json
+import os
+import sys
+import tripleoclient.export
+import yaml
+
+CEPH_USER_FN = 'ceph_client_user.json'
+CEPH_USER_KEY = 'ceph_client_user'
+CEPH_DEPLOY_DIRS = (
+    'ceph-ansible',
+    'cephadm'
+)
+DEFAULT_CEPH_USER = 'overcloud'
+
+
+def get_cephx_name(playbooks_dir):
+    ceph_user_file_path = os.path.join(playbooks_dir, CEPH_USER_FN)
+    try:
+        with open(ceph_user_file_path) as ceph_user_file:
+            data = json.loads(ceph_user_file.read())
+    except Exception:
+        return None
+    return data.get(CEPH_USER_KEY, DEFAULT_CEPH_USER)
+
+
+def export_ceph_data(working_dir):
+    stackname = 'tripleo-ansible'
+    playbooks_dir = os.path.join(working_dir, 'playbooks')
+    output_file = os.path.join(playbooks_dir, 'ceph-export.yaml')
+
+    data = {}
+    data['parameter_defaults'] = {}
+
+    ceph_deploy_found = False
+    for ceph_deploy_dir in CEPH_DEPLOY_DIRS:
+        if os.path.exists(os.path.join(playbooks_dir, stackname, ceph_deploy_dir)):
+            ceph_deploy_found = True
+            break
+
+    if ceph_deploy_found:
+        cephx = get_cephx_name(playbooks_dir)
+        if cephx is not None:
+            print("Using cephx name: {}".format(cephx))
+            ceph_data = tripleoclient.export.export_ceph(stackname, cephx, playbooks_dir)
+            data['parameter_defaults']['CephExternalMultiConfig'] = [ceph_data]
+            data['parameter_merge_strategies'] = {}
+            data['parameter_merge_strategies']['CephExternalMultiConfig'] = 'merge'
+        else:
+            print("Error reading ceph user file {}, skipping ceph data export".format(CEPH_USER_FN))
+
+    with open(output_file, 'w') as f:
+        yaml.safe_dump(data, f, default_flow_style=False)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: tripleo-export-ceph <workdir>")
+        sys.exit(1)
+    working_dir = os.path.abspath(sys.argv[1])
+    export_ceph_data(working_dir)

--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -242,6 +242,9 @@ tar -xvf $HOME/tht-tars/{{ $key }} -C tarball
 {{- end }}
 {{- end }}
 
+# Record the ceph user as we need this later to export the ceph backend config
+openstack stack environment show overcloud -f json | jq '.parameter_defaults.CephClientUserName // "openstack" | {ceph_client_user: .}' > ceph_client_user.json
+
 git add *
 git commit -a -m "Generated playbooks for $ConfigHash"
 git push -f origin $ConfigHash


### PR DESCRIPTION
Store the CephClientUserName from the heat environment if set, if not then fall back to the default ("openstack").

Add a python script that mimics the python-tripleoclient export ceph logic. Run this after every deploy to generate the ceph export yaml. Also the merge strategy to allow multiple ceph export environment files to be combined. If ceph is not deployed then just generate a valid empty heat environment file. Store the ceph export yaml on the existing exported data config map.