### PR TITLE
[OSPK8-439] Stop trying to parse git url, just set GIT_SSH_COMMAND

### DIFF
--- a/templates/openstackclient/bin/tripleo-deploy.sh
+++ b/templates/openstackclient/bin/tripleo-deploy.sh
@@ -26,10 +26,7 @@ if [ ! -L /var/log/validations ]; then
   sudo ln -s ~/tripleo-deploy/validations /var/log/validations
 fi
 
-GIT_HOST=$(echo $GIT_URL | sed -e 's|^git@\(.*\):.*|\1|g')
-GIT_USER=$(echo $GIT_URL | sed -e 's|^git@.*:\(.*\)/.*|\1|g')
-
-export GIT_SSH_COMMAND="ssh -i $WORKDIR/git_id_rsa -l git -o StrictHostKeyChecking=no"
+export GIT_SSH_COMMAND="ssh -i $WORKDIR/git_id_rsa -o StrictHostKeyChecking=no"
 echo $GIT_ID_RSA | sed -e 's|- |-\n|' | sed -e 's| -|\n-|'  > $WORKDIR/git_id_rsa
 chmod 600 $WORKDIR/git_id_rsa
 

--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -7,16 +7,7 @@ cp /mnt/ssh-config/* $HOME/.ssh/
 chmod 600 $HOME/.ssh/git_id_rsa
 chown -R cloud-admin: $HOME/.ssh
 
-GIT_HOST=$(echo $GIT_URL | sed -e 's|^git@\(.*\):.*|\1|g')
-GIT_USER=$(echo $GIT_URL | sed -e 's|^git@.*:\(.*\)/.*|\1|g')
-
-cat <<EOF > $HOME/.ssh/config
-Host $GIT_HOST
-    User $GIT_USER
-    IdentityFile $HOME/.ssh/git_id_rsa
-    StrictHostKeyChecking no
-EOF
-chmod 644 $HOME/.ssh/config
+export GIT_SSH_COMMAND="ssh -i $HOME/.ssh/git_id_rsa -o StrictHostKeyChecking=no"
 
 unset OS_CLOUD
 export OS_AUTH_TYPE=none


### PR DESCRIPTION
The only reason the git url is parsed is to generate an ssh config file.
Since parsing git urls is non-trivial we can avoid this completely and
just set the required SSH config on the command line via GIT_SSH_COMMAND.

Also remove the hardcoded git user from GIT_SSH_COMMAND