### PR TITLE
Fix local build of OSPdO agent for RHEL 9 environments

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -18,7 +18,7 @@ ARG GO_BUILD_EXTRA_ARGS=
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
 WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=1 go build ${GO_BUILD_EXTRA_ARGS} -o ${DEST_ROOT}/${WHAT} ./containers/agent
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0 go build ${GO_BUILD_EXTRA_ARGS} -o ${DEST_ROOT}/${WHAT} ./containers/agent
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
For some reason we use `CGO_ENABLED=1` for the OSPdO agent build.  We do not use this for the operator build itself [1].  When it is enabled and the agent is built on a RHEL 9 machine, the resulting image will crashloop when deployed in a 4.16 cluster:

```
# oc logs openstack-677fbd7745-7pljr -c osp-provision-ip-discovery-agent
/osp-director-agent: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /osp-director-agent)
/osp-director-agent: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /osp-director-agent)
```

We should align this flag between the agent build and the operator build so that we are consistent and avoid the aforementioned issue.

[1]https://github.com/openstack-k8s-operators/osp-director-operator/blob/80bbaf244d92c700ced6ef51e368f58ff0a7f9f9/Dockerfile#L27