### PR TITLE
[CVE-2023-44487] Disable HTTP2 in webhook server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,6 @@ require (
 )
 
 replace (
-
 	// required by Microsoft/hcsshim, containers/storage, sriov-network-operator
 	// Not used within this Operator.
 	// Bump to avoid CVE detection with earlier versions (v1.5.4).


### PR DESCRIPTION
Further mitigation against the Rapid Reset exploit