### PR TITLE
Remove Go 1.25 version caps from v1.3.x dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,21 +55,22 @@ updates:
       versions: ">= 0.32.0"
     - dependency-name: "k8s.io/klog/v2"
       versions: ">= 3.0.0"
-    # golang.org/x/crypto 0.49.0+ requires Go 1.25
-    - dependency-name: "golang.org/x/crypto"
-      versions: ">= 0.49.0"
-    # ginkgo/v2 2.28.3+ requires Go 1.25
-    - dependency-name: "github.com/onsi/ginkgo/v2"
-      versions: ">= 2.28.3"
-    # gophercloud/v2 2.11.0+ requires Go 1.25
-    - dependency-name: "github.com/gophercloud/gophercloud/v2"
-      versions: ">= 2.11.0"
-    # go-git/v5 5.19.0+ requires Go 1.25
-    - dependency-name: "github.com/go-git/go-git/v5"
-      versions: ">= 5.19.0"
-    # go-billy/v5 5.9.0+ requires Go 1.25
-    - dependency-name: "github.com/go-git/go-billy/v5"
-      versions: ">= 5.9.0"
+    # [go-bump 1.26] commented out -- no longer needed with Go 1.26
+    # # golang.org/x/crypto 0.49.0+ requires Go 1.25
+    # - dependency-name: "golang.org/x/crypto"
+    #   versions: ">= 0.49.0"
+    # # ginkgo/v2 2.28.3+ requires Go 1.25
+    # - dependency-name: "github.com/onsi/ginkgo/v2"
+    #   versions: ">= 2.28.3"
+    # # gophercloud/v2 2.11.0+ requires Go 1.25
+    # - dependency-name: "github.com/gophercloud/gophercloud/v2"
+    #   versions: ">= 2.11.0"
+    # # go-git/v5 5.19.0+ requires Go 1.25
+    # - dependency-name: "github.com/go-git/go-git/v5"
+    #   versions: ">= 5.19.0"
+    # # go-billy/v5 5.9.0+ requires Go 1.25
+    # - dependency-name: "github.com/go-git/go-billy/v5"
+    #   versions: ">= 5.9.0"
   commit-message:
     # Prefix all commit messages with "[v1.3.x]"
     prefix: "[v1.3.x]"


### PR DESCRIPTION
The v1.3.x branch has been bumped to Go 1.26, so the version caps that prevented dependabot from bumping dependencies requiring Go 1.25+ are no longer needed.

Jira: [OSPRH-32127](https://redhat.atlassian.net/browse/OSPRH-32127)