### PR TITLE
Switch OsProvServer perms to 'hostnetwork' instead of 'privileged'

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -807,22 +807,6 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - anyuid
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - privileged
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
-- apiGroups:
   - subresources.kubevirt.io
   resources:
   - virtualmachines/start

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -66,7 +66,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - privileged
+  - hostnetwork
   resources:
   - securitycontextconstraints
   verbs:

--- a/pkg/provisionserver/initcontainer.go
+++ b/pkg/provisionserver/initcontainer.go
@@ -18,21 +18,13 @@ type InitContainer struct {
 
 // GetInitContainers - init containers for ProvisionServers
 func GetInitContainers(inits []InitContainer) []corev1.Container {
-	trueVar := true
-
-	securityContext := &corev1.SecurityContext{}
 	initContainers := []corev1.Container{}
 
 	for index, init := range inits {
-		if init.Privileged {
-			securityContext.Privileged = &trueVar
-		}
-
 		container := corev1.Container{
 			Name:            fmt.Sprintf("init-%d", index),
 			Image:           init.ContainerImage,
 			ImagePullPolicy: corev1.PullAlways,
-			SecurityContext: securityContext,
 			VolumeMounts:    init.VolumeMounts,
 			Env:             init.Env,
 		}

--- a/pkg/provisionserver/volumes.go
+++ b/pkg/provisionserver/volumes.go
@@ -46,12 +46,6 @@ func GetInitVolumeMounts(name string) []corev1.VolumeMount {
 			Name:      name + "-image-data",
 			MountPath: "/usr/local/apache2/htdocs",
 		},
-		{
-			Name:      name + "-httpd-config",
-			MountPath: HttpdConfPath,
-			SubPath:   "httpd.conf",
-			ReadOnly:  false,
-		},
 	}
 }
 


### PR DESCRIPTION
Takes inspiration from https://github.com/openstack-k8s-operators/openstack-baremetal-operator/pull/22 to improve security of the provision server pod by downgrading it from `privileged` to only `hostnetwork`.  Also further improves security by removing the `privileged` and `anyuid` permissions from the controller-manager pod, as they are not needed.