### PR TITLE
[OSPRH-14001]Make fields optional in v1beta1 to resolve reinstall issues

### DIFF
--- a/api/v1beta1/openstackcontrolplane_types.go
+++ b/api/v1beta1/openstackcontrolplane_types.go
@@ -38,13 +38,13 @@ type OpenStackControlPlaneSpec struct {
 	// OpenStackClientNetworks the name(s) of the OpenStackClientNetworks used to attach the openstackclient to
 	OpenStackClientNetworks []string `json:"openStackClientNetworks"`
 
-	// +kubebuilder:default=false
+	// +kubebuilder:validation:Optional
 	// EnableFencing is provided so that users have the option to disable fencing if desired
 	// FIXME: Defaulting to false until Kubevirt agent merged into RHEL overcloud image
 	EnableFencing bool `json:"enableFencing"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum={"train","wallaby","16.2","17.0"}
+	// +kubebuilder:validation:Enum={"train","wallaby","16.2","17.0","17.1"}
 	// OpenStackRelease to overwrite OSPrelease auto detection from tripleoclient container image
 	OpenStackRelease string `json:"openStackRelease"`
 
@@ -72,8 +72,11 @@ type OpenStackVirtualMachineRoleSpec struct {
 	Cores uint32 `json:"cores"`
 	// amount of Memory in GB used by the VM
 	Memory uint32 `json:"memory"`
+
+	// +kubebuilder:validation:Optional
 	// root Disc size in GB
 	DiskSize uint32 `json:"diskSize"`
+	// +kubebuilder:validation:Optional
 	// StorageClass to be used for the controller disks
 	StorageClass string `json:"storageClass,omitempty"`
 	// +kubebuilder:validation:Optional
@@ -88,6 +91,7 @@ type OpenStackVirtualMachineRoleSpec struct {
 	// RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
 	// To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and VolumeMode: Block.
 	StorageVolumeMode string `json:"storageVolumeMode"`
+	// +kubebuilder:validation:Optional
 	// BaseImageVolumeName used as the base volume for the VM
 	BaseImageVolumeName string `json:"baseImageVolumeName"`
 

--- a/api/v1beta1/openstackvmset_types.go
+++ b/api/v1beta1/openstackvmset_types.go
@@ -30,8 +30,10 @@ type OpenStackVMSetSpec struct {
 	Cores uint32 `json:"cores"`
 	// amount of Memory in GB used by the VMs
 	Memory uint32 `json:"memory"`
+	// +kubebuilder:validation:Optional
 	// root Disc size in GB
 	DiskSize uint32 `json:"diskSize"`
+	// +kubebuilder:validation:Optional
 	// StorageClass to be used for the disks
 	StorageClass string `json:"storageClass,omitempty"`
 	// +kubebuilder:validation:Optional
@@ -48,6 +50,7 @@ type OpenStackVMSetSpec struct {
 	// RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
 	// To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and VolumeMode: Block.
 	StorageVolumeMode string `json:"storageVolumeMode"`
+	// +kubebuilder:validation:Optional
 	// BaseImageVolumeName used as the base volume for the VM
 	BaseImageVolumeName string `json:"baseImageVolumeName"`
 	// name of secret holding the stack-admin ssh keys

--- a/config/crd/bases/osp-director.openstack.org_openstackbackuprequests.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackuprequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackbackuprequests.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbackups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackbackups.osp-director.openstack.org
 spec:
@@ -812,7 +812,6 @@ spec:
                                     CA certificates to trust
                                   type: string
                                 enableFencing:
-                                  default: false
                                   description: 'EnableFencing is provided so that
                                     users have the option to disable fencing if desired
                                     FIXME: Defaulting to false until Kubevirt agent
@@ -849,6 +848,7 @@ spec:
                                   - wallaby
                                   - "16.2"
                                   - "17.0"
+                                  - "17.1"
                                   type: string
                                 passwordSecret:
                                   description: PasswordSecret used to e.g specify
@@ -940,10 +940,8 @@ spec:
                                         - Filesystem
                                         type: string
                                     required:
-                                    - baseImageVolumeName
                                     - cores
                                     - ctlplaneInterface
-                                    - diskSize
                                     - memory
                                     - networks
                                     - roleCount
@@ -952,7 +950,6 @@ spec:
                                   description: List of VirtualMachine roles
                                   type: object
                               required:
-                              - enableFencing
                               - virtualMachineRoles
                               type: object
                             status:
@@ -2748,11 +2745,9 @@ spec:
                                   description: Number of VMs to configure, 1 or 3
                                   type: integer
                               required:
-                              - baseImageVolumeName
                               - cores
                               - ctlplaneInterface
                               - deploymentSSHSecret
-                              - diskSize
                               - isTripleoRole
                               - memory
                               - networks

--- a/config/crd/bases/osp-director.openstack.org_openstackbaremetalsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackbaremetalsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackbaremetalsets.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackclients.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackclients.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackconfiggenerators.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackconfiggenerators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackconfiggenerators.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackconfigversions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackconfigversions.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackcontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackcontrolplanes.osp-director.openstack.org
 spec:
@@ -75,7 +75,6 @@ spec:
                   to trust
                 type: string
               enableFencing:
-                default: false
                 description: 'EnableFencing is provided so that users have the option
                   to disable fencing if desired FIXME: Defaulting to false until Kubevirt
                   agent merged into RHEL overcloud image'
@@ -108,6 +107,7 @@ spec:
                 - wallaby
                 - "16.2"
                 - "17.0"
+                - "17.1"
                 type: string
               passwordSecret:
                 description: PasswordSecret used to e.g specify root pwd
@@ -189,10 +189,8 @@ spec:
                       - Filesystem
                       type: string
                   required:
-                  - baseImageVolumeName
                   - cores
                   - ctlplaneInterface
-                  - diskSize
                   - memory
                   - networks
                   - roleCount
@@ -201,7 +199,6 @@ spec:
                 description: List of VirtualMachine roles
                 type: object
             required:
-            - enableFencing
             - virtualMachineRoles
             type: object
           status:

--- a/config/crd/bases/osp-director.openstack.org_openstackdeploys.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackdeploys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackdeploys.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackephemeralheats.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackephemeralheats.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackephemeralheats.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackipsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackipsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackipsets.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackmacaddresses.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackmacaddresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackmacaddresses.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstacknetattachments.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknetattachments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstacknetattachments.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknetconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstacknetconfigs.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstacknets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstacknets.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackprovisionservers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackprovisionservers.osp-director.openstack.org
 spec:

--- a/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
+++ b/config/crd/bases/osp-director.openstack.org_openstackvmsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: openstackvmsets.osp-director.openstack.org
 spec:
@@ -153,11 +153,9 @@ spec:
                 description: Number of VMs to configure, 1 or 3
                 type: integer
             required:
-            - baseImageVolumeName
             - cores
             - ctlplaneInterface
             - deploymentSSHSecret
-            - diskSize
             - isTripleoRole
             - memory
             - networks


### PR DESCRIPTION
With 4.16 there is additional validation in olm when the installplan gets deployed. In this validation the CR gets checked against the old v1beta1 CRD, even the object storage version is v1beta2. As there are no conversion webhooks in ospdo the verification fails.

To resolve this this adds the fields which get reported as errors in v1beta1 as optional.