### PR TITLE
Use sudo to run chown in init.sh of openstackclient

### DIFF
--- a/templates/openstackclient/bin/init.sh
+++ b/templates/openstackclient/bin/init.sh
@@ -40,7 +40,7 @@ if [ -d /mnt/ssh-config ]; then
   mkdir -p /home/cloud-admin/.ssh
   cp /mnt/ssh-config/* /home/cloud-admin/.ssh/
   chmod 600 /home/cloud-admin/.ssh/id_rsa
-  chown -R cloud-admin: /home/cloud-admin/.ssh
+  sudo chown -R cloud-admin: /home/cloud-admin/.ssh
 fi
 
 if [ -d /mnt/ca-certs ]; then


### PR DESCRIPTION
cephadm creates a key for the user used to deploy ceph in OSP17. This the cloud-admin user does not have permissions to change the ownership of this file in the next restart and the init container fails with:

~~~
+ chown -R cloud-admin: /home/cloud-admin/.ssh
chown: changing ownership of '/home/cloud-admin/.ssh/foo': Operation not permitted 
~~~

For now run the chown using sudo until we figure out other options.