### PR TITLE
Trust openstackcontrolplane CAs in configgenerator

### DIFF
--- a/pkg/openstackconfiggenerator/job.go
+++ b/pkg/openstackconfiggenerator/job.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ConfigJob -
-func ConfigJob(cr *ospdirectorv1beta1.OpenStackConfigGenerator, configHash string, ospVersion shared.OSPVersion) *batchv1.Job {
+func ConfigJob(cr *ospdirectorv1beta1.OpenStackConfigGenerator, configHash string, ospVersion shared.OSPVersion, caConfigMap string) *batchv1.Job {
 
 	runAsUser := int64(openstackclient.CloudAdminUID)
 	runAsGroup := int64(openstackclient.CloudAdminGID)
@@ -42,8 +42,8 @@ func ConfigJob(cr *ospdirectorv1beta1.OpenStackConfigGenerator, configHash strin
 	var backoffLimit int32 = 2
 
 	// Get volumes
-	volumeMounts := GetVolumeMounts(cr)
-	volumes := GetVolumes(cr)
+	volumeMounts := GetVolumeMounts(cr, caConfigMap)
+	volumes := GetVolumes(cr, caConfigMap)
 
 	cmd := []string{"/bin/bash", "/home/cloud-admin/create-playbooks.sh"}
 	if cr.Spec.Interactive {

--- a/pkg/openstackconfiggenerator/volumes.go
+++ b/pkg/openstackconfiggenerator/volumes.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GetVolumeMounts -
-func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []corev1.VolumeMount {
+func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackConfigGenerator, caConfigMap string) []corev1.VolumeMount {
 	retVolMounts := []corev1.VolumeMount{
 		{
 			Name:      "tripleo-deploy-config-" + instance.Name,
@@ -75,11 +75,20 @@ func GetVolumeMounts(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []co
 			},
 		)
 	}
+
+	if caConfigMap != "" {
+		retVolMounts = append(retVolMounts, corev1.VolumeMount{
+			Name:      "ca-certs",
+			MountPath: "/mnt/ca-certs",
+			ReadOnly:  true,
+		})
+	}
+
 	return retVolMounts
 }
 
 // GetVolumes -
-func GetVolumes(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []corev1.Volume {
+func GetVolumes(instance *ospdirectorv1beta1.OpenStackConfigGenerator, caConfigMap string) []corev1.Volume {
 	var config0600AccessMode int32 = 0600
 	var config0644AccessMode int32 = 0644
 	var config0755AccessMode int32 = 0755
@@ -174,5 +183,20 @@ func GetVolumes(instance *ospdirectorv1beta1.OpenStackConfigGenerator) []corev1.
 			},
 		)
 	}
+
+	if caConfigMap != "" {
+		retVolumes = append(retVolumes, corev1.Volume{
+			Name: "ca-certs",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: &config0644AccessMode,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: caConfigMap,
+					},
+				},
+			},
+		})
+	}
+
 	return retVolumes
 }

--- a/templates/openstackconfiggenerator/bin/create-playbooks.sh
+++ b/templates/openstackconfiggenerator/bin/create-playbooks.sh
@@ -5,6 +5,12 @@ umask 0022
 CHOWN_UID=$(id -u)
 CHOWN_GID=$(id -g)
 
+# Add any additional CA certs
+if [ -d /mnt/ca-certs ]; then
+  sudo cp -v /mnt/ca-certs/* /etc/pki/ca-trust/source/anchors/
+  sudo update-ca-trust
+fi
+
 # add cloud-admin ssh keys to $HOME/.ssh
 mkdir -p $HOME/.ssh
 sudo cp /mnt/ssh-config/* $HOME/.ssh/


### PR DESCRIPTION
Add the openstackcontrolplane CAConfigMap CA certs to the trusted certs when running the config generator job as it may need to connect to container registries that use a custom CA (e.g to resolve image tags).