### PR TITLE
Narrow wildcard RBAC to least-privilege

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,13 +124,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - machine.openshift.io
-  - metal3.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts
@@ -150,6 +143,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - metal3.io
+  resources:
+  - provisionings
+  verbs:
+  - get
 - apiGroups:
   - migration.k8s.io
   resources:
@@ -341,12 +340,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - hco.kubevirt.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
 - apiGroups:
   - kubevirt.io
   resources:

--- a/controllers/openstackcontrolplane_controller.go
+++ b/controllers/openstackcontrolplane_controller.go
@@ -85,7 +85,6 @@ func (r *OpenStackControlPlaneReconciler) GetScheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=osp-director.openstack.org,resources=openstackclients,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=osp-director.openstack.org,resources=openstackclients/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osp-director.openstack.org,resources=openstackmacaddresses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=hco.kubevirt.io,namespace=openstack,resources="*",verbs="*"
 // +kubebuilder:rbac:groups=migration.k8s.io,resources=storageversionmigrations,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;create;delete;update

--- a/controllers/openstackprovisionserver_controller.go
+++ b/controllers/openstackprovisionserver_controller.go
@@ -89,8 +89,7 @@ func (r *OpenStackProvisionServerReconciler) GetScheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=core,resources=volumes,verbs=get;list;create;update;delete;watch;
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;update;watch;
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;update;watch;
-// +kubebuilder:rbac:groups=machine.openshift.io,resources="*",verbs="*"
-// +kubebuilder:rbac:groups=metal3.io,resources="*",verbs="*"
+// +kubebuilder:rbac:groups=metal3.io,resources=provisionings,verbs=get
 
 // Reconcile - provision image servers
 func (r *OpenStackProvisionServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Remove `machine.openshift.io` and `hco.kubevirt.io` wildcard RBAC markers that granted full access to API groups with no corresponding code usage. Replace the `metal3.io` wildcard with a scoped rule granting only get on `provisionings`, which is the single resource actually accessed via the dynamic client.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>