### PR TITLE
Update deprecated command and actions in git workflows

### DIFF
--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Check secrets are set
         id: have-secrets
         if: "${{ env.imagenamespace != '' }}"
-        run: echo "::set-output name=ok::true"
+        run: echo "ok=true" >>$GITHUB_OUTPUT
     outputs:
       have-secrets: ${{ steps.have-secrets.outputs.ok }}
 
@@ -43,11 +43,11 @@ jobs:
     if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v5
+      uses: tj-actions/branch-names@v6
 
     - name: Set latest tag for non master branch
       if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
@@ -79,11 +79,11 @@ jobs:
     if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v5
+      uses: tj-actions/branch-names@v6
 
     - name: Set latest tag for non master branch
       if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
@@ -117,11 +117,11 @@ jobs:
     if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v5
+      uses: tj-actions/branch-names@v6
 
     - name: Set latest tag for non master branch
       if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
@@ -162,12 +162,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18.x
 
     - name: Checkout osp-director-operator repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install operator-sdk
       uses: redhat-actions/openshift-tools-installer@v1
@@ -205,7 +205,7 @@ jobs:
 
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v5
+      uses: tj-actions/branch-names@v6
 
     - name: Set latest tag for non master branch
       if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
@@ -248,11 +248,11 @@ jobs:
 
     steps:
     - name: Checkout osp-director-operator repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v5
+      uses: tj-actions/branch-names@v6
 
     - name: Set latest tag for non master branch
       if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Checkout project code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout openstack-k8s-operators-ci project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: openstack-k8s-operators/openstack-k8s-operators-ci
           path: ./openstack-k8s-operators-ci
@@ -30,12 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Checkout project code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run golangci lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout 5m

--- a/.github/workflows/release-osp-director-operator.yaml
+++ b/.github/workflows/release-osp-director-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Tag osp-director-operator image
       uses: tinact/docker.image-retag@1.0.2


### PR DESCRIPTION
Node 12 is out of support[1]. Actions using this need to be updated: actions/checkout@v2 -> v3
actions/setup-go@v2 -> v3
golangci/golangci-lint-action@v2 -> v3
tj-actions/branch-names@v5 -> v6

Replace set-output with new env command [2]

Remaining warnings come from redhat-actions which are in the process of being updated.

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ [2] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/