### PR TITLE
[OSPRH-14473] Disable HTTP TRACE in OpenStackProvisionServer

### DIFF
--- a/templates/openstackprovisionserver/config/httpd.conf
+++ b/templates/openstackprovisionserver/config/httpd.conf
@@ -344,3 +344,6 @@ IncludeOptional conf.d/autoindex.conf
 IncludeOptional conf.d/mod_security.conf
 IncludeOptional conf.d/userdir.conf
 IncludeOptional conf.d/welcome.conf
+
+# Disable tracing for security purposes
+TraceEnable Off


### PR DESCRIPTION
Security improvement.  Tested in my environment via `curl -v -X TRACE http://192.168.111.10:6190/edpm-hardened-uefi.qcow2`.  Result looked good:

```
< HTTP/1.1 405 Method Not Allowed
< Date: Mon, 17 Mar 2025 09:26:36 GMT
< Server: Apache/2.4.62 (Red Hat Enterprise Linux) OpenSSL/3.2.2
< Allow: 
< Content-Length: 222
< Content-Type: text/html; charset=iso-8859-1
< 
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>405 Method Not Allowed</title>
</head><body>
<h1>Method Not Allowed</h1>
<p>The requested method TRACE is not allowed for this URL.</p>
</body></html>
```

Jira: https://issues.redhat.com/browse/OSPRH-14473