### PR TITLE
Improve backup and restore functionality for OpenStackBaremetalSets

### DIFF
--- a/api/shared/labels.go
+++ b/api/shared/labels.go
@@ -38,4 +38,8 @@ const (
 	OwnerControllerNameLabelSelector string = "osp-director.openstack.org/controller"
 	// OwnerUIDLabelSelector -
 	OwnerUIDLabelSelector string = "osp-director.openstack.org/uid"
+	// OwnerNameLabelSelector -
+	OwnerNameLabelSelector = "osp-director.openstack.org/name"
+	// RequireBMHDeprovision - placed on a BMH to indicate that it must fully deprovision before we are done with it
+	RequireBMHDeprovision = "osp-director.openstack.org/require-deprovision"
 )

--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -1683,7 +1683,7 @@ func (r *OpenStackBaremetalSetReconciler) getExistingBaremetalHosts(
 		"openshift-machine-api",
 		map[string]string{
 			common.OwnerControllerNameLabelSelector: shared.OpenStackBaremetalSetAppLabel,
-			common.OwnerUIDLabelSelector:            string(instance.GetUID()),
+			common.OwnerNameLabelSelector:           instance.Name,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
When we reworked the way that we handle `OpenStackBaremetalSet` scale-up a while back, we inadvertently introduced logic that could prevent `OpenStackBackup`s from being restored.  We need to make sure that `cleanRestore` backups first allow any existing in-use BMHs to deprovision during cleaning before transitioning to the actual restore.  Failure to do so will possibly cause our newer `OpenStackBaremetalSet` scale-up logic to fail if there are not enough BMHs in the state `available` state to satisfy all `OpenStackBaremetalSet` requests.  If that logic fails, the restore process will error-out and be stuck.