### PR TITLE
Add .ci-operator.yaml for build_root from_repository

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: tools
+  namespace: openstack-k8s-operators
+  tag: ci-build-root-golang-1.24-sdk-1.31


### PR DESCRIPTION
Allows the ci-operator build root image to be controlled from the repo instead of hardcoded in the openshift/release config. This enables atomic Go version bumps without a separate openshift/release PR.

Jira: [OSPRH-32127](https://redhat.atlassian.net/browse/OSPRH-32127)