### PR TITLE
Fix IPSet label variable usage in AddOSNetConfigRefLabel context

### DIFF
--- a/controllers/openstackbaremetalset_controller.go
+++ b/controllers/openstackbaremetalset_controller.go
@@ -261,7 +261,7 @@ func (r *OpenStackBaremetalSetReconciler) Reconcile(ctx context.Context, req ctr
 			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
-			currentLabels,
+			instance.Labels,
 		)
 		if err != nil {
 			return ctrlResult, err

--- a/controllers/openstackclient_controller.go
+++ b/controllers/openstackclient_controller.go
@@ -159,7 +159,7 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
-			currentLabels,
+			instance.Labels,
 		)
 		if err != nil {
 			return ctrlResult, err

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -913,7 +913,7 @@ func (r *OpenStackControlPlaneReconciler) ensureVIPs(
 			r.Client,
 			instance.Namespace,
 			vipNetworksList[0],
-			currentLabels,
+			instance.Labels,
 		)
 		if err != nil {
 			return ctrlResult, err

--- a/controllers/openstackipset_controller.go
+++ b/controllers/openstackipset_controller.go
@@ -149,7 +149,7 @@ func (r *OpenStackIPSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
-			currentLabels,
+			instance.Labels,
 		)
 		if err != nil {
 			return ctrlResult, err

--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -266,7 +266,7 @@ func (r *OpenStackVMSetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			r.Client,
 			instance.Namespace,
 			instance.Spec.Networks[0],
-			currentLabels,
+			instance.Labels,
 		)
 		if err != nil {
 			return ctrlResult, err


### PR DESCRIPTION
1. We set `currentLabels` to the current `instance.Labels` here: [https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481[…]86e3f471f5a894d87472b5/controllers/openstackipset_controller.go](https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481fea44886e3f471f5a894d87472b5/controllers/openstackipset_controller.go#L139)

2. Then we set `instance.Labels` equal to the `currentLabels` plus the new label we add by calling `AddOSNetConfigRefLabel()` here: [https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481[…]86e3f471f5a894d87472b5/controllers/openstackipset_controller.go](https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481fea44886e3f471f5a894d87472b5/controllers/openstackipset_controller.go#L148-L153)

3. But in that func call, we are modifying the `currentLabels` map...but maps are pass-by-reference in Golang: https://stackoverflow.com/questions/28384343/accessing-a-map-using-its-reference.  So any changes made to the local `currentLabels` map will effect the `currentLabels` map in the caller
 
4. So then at [https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481[…]86e3f471f5a894d87472b5/controllers/openstackipset_controller.go](https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481fea44886e3f471f5a894d87472b5/controllers/openstackipset_controller.go#L174-L177) both maps could be equal if the intervening `AddOSNetNameLowerLabels()` [call](https://github.com/openstack-k8s-operators/osp-director-operator/blob/80bbaf244d92c700ced6ef51e368f58ff0a7f9f9/controllers/openstackipset_controller.go#L159-L169) does not add any labels, and thus the call to `Update()` on [https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481[…]86e3f471f5a894d87472b5/controllers/openstackipset_controller.go](https://github.com/openstack-k8s-operators/osp-director-operator/blob/905b90ce1481fea44886e3f471f5a894d87472b5/controllers/openstackipset_controller.go#L178) might not happen when it actually needs to

5. As a result, the label for the `OSNetConfig` reference would not be persisted to etcd

Let's pass `instance.Labels` to `AddOSNetNameLowerLabels()` instead, like we do a few lines lower for the [call](https://github.com/openstack-k8s-operators/osp-director-operator/blob/80bbaf244d92c700ced6ef51e368f58ff0a7f9f9/controllers/openstackipset_controller.go#L159-L166) to `AddOSNetNameLowerLabels()`.