### PR TITLE
Enable TLS verification in fencing kubeconfig

### DIFF
--- a/controllers/openstackvmset_controller.go
+++ b/controllers/openstackvmset_controller.go
@@ -18,7 +18,9 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -577,9 +579,23 @@ func (r *OpenStackVMSetReconciler) generateNamespaceFencingData(
 		return err
 	}
 
+	caData := kubeconfig.CAData
+	if len(caData) == 0 && kubeconfig.CAFile != "" {
+		caData, err = os.ReadFile(kubeconfig.CAFile)
+		if err != nil {
+			cond.Message = "Error reading CA file for fencing kubeconfig"
+			cond.Reason = shared.VMSetCondReasonKubeConfigError
+			cond.Type = shared.CommonCondTypeError
+			err = common.WrapErrorForObject(cond.Message, instance, err)
+
+			return err
+		}
+	}
+
 	templateParameters := map[string]interface{}{}
 	templateParameters["Server"] = kubeconfig.Host
 	templateParameters["Namespace"] = instance.Namespace
+	templateParameters["CertificateAuthorityData"] = base64.StdEncoding.EncodeToString(caData)
 
 	// Read-back the secret for the kubevirt agent service account token
 	kubevirtAgentTokenSecret, err := r.Kclient.CoreV1().Secrets(instance.Namespace).Get(ctx, vmset.KubevirtFencingServiceAccountSecret, metav1.GetOptions{})

--- a/templates/vmset/fencing-kubeconfig/fencing-kubeconfig
+++ b/templates/vmset/fencing-kubeconfig/fencing-kubeconfig
@@ -1,7 +1,7 @@
 apiVersion: v1
 clusters:
 - cluster:
-    insecure-skip-tls-verify: true
+    certificate-authority-data: {{ .CertificateAuthorityData }}
     server: {{ .Server }}
   name: openstack
 contexts:


### PR DESCRIPTION
The fencing kubeconfig template hardcoded `insecure-skip-tls-verify: true`, allowing a network-adjacent attacker to impersonate the API server and capture the kubevirt fencing agent's `ServiceAccount` token. Extract the cluster CA from the operator's `rest.Config` and template it as `certificate-authority-data` so the fencing agent validates the API server certificate.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>