### PR TITLE
Remove tj-actions/branch-names from build workflow

### DIFF
--- a/.github/workflows/build-osp-director-operator.yaml
+++ b/.github/workflows/build-osp-director-operator.yaml
@@ -45,14 +45,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9.0.0
-
     - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+      if: github.ref_name != 'master'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Buildah Action
       id: build-osp-director-operator
@@ -81,14 +79,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9.0.0
-
     - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+      if: github.ref_name != 'master'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Buildah Action
       id: build-osp-director-downloader
@@ -119,14 +115,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9.0.0
-
     - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+      if: github.ref_name != 'master'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Buildah Action
       id: build-osp-director-agent
@@ -205,14 +199,12 @@ jobs:
         OSP_RELEASE: "${{ matrix.osp_release }}"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9.0.0
-
     - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+      if: github.ref_name != 'master'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Build osp-director-operator-bundle using buildah
       id: build-osp-director-operator-bundle
@@ -253,14 +245,12 @@ jobs:
     - name: Checkout osp-director-operator repository
       uses: actions/checkout@v3
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9.0.0
-
     - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+      if: github.ref_name != 'master'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Install opm
       uses: redhat-actions/openshift-tools-installer@v1


### PR DESCRIPTION
Replace tj-actions/branch-names with github.ref_name which provides the branch name natively without a third-party action. The tj-actions GitHub namespace was compromised in March 2025 (CVE-2025-30066) and using actions from that namespace is no longer recommended. Pass the value via env: to avoid shell interpolation of untrusted input in run: blocks.

Jira: [OSPRH-31652](https://redhat.atlassian.net/browse/OSPRH-31652)