### PR TITLE
Fix override of rendered files via tarball

### DIFF
--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -38,14 +38,14 @@ cp -a /usr/share/openstack-tripleo-heat-templates/* $TEMPLATES_DIR
 rm -Rf $HOME/config-tmp
 mkdir -p $HOME/config-tmp
 pushd $HOME/config-tmp
+cp $HOME/config/* $HOME/config-tmp
+cp $HOME/config-custom/* $HOME/config-tmp
 # extract any tar files into $HOME/config-tmp
 {{- if .TripleoTarballFiles }}
 {{- range $key, $value := .TripleoTarballFiles }}
 tar -xvf $HOME/tht-tars/{{ $key }}
 {{- end }}
 {{- end }}
-cp $HOME/config/* $HOME/config-tmp
-cp $HOME/config-custom/* $HOME/config-tmp
 # remove all references to the default tht dir
 sed -e "s|/usr/share/openstack\-tripleo\-heat\-templates|\.|" -i $HOME/config-tmp/*.yaml
 # copy to our temp t-h-t dir


### PR DESCRIPTION
Extracting/placing default tht files via the script to render the playbooks is intended to allow to override default and rendered tht files. Right now the ordering to copy the files in the final place first copies the tarball and afterwards the default/rendered ones. This prevents from override them via the tarball.

This changes the order to extract the tarball last.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2251800