### PR TITLE
[OSPK8-820] Using non-conflicting OSProvServer port for OCP 4.16+

### DIFF
--- a/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
+++ b/config/samples/osp-director_v1beta1_openstackprovisionserver.yaml
@@ -4,6 +4,6 @@ metadata:
   name: openstack
   namespace: openstack
 spec:
-  port: 8080
+  port: 6190
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   interface: br-ctlplane

--- a/docs/README-baremetal-provisioning.md
+++ b/docs/README-baremetal-provisioning.md
@@ -49,7 +49,7 @@ clusters, there are the following further prerequisites:
       name: openstack
       namespace: openstack
     spec:
-      port: 8080
+      port: 6190
       baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-1168.x86_64.qcow2
       interface: enp3s0
     ```

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -17,6 +17,7 @@
 # 4. There are preferrably NO existing OSP Director Operator CRs deployed
 #    - dev-tools probably installed them, so remove via:
 #        oc delete openstackbaremetalset --all
+#        oc delete openstackprovisionserver --all
 #        oc delete openstackcontrolplane --all
 #        oc delete openstackvmset --all
 #        oc delete openstacknet --all

--- a/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
+++ b/tests/kuttl/tests/openstackbaremetalset_scale/03-assert.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   interface: br-ctlplane
-  port: 8080
+  port: 6190
 status:
   provisioningStatus:
     reason: OpenStackProvisionServer has been provisioned

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/02-assert.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
   interface: br-ctlplane
-  port: 8080
+  port: 6190
 status:
   conditions:
   - message: Provisioning of OpenStackProvisionServer in progress

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/03-assert.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/03-assert.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: openstack
 spec:
   baseImageUrl: http://192.168.111.1/images/rhel-guest-image-8.4-992.x86_64.qcow2
-  port: 8081
+  port: 6191
 status:
   conditions:
   - message: Provisioning of OpenStackProvisionServer in progress

--- a/tests/kuttl/tests/openstackprovisionserver_unique_port/03-create_openstackprovisionserver.yaml
+++ b/tests/kuttl/tests/openstackprovisionserver_unique_port/03-create_openstackprovisionserver.yaml
@@ -6,4 +6,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      sed 's/name: openstack/name: goodprov/g' ../../../../config/samples/osp-director_v1beta1_openstackprovisionserver.yaml | sed 's/port: 8080/port: 8081/g' | oc apply -f -
+      sed 's/name: openstack/name: goodprov/g' ../../../../config/samples/osp-director_v1beta1_openstackprovisionserver.yaml | sed 's/port: 6190/port: 6191/g' | oc apply -f -


### PR DESCRIPTION
In OCP 4.16+, the cluster network operator now listens on port 8080 on one of the master nodes.  So in a 3-node master/worker combo scenario, we could run into a collision with the default 8080 port we suggest for the `OpenStackProvisionServer`:

```
tcp   LISTEN     0      4096                                         *:8080                        *:*     users:(("cluster-network",pid=100006,fd=9)) 
```

Let's use 6190 instead, as we do in the newer RHOSO OpenStack Baremetal operator.

Jira: https://issues.redhat.com/browse/OSPK8-820