### PR TITLE
Harden manager container securityContext

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,4 +39,18 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      securityContext:
+        runAsNonRoot: true
       terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: tmp


### PR DESCRIPTION
Add `readOnlyRootFilesystem`, drop `ALL` capabilities, set `allowPrivilegeEscalation: false` and `runAsNonRoot: true` on the controller-manager `Deployment`. Mount an `emptyDir` at `/tmp` for `controller-runtime` cert generation and Go temporary files.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>