### PR TITLE
[v1.3.x] DCN: Add support for routed ctlplane subnets

### DIFF
--- a/controllers/openstacknetconfig_controller.go
+++ b/controllers/openstacknetconfig_controller.go
@@ -641,11 +641,12 @@ func (r *OpenStackNetConfigReconciler) applyNetConfig(
 		osNet.Spec.NameLower = subnet.Name
 		if net.IsControlPlane {
 			osNet.Spec.DomainName = fmt.Sprintf("%s.%s", ospdirectorv1beta1.ControlPlaneNameLower, instance.Spec.DomainName)
+			// TripleO does not support VLAN on ctlplane
 		} else {
 			osNet.Spec.DomainName = fmt.Sprintf("%s.%s", strings.ToLower(net.Name), instance.Spec.DomainName)
+			osNet.Spec.Vlan = subnet.Vlan
 		}
 		osNet.Spec.VIP = net.VIP
-		osNet.Spec.Vlan = subnet.Vlan
 
 		if subnet.IPv4.Cidr != "" {
 			osNet.Spec.AllocationEnd = subnet.IPv4.AllocationEnd

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -225,6 +225,7 @@ func (r *OpenStackProvisionServerReconciler) Reconcile(ctx context.Context, req 
 			return ctrl.Result{}, err
 		}
 
+		// FIXME: changing the imageURL on the spec updates the pod, but doesn't update the LocalImageURL
 		// If the current LocalImageURL is empty, or its embedded IP does not equal the ProvisionIP, the update the LocalImageURL
 		if instance.Status.LocalImageURL == "" || curURL.Hostname() != instance.Status.ProvisionIP {
 			// Update status with LocalImageURL, given ProvisionIP status value

--- a/pkg/openstackconfiggenerator/configmap.go
+++ b/pkg/openstackconfiggenerator/configmap.go
@@ -35,8 +35,9 @@ import (
 )
 
 type roleNetworkType struct {
-	Name            string
-	NameLower       string
+	ID              string // e.g. ctlplane_leaf1
+	Name            string // e.g. Control
+	NameLower       string // e.g. ctlplane
 	Cidr            string // e.g. 192.168.24.0/24
 	NetAddr         string // e.g. 192.168.24.0
 	CidrSuffix      int    // e.g. 24
@@ -85,7 +86,7 @@ type RoleType struct {
 	Nodes          map[string]*roleNodeType
 	IsVMType       bool
 	IsTripleoRole  bool
-	IsControlPlane bool
+	IsControlPlane bool // is vip or serviceVIP
 }
 
 type netDetailsType struct {
@@ -436,6 +437,7 @@ func createRolesMap(
 				nameLower := networkMappingList[osnet.Spec.NameLower]
 
 				rolesMap[roleName].Networks[osnet.Spec.NameLower] = &roleNetworkType{
+					ID:              osnet.Spec.NameLower,
 					Name:            osnet.Spec.Name,
 					NameLower:       nameLower,
 					Cidr:            osnet.Spec.Cidr,
@@ -488,8 +490,9 @@ func createRolesMap(
 							// IP address with brackets in case of IPv6, e.g. [2001:DB8:24::15]
 							uri = fmt.Sprintf("[%s]", uri)
 						}
-						if rolesMap[roleName].Nodes[reservation.Hostname].IPaddr[osnet.Spec.NameLower] == nil {
-							rolesMap[roleName].Nodes[reservation.Hostname].IPaddr[osnet.Spec.NameLower] = &roleIPType{
+
+						if rolesMap[roleName].Nodes[reservation.Hostname].IPaddr[nameLower] == nil {
+							rolesMap[roleName].Nodes[reservation.Hostname].IPaddr[nameLower] = &roleIPType{
 								IPaddr:       reservation.IP,
 								IPAddrURI:    uri,
 								IPAddrSubnet: fmt.Sprintf("%s/%d", reservation.IP, cidrSuffix),

--- a/pkg/openstacknetattachment/const.go
+++ b/pkg/openstacknetattachment/const.go
@@ -35,26 +35,30 @@ const (
 	// CniConfigTemplate -
 	CniConfigTemplate = `
 {
-    "cniVersion": "0.3.1",
-    "name": "{{ .Name }}",
-    "plugins": [
-	{
-	    "type": "bridge",
-	    "bridge": "{{ .BridgeName }}",
-	    "mtu": {{ .MTU }},
+	"cniVersion": "0.3.1",
+	"name": "{{ .Name }}",
+	"plugins": [
+		{
+			"type": "bridge",
+			"bridge": "{{ .BridgeName }}",
+			"mtu": {{ .MTU }},
 {{- if ne .Vlan "0"}}
-	    "vlan": {{ .Vlan }},
+			"vlan": {{ .Vlan }},
 {{- end }}
-	    "ipam": {
+			"ipam": {
 {{- if .Static }}
-                "type": "static"
+				"type": "static"
 {{- end }}
-	    }
-	},
-	{
-	    "type": "tuning"
-	}
-    ]
+			}
+		},
+		{
+			"type": "tuning"
+		},
+		{
+			"type": "route-override",
+			"addroutes": {{ .Routes }}
+		}
+	]
 }
 `
 )

--- a/templates/baremetalset/cloudinit/networkdata
+++ b/templates/baremetalset/cloudinit/networkdata
@@ -9,6 +9,14 @@ networks:
   ip_address: {{ .CtlplaneIp }}
   type: ipv4
   gateway: {{ .CtlplaneGateway }}
+  {{- if not (eq (len .CtlplaneRoutes) 0) }}
+  routes:
+    {{- range $value := .CtlplaneRoutes }}
+    - network: {{ $value.network }}
+      netmask: {{ $value.netmask }}
+      gateway: {{ $value.gateway }}
+    {{- end }}
+  {{- end }}
 {{- if not (eq (len .CtlplaneDns) 0) }}
 services:
 - type: dns-nameserver

--- a/templates/openstackclient/bin/ansible-inventory
+++ b/templates/openstackclient/bin/ansible-inventory
@@ -8,7 +8,7 @@ NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
 TOKEN=$(cat ${SERVICEACCOUNT}/token)
 CACERT=${SERVICEACCOUNT}/ca.crt
 
-ROLE_RESERVATIONS=$(curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/apis/osp-director.openstack.org/v1beta1/namespaces/$NAMESPACE/openstacknets/ctlplane | jq .spec.roleReservations | jq -r "to_entries | map(select(.value.addToPredictableIPs == true and .value.reservations[].vip == false)) | del(.[] | .value.reservations[] | select(.deleted? == true))| unique[]")
+ROLE_RESERVATIONS=$(curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/apis/osp-director.openstack.org/v1beta1/namespaces/$NAMESPACE/openstacknets?labelSelector=ooo-ctlplane-network=true | jq .items[].spec.roleReservations | jq -r "to_entries | map(select(.value.addToPredictableIPs == true and .value.reservations[].vip == false)) | del(.[] | .value.reservations[] | select(.deleted? == true))| unique[]")
 
 ROLES=$(echo $ROLE_RESERVATIONS | jq -re '.key')
 

--- a/templates/openstackconfiggenerator/config/16.2/rendered-tripleo-config.yaml
+++ b/templates/openstackconfiggenerator/config/16.2/rendered-tripleo-config.yaml
@@ -54,20 +54,23 @@ parameter_defaults:
         - ip_address: {{ $ip.IPaddr }}
       subnets:
         - cidr: {{ $ip.Network.Cidr }}
+          {{- range $_, $net := $.NetworksMap }}
+          {{- range $subnetname, $subnet := $net.Subnets }}
+          {{- if eq $subnetname $ip.Network.ID }}
+          gateway_ip: {{ $subnet.IPv4.Gateway }}
+          host_routes: {{ if eq (len $subnet.IPv4.Routes) 0 }}[]{{ else }}
+          {{- range $_, $route := $subnet.IPv4.Routes }}
+            - destination: '{{ $route.Destination }}'
+              nexthop: '{{ $route.Nexthop }}'
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
       network:
         tags:
           - {{ $ip.Network.Cidr }}
 {{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-  #
-  # Per ctlplane details
-{{- range $netid, $net := .NetworksMap }}
-{{- if $net.IsControlPlane }}
-{{- if ne $net.DefaultSubnet.IPv4.Cidr "" }}
-  ControlPlaneDefaultRoute: {{ $net.DefaultSubnet.IPv4.Gateway }}
-  ControlPlaneSubnetCidr: {{ $net.DefaultSubnet.IPv4.CidrSuffix }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -124,36 +127,3 @@ parameter_defaults:
 {{- end }}
 {{- end }}
 {{- end }}
-  #
-  # CtlplaneNetworkAttributes
-  CtlplaneNetworkAttributes:
-    {{- range $netname, $net := .NetworksMap }}
-    {{- if $net.IsControlPlane }}
-    {{- $subnetname := $net.DefaultSubnet.Name }}
-    {{- $subnet := $net.DefaultSubnet }}
-    network:
-      dns_domain: {{ $net.DomainName }}.
-      mtu: {{ $net.MTU }}
-      name: {{ $net.NameLower }}
-      tags:
-      - {{ $subnet.IPv4.Cidr }}
-    {{- /* subnets start */}}
-    subnets:
-      {{ $subnetname }}-subnet:
-        cidr: {{ $subnet.IPv4.Cidr }}
-        dns_nameservers: {{ if eq (len $net.DNSServers) 0 }}[]{{ else }}
-          {{- range $idx, $dnsServer := $net.DNSServers }}
-          - {{ $dnsServer }}
-          {{- end }}
-          {{- end }}
-        gateway_ip: {{ $subnet.IPv4.Gateway }}
-        host_routes: {{ if eq (len $subnet.IPv4.Routes) 0 }}[]{{ else }}
-          {{- range $netname, $route := $subnet.IPv4.Routes }}
-          - destination: '{{ $route.Destination }}'
-            nexthop: '{{ $route.Nexthop }}'
-          {{- end }}
-          {{- end }}
-        ip_version: 4
-        name: {{ $subnetname }}-subnet
-    {{- end }}
-    {{- end }}

--- a/templates/openstackconfiggenerator/config/17.0/rendered-tripleo-config.yaml
+++ b/templates/openstackconfiggenerator/config/17.0/rendered-tripleo-config.yaml
@@ -9,7 +9,6 @@ parameter_defaults:
   DeployIdentifier: OSP_DIRECTOR_OPERATOR_DEPLOY_IDENTIFIER
   SoftwareConfigTransport: POLL_SERVER_HEAT
   RootStackName: overcloud
-  ManageNetworks: False
   NeutronPublicInterface: nic3
 {{- /* HostnameFormat and RoleCount */ -}}
 {{- range $roleid, $role := .RolesMap }}
@@ -108,6 +107,19 @@ parameter_defaults:
 {{- end }}
 {{- end }}
   #
+  # ControlPlaneSubnet
+{{- range $roleid, $role := .RolesMap }}
+{{- if $role.IsControlPlane }}
+{{- range $nodeid, $node := $role.Nodes }}
+{{- range $netname, $ip := $node.IPaddr }}
+{{- if and ($node.VIP) ($ip.Network.IsControlPlane) }}
+  ControlPlaneSubnet: {{ $ip.Network.ID }}-subnet
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+  #
   # Set VIP's for redis and OVN
 {{- range $roleid, $role := .RolesMap }}
 {{- range $nodeid, $node := $role.Nodes }}
@@ -150,7 +162,7 @@ parameter_defaults:
     subnets:
     {{- range $subnetname, $subnet := $net.Subnets }}
       {{ $subnetname }}-subnet:
-        cidr: {{ $subnet.IPv4.Cidr }}
+        cidr: '{{ $subnet.IPv4.Cidr }}'
         dns_nameservers: {{ if eq (len $net.DNSServers) 0 }}[]{{ else }}
           {{- range $idx, $dnsServer := $net.DNSServers }}
           - {{ $dnsServer }}
@@ -168,3 +180,18 @@ parameter_defaults:
     {{- end }}
     {{- end }}
     {{- end }}
+  #
+  # <role>ControlPlaneSubnet
+{{- range $roleid, $role := .RolesMap }}
+{{- if not $role.IsControlPlane }}
+{{- $done := 0 }}
+{{- range $nodeid, $node := $role.Nodes }}
+{{- range $netname, $ip := $node.IPaddr }}
+{{- if and (eq $done 0) $ip.Network.IsControlPlane }}
+  {{ $role.Name }}ControlPlaneSubnet: {{ $ip.Network.ID }}-subnet
+  {{- $done = 1 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/vmset/cloudinit/networkdata
+++ b/templates/vmset/cloudinit/networkdata
@@ -11,9 +11,16 @@ ethernets:
         {{- end }}
       {{- end }}
       addresses:
-         {{- range $value := .CtlplaneDns }}
-         - {{ $value }}
-         {{- end }}
+        {{- range $value := .CtlplaneDns }}
+        - {{ $value }}
+        {{- end }}
+    {{- end }}
+    {{- if not (eq (len .CtlplaneRoutes) 0) }}
+    routes:
+      {{- range $value := .CtlplaneRoutes }}
+      - to: {{ $value.to }}
+        via: {{ $value.via }}
+      {{- end }}
     {{- end }}
 {{- if .Gateway }}
     {{ .Gateway }}


### PR DESCRIPTION
Query the ctlplane network in osbmet/osvmset instead of assuming 'ctlplane'. Add ctlplane routes to bmh/vm cloud-init and openstackclient pod cni templates. Add routes to DeployServerPortMap/CtlplaneNetworkAttributes. Update ansible inventory script to support multiple ctlplane networks.