### PR TITLE
Return error id OpenStackNet misses OpenStackNetConfig owner ref

### DIFF
--- a/api/v1beta1/common_openstacknet.go
+++ b/api/v1beta1/common_openstacknet.go
@@ -124,6 +124,10 @@ func AddOSNetConfigRefLabel(
 		}
 	}
 
+	if _, ok := labels[shared.OpenStackNetConfigReconcileLabel]; !ok {
+		return labels, fmt.Errorf("OpenStackNet %s misses OpenStackNetConfig owner reference", subnetName)
+	}
+
 	return labels, nil
 }
 

--- a/api/v1beta1/openstackipset_webhook.go
+++ b/api/v1beta1/openstackipset_webhook.go
@@ -76,7 +76,17 @@ var _ webhook.Validator = &OpenStackIPSet{}
 func (r *OpenStackIPSet) ValidateCreate() error {
 	openstackipsetlog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
+	//
+	// Fail early on create if osnetcfg ist not found
+	//
+	_, err := GetOsNetCfg(webhookClient, r.GetNamespace(), r.GetLabels()[shared.OpenStackNetConfigReconcileLabel])
+	if err != nil {
+		return fmt.Errorf("error getting OpenStackNetConfig %s - %s: %w",
+			r.GetLabels()[shared.OpenStackNetConfigReconcileLabel],
+			r.Name,
+			err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
In case of backup restore the owner ref needs to get updated by the OpenStackNetConfig controller. If some other reconcile using the OpenStackNet happens first, this reference is missing and e.g. the OpenStackIPSet gets stuck waiting for IPs to be processed.