### PR TITLE
InstanceHA: Use deep-merge for FencingConfig

### DIFF
--- a/templates/openstackconfiggenerator/config/common/fencing.yaml
+++ b/templates/openstackconfiggenerator/config/common/fencing.yaml
@@ -15,4 +15,6 @@ parameter_defaults:
           power_timeout: 30
           kubeconfig: /root/kubeconfig/kubeconfig
 {{- end }}
+parameter_merge_strategies:
+  FencingConfig: deep_merge
 {{- end }}


### PR DESCRIPTION
Required to allow additional FencingConfig to be added for compute nodes

Resolves: [OSP-31777](https://issues.redhat.com//browse/OSP-31777)