### PR TITLE
Stop setting FSGroup

### DIFF
--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -556,7 +556,6 @@ func (r *OpenStackClientReconciler) podCreateOrUpdate(
 
 		pod.Spec.SecurityContext.RunAsUser = &runAsUser
 		pod.Spec.SecurityContext.RunAsGroup = &runAsGroup
-		pod.Spec.SecurityContext.FSGroup = &runAsGroup
 		pod.Spec.ServiceAccountName = openstackclient.ServiceAccount
 		pod.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 		pod.Spec.Volumes = common.MergeVolumes(pod.Spec.Volumes, volumes)

--- a/pkg/openstackconfiggenerator/job.go
+++ b/pkg/openstackconfiggenerator/job.go
@@ -58,7 +58,6 @@ func ConfigJob(cr *ospdirectorv1beta1.OpenStackConfigGenerator, configHash strin
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsUser:  &runAsUser,
 			RunAsGroup: &runAsGroup,
-			FSGroup:    &runAsGroup,
 		},
 		TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 		Volumes:                       volumes,

--- a/pkg/openstackdeploy/job.go
+++ b/pkg/openstackdeploy/job.go
@@ -61,7 +61,6 @@ func DeployJob(
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsUser:  &runAsUser,
 			RunAsGroup: &runAsGroup,
-			FSGroup:    &runAsGroup,
 		},
 		TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 		Containers: []corev1.Container{

--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -eux
 
+umask 0022
+CHOWN_UID=$(id -u)
+CHOWN_GID=$(id -g)
+
 # add cloud-admin ssh keys to $HOME/.ssh
 mkdir -p $HOME/.ssh
-cp /mnt/ssh-config/* $HOME/.ssh/
-chmod 600 $HOME/.ssh/git_id_rsa
-chown -R cloud-admin: $HOME/.ssh
+sudo cp /mnt/ssh-config/* $HOME/.ssh/
+sudo chmod 600 $HOME/.ssh/git_id_rsa
+sudo chown -R $CHOWN_UID:$CHOWN_GID $HOME/.ssh
 
 export GIT_SSH_COMMAND="ssh -i $HOME/.ssh/git_id_rsa -o StrictHostKeyChecking=no"
 


### PR DESCRIPTION
FSGroup recursively chowns/chgrps each volume and setgids the dirs. This can interfere with permissions on the openstackclient, which needs to resemble a traditional undercloud host as closely as possible. SSH in particular has strict rule for the ownership and mode of it's files, but there could be other pemissions issues too.

Note FSGroup has no effect on NFS, which we happen to be using in CI, but will affect local volumes, RBD etc... which provide formatted block devices.

Avoid this completely by removing FSGroup and explicitly setting all ownership/modes in the init container.

Jira: [OSP-27993](https://issues.redhat.com//browse/OSP-27993)
Resolves: rhbz#2236085