### PR TITLE
Handle provisionserver IP change during bmh provisioning

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -1017,15 +1017,21 @@ func (r *OpenStackBaremetalSetReconciler) baremetalHostProvision(
 		)
 
 		//
+		// Ensure the image url is up to date unless already provisioned
+		//
+		if string(foundBaremetalHost.Status.Provisioning.State) != "provisioned" {
+			foundBaremetalHost.Spec.Image = &metal3v1alpha1.Image{
+				URL:      localImageURL,
+				Checksum: fmt.Sprintf("%s.md5sum", localImageURL),
+			}
+		}
+
+		//
 		// Update the BMH spec once when ConsumerRef is nil to only perform one time provision.
 		//
 		if foundBaremetalHost.Spec.ConsumerRef == nil {
 			foundBaremetalHost.Spec.Online = true
 			foundBaremetalHost.Spec.ConsumerRef = &corev1.ObjectReference{Name: instance.Name, Kind: instance.Kind, Namespace: instance.Namespace}
-			foundBaremetalHost.Spec.Image = &metal3v1alpha1.Image{
-				URL:      localImageURL,
-				Checksum: fmt.Sprintf("%s.md5sum", localImageURL),
-			}
 			foundBaremetalHost.Spec.UserData = &corev1.SecretReference{
 				Name:      userDataSecretName,
 				Namespace: "openshift-machine-api",


### PR DESCRIPTION
If the provisonserver pod redeployes while baremetalhosts are provisioning they would continue attempting to fetch the image from the old provision server ip.

This patch updates the image url on any baremetalhosts that are not fully provisioned to ensure the current provision server ip is used.