### PR TITLE
Allow passing in full pullspecs as env vars during bundle creation

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -10,17 +10,22 @@ echo "${BASE_IMAGE}"
 echo "${AGENT_IMAGE}"
 echo "${DOWNLOADER_IMAGE}"
 echo "${OSP_RELEASE}"
-skopeo --version
+skopeo --version || true
 
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output: 
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/osp-director-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
+if [[ -z "${OPERATOR_IMG_WITH_DIGEST}" ]]; then
+  echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
+  DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
+  # Output:
+  # Calculating image digest for docker://quay.io/openstack-k8s-operators/osp-director-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
+  # Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
+  echo "Digest: ${DIGEST}"
 
-RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')-${OSP_RELEASE}
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
+  OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
+fi
+
+if [[ -z "${RELEASE_VERSION}" ]]; then
+  RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')-${OSP_RELEASE}
+fi
 
 echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
@@ -33,27 +38,29 @@ cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
 grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
 
 # Replace AGENT_IMAGE_URL_DEFAULT in CSV
-
-AGENT_IMG_BASE="${REGISTRY}/${AGENT_IMAGE}"
-AGENT_IMG="${AGENT_IMG_BASE}:${GITHUB_SHA}"
-AGENT_DIGEST=$(skopeo inspect docker://${AGENT_IMG} | jq '.Digest' -r)
-if [[ -z "$AGENT_DIGEST" ]]; then
-  echo "ERROR: skopeo inspect failed for ${AGENT_IMG}"
-  exit 1
+if [[ -z "${AGENT_IMG_WITH_DIGEST}" ]]; then
+  AGENT_IMG_BASE="${REGISTRY}/${AGENT_IMAGE}"
+  AGENT_IMG="${AGENT_IMG_BASE}:${GITHUB_SHA}"
+  AGENT_DIGEST=$(skopeo inspect docker://${AGENT_IMG} | jq '.Digest' -r)
+  if [[ -z "$AGENT_DIGEST" ]]; then
+    echo "ERROR: skopeo inspect failed for ${AGENT_IMG}"
+    exit 1
+  fi
+  AGENT_IMG_WITH_DIGEST="${AGENT_IMG_BASE}@${AGENT_DIGEST}"
 fi
-AGENT_IMG_WITH_DIGEST="${AGENT_IMG_BASE}@${AGENT_DIGEST}"
 sed -z -e 's!\(AGENT_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${AGENT_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
 
 # Replace DOWNLOADER_IMAGE_URL_DEFAULT in CSV
-
-DOWNLOADER_IMG_BASE="${REGISTRY}/${DOWNLOADER_IMAGE}"
-DOWNLOADER_IMG="${DOWNLOADER_IMG_BASE}:${GITHUB_SHA}"
-DOWNLOADER_DIGEST=$(skopeo inspect docker://${DOWNLOADER_IMG} | jq '.Digest' -r)
-if [[ -z "$DOWNLOADER_DIGEST" ]]; then
-  echo "ERROR: skopeo inspect failed for ${DOWNLOADER_IMG}"
-  exit 1
+if [[ -z "${DOWNLOADER_IMG_WITH_DIGEST}" ]]; then
+  DOWNLOADER_IMG_BASE="${REGISTRY}/${DOWNLOADER_IMAGE}"
+  DOWNLOADER_IMG="${DOWNLOADER_IMG_BASE}:${GITHUB_SHA}"
+  DOWNLOADER_DIGEST=$(skopeo inspect docker://${DOWNLOADER_IMG} | jq '.Digest' -r)
+  if [[ -z "$DOWNLOADER_DIGEST" ]]; then
+    echo "ERROR: skopeo inspect failed for ${DOWNLOADER_IMG}"
+    exit 1
+  fi
+  DOWNLOADER_IMG_WITH_DIGEST="${DOWNLOADER_IMG_BASE}@${DOWNLOADER_DIGEST}"
 fi
-DOWNLOADER_IMG_WITH_DIGEST="${DOWNLOADER_IMG_BASE}@${DOWNLOADER_DIGEST}"
 sed -z -e 's!\(DOWNLOADER_IMAGE_URL_DEFAULT\n\s\+value: \)\S\+!\1'${DOWNLOADER_IMG_WITH_DIGEST}'!' -i "${CLUSTER_BUNDLE_FILE}"
 
 echo "Applying work-arounds..."
@@ -63,9 +70,15 @@ sed -i 's/deploymentName: webhook/deploymentName: osp-director-operator-controll
 # We do not want to exit here. Some images are in different registries, so
 # error will be reported to the console.
 set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
+for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep -E "(image:|value:)" | sed -e "s|.*image:||;s|.*value:||" | sort -u); do
   digest_image=""
   echo "CSV line: ${csv_image}"
+  
+  if ! [[ "$csv_image" =~ .*:.* ]]; then
+    # Matching for "value:" means we get matches that aren't image pullspecs.
+    echo "$csv_image does not look like an image, skipping it."
+    continue
+  fi
 
   # case where @ is in the csv_image image
   if [[ "$csv_image" =~ .*"@".* ]]; then
@@ -87,11 +100,27 @@ for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*im
     echo "$base_image:$tag_image becomes $DOWNLOADER_IMG_WITH_DIGEST"
     sed -e "s|$base_image:$tag_image|$DOWNLOADER_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
   else
-    digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
+    # Check for an env var containing the full image pullspec with digest.
+    # Useful for hermetic builds that can't use the network when generating bundles.
+    # "quay.io/openstack-k8s-operators/kube-rbac-proxy" -> RELATED_IMAGE_KUBE_RBAC_PROXY_PULLSPEC
+    # 1. Take only the image name, e.g. kube-rbac-proxy
+    image_name="${base_image##*/}"
+    # 2. Convert it to uppercase, e.g. KUBE-RBAC-PROXY
+    image_name="${image_name^^}"
+    # 3. Replace dashes with underscores, e.g. KUBE_RBAC_PROXY
+    image_name="${image_name//-/_}"
+    # 4. Build up the env var name to check, e.g. RELATED_IMAGE_KUBE_RBAC_PROXY_PULLSPEC
+    envvar_with_digest=RELATED_IMAGE_${image_name}_PULLSPEC
+    image_with_digest=${!envvar_with_digest}
+    if [[ -z "${image_with_digest}" ]]; then
+      # No env var found, fall back to querying the registry
+      digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
+      image_with_digest=${base_image}@${digest_image}
+    fi
     echo "Base image: $base_image"
-    if [ -n "$digest_image" ]; then
-      echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-      sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
+    if [ -n "${image_with_digest}" ]; then
+      echo "$base_image${delimeter}$tag_image becomes $image_with_digest"
+      sed -i "s|$base_image$delimeter$tag_image|$image_with_digest|g" "${CLUSTER_BUNDLE_FILE}"
     else
       echo "$base_image${delimeter}$tag_image not changed"
     fi


### PR DESCRIPTION
This makes it possible to create our bundles within hermetic build environments, where network access isn't available, such as the ones used downstream.

When the new environment variables aren't set, existing behavior is preserved.

RELDEL-7707