### PR TITLE
[OSPRH-12353] Prevent nil pointer panic when network validation fails

### DIFF
--- a/api/v1beta1/common_openstacknet.go
+++ b/api/v1beta1/common_openstacknet.go
@@ -235,11 +235,11 @@ func ValidateNetworks(namespace string, networks []string) error {
 		labelSelector := map[string]string{
 			shared.SubNetNameLabelSelector: subnetName,
 		}
-		osnet, err := GetOpenStackNetWithLabel(webhookClient, namespace, labelSelector)
+		_, err := GetOpenStackNetWithLabel(webhookClient, namespace, labelSelector)
 		if err != nil && k8s_errors.IsNotFound(err) {
-			return fmt.Errorf("%s %s not found, validate the object network list", osnet.GetObjectKind().GroupVersionKind().Kind, subnetName)
+			return fmt.Errorf("OpenStackNet %s not found, validate the object network list", subnetName)
 		} else if err != nil {
-			return fmt.Errorf("Failed to get %s %s", osnet.Kind, subnetName)
+			return fmt.Errorf("Failed to get OpenStackNet %s", subnetName)
 		}
 	}
 


### PR DESCRIPTION
If an `OpenStackNet` is missing, we don't have an actual object to reference for producing an error message.  Therefore, just hard-code the Kind into the message, since it won't ever be anything other than `OpenStackNet`.