### PR TITLE
[OSPK8-803] Use list format for SSH authorized keys in OSBMS cloud-init

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -1101,7 +1101,14 @@ func (r *OpenStackBaremetalSetReconciler) cloudInitProvision(ctx context.Context
 		// Automatically generate user data cloud-init secret (i.e. user did not
 		// already manually create it for the BMH)
 		templateParameters := make(map[string]interface{})
-		templateParameters["AuthorizedKeys"] = sshSecret
+
+		// Split the keys into a list of separate strings, as cloud-init wants a list
+		// (a single-key string also works, but if there multiple keys in that string
+		// then passing the keys as a string results in *none* of them working, so it
+		// is better to create a list always)
+		splitKeys := strings.Split(strings.TrimSuffix(string(sshSecret), "\n"), "\n")
+		templateParameters["AuthorizedKeys"] = splitKeys
+
 		templateParameters["Hostname"] = hostName
 		templateParameters["DomainName"] = osNetCfg.Spec.DomainName
 

--- a/templates/baremetalset/cloudinit/userdata
+++ b/templates/baremetalset/cloudinit/userdata
@@ -3,7 +3,12 @@
 fqdn: {{ .Hostname }}{{ if .DomainName }}.{{ .DomainName }}{{ end }}
 users:
   - name: cloud-admin
-    ssh-authorized-keys: {{ .AuthorizedKeys }}
+    ssh_authorized_keys:
+{{ range $ssh_key := .AuthorizedKeys }}
+{{ if not (eq $ssh_key "") }}
+      - {{ $ssh_key }}
+{{ end }}
+{{ end }}
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash
 {{- if .NodeRootPassword }}


### PR DESCRIPTION
The proper format for authorized keys in cloud-init is a [list](https://cloudinit.readthedocs.io/en/latest/reference/examples.html#configure-instance-s-ssh-keys), but we are using a string instead.  As a result, if multiple keys are desired, none of the SSH keys will work if we place them in that string.