### PR TITLE
[OSPK8-735] Improve logging for OSBMS scale-up

### DIFF
--- a/tests/kuttl/tests/openstackbaremetalset_scale/10-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/10-assert.yaml
@@ -33,7 +33,7 @@ status:
       hostname: compute-1
   provisioningStatus:
     readyCount: 1
-    reason: Existing BaremetalHost "openshift-worker-0" not found for OsBaremetalSet
+    reason: Existing BaremetalHost "openshift-worker-0" not found for OpenStackBaremetalSet
       compute.  Please check BaremetalHost resources and re-add "openshift-worker-0"
       to continue
     state: Error

--- a/tests/kuttl/tests/openstackbaremetalset_scale/11-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/11-assert.yaml
@@ -33,7 +33,7 @@ status:
       hostname: compute-1
   provisioningStatus:
     readyCount: 1
-    reason: Existing BaremetalHost "openshift-worker-0" not found for OsBaremetalSet
+    reason: Existing BaremetalHost "openshift-worker-0" not found for OpenStackBaremetalSet
       compute.  Please check BaremetalHost resources and re-add "openshift-worker-0"
       to continue
     state: Error


### PR DESCRIPTION
Be more explicit about what is happening during a scale-up of an `OpenStackBaremetalSet`