### PR TITLE
Fix backup/restore KUTTL test to work with current OSBMS config sample

### DIFF
--- a/tests/kuttl/tests/openstackbackuprequest_save_restore/02-create_remaining_resources.yaml
+++ b/tests/kuttl/tests/openstackbackuprequest_save_restore/02-create_remaining_resources.yaml
@@ -31,11 +31,3 @@ commands:
   - command: |
       oc patch openstackbaremetalset compute --type='json' -p='[{"op": "replace", "path": "/spec/count", "value":0}]'
     namespaced: true
-  # Remove sample YAML's bmhLabelSelector from spec
-  - command: |
-      oc patch openstackbaremetalset compute --type='json' -p='[{"op": "remove", "path": "/spec/bmhLabelSelector"}]'
-    namespaced: true
-  # Remove sample YAML's hardwareReqs from spec
-  - command: |
-      oc patch openstackbaremetalset compute --type='json' -p='[{"op": "remove", "path": "/spec/hardwareReqs"}]'
-    namespaced: true


### PR DESCRIPTION
We changed the `OpenStackBaremetalSet` `samples/config` YAML a while ago and need to adjust the backup/restore KUTTL test so that it works with it properly